### PR TITLE
Updates to use pointer for notes to pass null values

### DIFF
--- a/.changes/unreleased/Bugfix-20220727-165829.yaml
+++ b/.changes/unreleased/Bugfix-20220727-165829.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where notes on a check could not be set to null
+time: 2022-07-27T16:58:29.789594-05:00

--- a/go.mod
+++ b/go.mod
@@ -88,5 +88,5 @@ require (
 )
 
 // Uncomment for local development
-//replace github.com/opslevel/opslevel-go/v2022 => ./submodules/opslevel-go/
+replace github.com/opslevel/opslevel-go/v2022 => ./submodules/opslevel-go/
 

--- a/opslevel/schema_checks.go
+++ b/opslevel/schema_checks.go
@@ -116,7 +116,8 @@ func setCheckCreateInput(d *schema.ResourceData, p opslevel.CheckCreateInputProv
 	input.Level = getID(d, "level")
 	input.Owner = getID(d, "owner")
 	input.Filter = getID(d, "filter")
-	input.Notes = d.Get("notes").(string)
+	notes := d.Get("notes").(string)
+	input.Notes = &notes
 }
 
 func setCheckUpdateInput(d *schema.ResourceData, p opslevel.CheckUpdateInputProvider) {
@@ -147,7 +148,8 @@ func setCheckUpdateInput(d *schema.ResourceData, p opslevel.CheckUpdateInputProv
 		input.Filter = getID(d, "filter")
 	}
 	if d.HasChange("notes") {
-		input.Notes = d.Get("notes").(string)
+		notes := d.Get("notes").(string)
+		input.Notes = &notes
 	}
 }
 


### PR DESCRIPTION
PR for opslevel-go changes:  https://github.com/OpsLevel/opslevel-go/pull/74