### PR TITLE
Add HasDocumentation Check

### DIFF
--- a/.changes/unreleased/Feature-20220807-150331.yaml
+++ b/.changes/unreleased/Feature-20220807-150331.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add ability to manage HasDocumentation checks
+time: 2022-08-07T15:03:31.850957-04:00

--- a/examples/resources/opslevel_check_has_documentation/import.sh
+++ b/examples/resources/opslevel_check_has_documentation/import.sh
@@ -1,0 +1,1 @@
+terraform import opslevel_check_has_documentation.example Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MDI0

--- a/examples/resources/opslevel_check_has_documentation/resource.tf
+++ b/examples/resources/opslevel_check_has_documentation/resource.tf
@@ -1,0 +1,38 @@
+data "opslevel_rubric_category" "security" {
+  filter {
+    field = "name"
+    value = "Security"
+  }
+}
+
+data "opslevel_rubric_level" "bronze" {
+  filter {
+    field = "name"
+    value = "Bronze"
+  }
+}
+
+data "opslevel_team" "a" {
+  alias = "a"
+}
+
+data "opslevel_filter" "tier1" {
+  filter {
+    field = "name"
+    value = "team"
+  }
+}
+
+resource "opslevel_check_has_documentation" "has_docs" {
+  name             = "foo"
+  enabled          = true
+  # To set a future enable date remove field 'enabled' and use 'enable_on'
+  # enable_on        = "2022-05-23T14:14:18.782000Z"
+  category         = data.opslevel_rubric_category.security.id
+  level            = data.opslevel_rubric_level.bronze.id
+  owner            = data.opslevel_team.a.id
+  filter           = data.opslevel_filter.tier1.id
+  notes            = "Optional additional info on why this check is run or how to fix it"
+  document_type    = "api"
+  document_subtype = "openapi"
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/opslevel/opslevel-go/v2022 v2022.8.1
+	github.com/opslevel/opslevel-go/v2022 v2022.8.25
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 )
 

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/opslevel/opslevel-go/v2022 v2022.8.1 h1:KK2MMVMYVtD5V0hK2j4ok9OBhzMzEKnvkgdXVTIfCeg=
-github.com/opslevel/opslevel-go/v2022 v2022.8.1/go.mod h1:2/cWgSTLK/6n7XlXe4kqG7IeHlNyjpP+BJ+YbKj28JM=
+github.com/opslevel/opslevel-go/v2022 v2022.8.25 h1:SUYm84vJei6fErxtfz5KpQFIpPFyr1x8eYUTcuSOTrY=
+github.com/opslevel/opslevel-go/v2022 v2022.8.25/go.mod h1:2/cWgSTLK/6n7XlXe4kqG7IeHlNyjpP+BJ+YbKj28JM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -53,6 +53,7 @@ func Provider() terraform.ResourceProvider {
 			"opslevel_check_alert_source_usage":    resourceCheckAlertSourceUsage(),
 			"opslevel_check_custom_event":          resourceCheckCustomEvent(),
 			"opslevel_check_git_branch_protection": resourceCheckGitBranchProtection(),
+			"opslevel_check_has_documentation":     resourceCheckHasDocumentation(),
 			"opslevel_check_has_recent_deploy":     resourceCheckHasRecentDeploy(),
 			"opslevel_check_manual":                resourceCheckManual(),
 			"opslevel_check_repository_file":       resourceCheckRepositoryFile(),

--- a/opslevel/resource_opslevel_check_has_documentation.go
+++ b/opslevel/resource_opslevel_check_has_documentation.go
@@ -1,0 +1,93 @@
+package opslevel
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/opslevel/opslevel-go/v2022"
+)
+
+func resourceCheckHasDocumentation() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages a has documentation check",
+		Create:      wrap(resourceCheckHasDocumentationCreate),
+		Read:        wrap(resourceCheckHasDocumentationRead),
+		Update:      wrap(resourceCheckHasDocumentationUpdate),
+		Delete:      wrap(resourceCheckDelete),
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: getCheckSchema(map[string]*schema.Schema{
+			"document_type": {
+				Type:         schema.TypeString,
+				Description:  "The type of the document.",
+				ForceNew:     false,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(opslevel.AllHasDocumentationTypeEnum(), false),
+			},
+			"document_subtype": {
+				Type:         schema.TypeString,
+				Description:  "The subtype of the document.",
+				ForceNew:     false,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(opslevel.AllHasDocumentationSubtypeEnum(), false),
+			},
+		}),
+	}
+}
+
+func resourceCheckHasDocumentationCreate(d *schema.ResourceData, client *opslevel.Client) error {
+	input := opslevel.CheckHasDocumentationCreateInput{}
+	setCheckCreateInput(d, &input)
+
+	input.DocumentType = opslevel.HasDocumentationTypeEnum(d.Get("document_type").(string))
+	input.DocumentSubtype = opslevel.HasDocumentationSubtypeEnum(d.Get("document_subtype").(string))
+
+	resource, err := client.CreateCheckHasDocumentation(input)
+	if err != nil {
+		return err
+	}
+	d.SetId(resource.Id.(string))
+
+	return resourceCheckHasDocumentationRead(d, client)
+}
+
+func resourceCheckHasDocumentationRead(d *schema.ResourceData, client *opslevel.Client) error {
+	id := d.Id()
+
+	resource, err := client.GetCheck(id)
+	if err != nil {
+		return err
+	}
+
+	if err := setCheckData(d, resource); err != nil {
+		return err
+	}
+	if err := d.Set("document_type", string(resource.DocumentType)); err != nil {
+		return err
+	}
+	if err := d.Set("document_subtype", string(resource.DocumentSubtype)); err != nil {
+		return err
+	}
+
+
+	return nil
+}
+
+func resourceCheckHasDocumentationUpdate(d *schema.ResourceData, client *opslevel.Client) error {
+	input := opslevel.CheckHasDocumentationUpdateInput{}
+	setCheckUpdateInput(d, &input)
+
+	if d.HasChange("document_type") {
+		input.DocumentType = opslevel.HasDocumentationTypeEnum(d.Get("document_type").(string))
+	}
+	if d.HasChange("document_subtype") {
+		input.DocumentSubtype = opslevel.HasDocumentationSubtypeEnum(d.Get("document_subtype").(string))
+	}
+
+	_, err := client.UpdateCheckHasDocumentation(input)
+	if err != nil {
+		return err
+	}
+	d.Set("last_updated", timeLastUpdated())
+	return resourceCheckHasDocumentationRead(d, client)
+}


### PR DESCRIPTION
Adding the HasDocumentation Check, which depends on this [PR](https://github.com/OpsLevel/opslevel-go/pull/75) to opslevel-go first. Testing locally with `replace github.com/opslevel/opslevel-go/v2022 => ../opslevel-go/` (seemed easier than git submodules), looks like it works!



<img width="1071" alt="Screen Shot 2022-08-07 at 3 38 27 PM" src="https://user-images.githubusercontent.com/74929492/183311134-d772eb90-991f-40c6-b4b3-ab8ed489c657.png">
