### PR TITLE
fix: correct environment variable reference in doc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -88,4 +88,4 @@ resource "opslevel_check_repository_integrated" "foo" {
 
 The following arguments are supported:
 
-* `token` - (Required) The API authorization token. It can also be sourced from the OPSLEVEL_APITOKEN environment variable.
+* `token` - (Required) The API authorization token. It can also be sourced from the OPSLEVEL_API_TOKEN environment variable.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -22,4 +22,4 @@ Use the navigation to the left to read about the available resources and datasou
 
 The following arguments are supported:
 
-* `token` - (Required) The API authorization token. It can also be sourced from the OPSLEVEL_APITOKEN environment variable.
+* `token` - (Required) The API authorization token. It can also be sourced from the OPSLEVEL_API_TOKEN environment variable.


### PR DESCRIPTION
The correct environment variable name is OPSLEVEL_API_TOKEN.