### PR TITLE
Add support for useAbsoluteRoot in repo file check

### DIFF
--- a/.changes/unreleased/Feature-20220516-075238.yaml
+++ b/.changes/unreleased/Feature-20220516-075238.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for RepositoryFileCheck "useAbsoluteRoot" field
+time: 2022-05-16T07:52:38.668128-05:00


### PR DESCRIPTION
The changes to opslevel-go are here - https://github.com/OpsLevel/opslevel-go/pull/56