### PR TITLE
fix: remove opslevel_rubric_category description from example

### DIFF
--- a/docs/resources/rubric_category.md
+++ b/docs/resources/rubric_category.md
@@ -15,7 +15,6 @@ Manages a rubric category
 ```terraform
 resource "opslevel_rubric_category" "example" {
   name = "foo"
-  description = "foo category"
 }
 
 output "category" {

--- a/examples/resources/opslevel_rubric_category/resource.tf
+++ b/examples/resources/opslevel_rubric_category/resource.tf
@@ -1,6 +1,5 @@
 resource "opslevel_rubric_category" "example" {
   name = "foo"
-  description = "foo category"
 }
 
 output "category" {


### PR DESCRIPTION
The opslevel_rubric_category resource does not support the description attribute.