### PR TITLE
Improved filters docs

### DIFF
--- a/examples/resources/opslevel_filter/resource.tf
+++ b/examples/resources/opslevel_filter/resource.tf
@@ -22,3 +22,12 @@ resource "opslevel_filter" "tier2_alpha" {
   }
   connective = "and"
 }
+
+resource "opslevel_filter" "tier3" {
+  name = "foo"
+  predicate {
+    key      = "tags"
+    type     = "does_not_exist"
+    key_data = "tier3"
+  }
+}

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -37,7 +37,7 @@ func resourceFilter() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:         schema.TypeString,
-							Description:  "The condition type used by the predicate.",
+							Description:  "The condition type used by the predicate. Valid values are `contains`, `does_not_contain`, `does_not_equal`, `does_not_exist`, `ends_with`, `equals`, `exists`, `greater_than_or_equal_to`, `less_than_or_equal_to`, `starts_with`, `satisfies_version_constraint`, `matches_regex`, `satisfies_jq_expression`",
 							ForceNew:     false,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice(opslevel.AllPredicateTypeEnum(), false),
@@ -57,7 +57,7 @@ func resourceFilter() *schema.Resource {
 						},
 						"key_data": {
 							Type:        schema.TypeString,
-							Description: "Additional data used by the predicate. This field is used by predicates with key = 'tags' to specify the tag key. For example, to create a predicate for services containing the tag 'db:mysql', set keyData = 'db' and value = 'mysql'.",
+							Description: "Additional data used by the predicate. This field is used by predicates with key = 'tags' to specify the tag key. For example, to create a predicate for services containing the tag 'db:mysql', set key_data = 'db' and value = 'mysql'.",
 							ForceNew:    false,
 							Optional:    true,
 						},


### PR DESCRIPTION
Hello!

This adds:
* The list of valid values for the `type` parameter in filters.
* Fixes a small typo on the `key_data` description.
* Adds a filter example where tags are used.