### PR TITLE
adding override feature for client timeout

### DIFF
--- a/.changes/unreleased/Feature-20220922-100247.yaml
+++ b/.changes/unreleased/Feature-20220922-100247.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Adding ability to override default client timout for opslevel-go"
+time: 2022-09-22T10:02:47.669724+01:00

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,7 @@ resource "opslevel_check_repository_integrated" "foo" {
 
 - `api_token` (String, Sensitive) The API authorization token. It can also be sourced from the OPSLEVEL_API_TOKEN environment variable.
 - `api_url` (String) The url of the OpsLevel API to. It can also be sourced from the OPSLEVEL_API_URL environment variable.
+- `client_timeout` (Int) Override value for the timeout to the graphql endpoint (defualt is 10s).
 
 ## Argument Reference
 

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -92,20 +92,12 @@ func Provider() terraform.ResourceProvider {
 
 			opts := make([]opslevel.Option, 0)
 
-			if token != "" {
-				opts = append(opts, opslevel.SetAPIToken(token))
-			}
-
-			if url != "" {
-				opts = append(opts, opslevel.SetURL(url))
-			}
+			opts = append(opts, opslevel.SetAPIToken(token))
+			opts = append(opts, opslevel.SetURL(url))
+			opts = append(opts, opslevel.SetUserAgentExtra(fmt.Sprintf("terraform-provider-%s", version)))
 
 			if timeout > 0 {
 				opts = append(opts, opslevel.SetTimeout(time.Duration(timeout)))
-			}
-
-			if version != "" {
-				opts = append(opts, opslevel.SetUserAgentExtra(fmt.Sprintf("terraform-provider-%s", version)))
 			}
 
 			client := opslevel.NewGQLClient(opts...)


### PR DESCRIPTION
- adding ability to set a custom value for the client timeout value in calls to GQL

This is being added due to the current continual timeout when trying to retrieve all team and service date using datasources.