### PR TITLE
Fixes #5152

### DIFF
--- a/.changes/unreleased/Bugfix-20221019-211141.yaml
+++ b/.changes/unreleased/Bugfix-20221019-211141.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix erronious whitespace around predicate values when multiline heredoc used
+  for value
+time: 2022-10-19T21:11:41.812673-05:00

--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -220,9 +220,9 @@ func expandFilterPredicates(d *schema.ResourceData) []opslevel.FilterPredicate {
 		data := item.(map[string]interface{})
 		output = append(output, opslevel.FilterPredicate{
 			Type:    opslevel.PredicateTypeEnum(data["type"].(string)),
-			Value:   data["value"].(string),
+			Value:   strings.TrimSpace(data["value"].(string)),
 			Key:     opslevel.PredicateKeyEnum(data["key"].(string)),
-			KeyData: data["key_data"].(string),
+			KeyData: strings.TrimSpace(data["key_data"].(string)),
 		})
 	}
 	return output


### PR DESCRIPTION
When doing
```
resource "opslevel_filter" "foo" {
  name = "foo"
  predicate {
    key      = "tags"
    type     = "contains"
    key_data = "foo"
    value = "bar"
  }
}
```
the data is correct in OpsLevel

but when doing
```
resource "opslevel_filter" "test" {
  name = "foo"
  predicate {
    key      = "tags"
    type     = "contains"
    key_data = "foo"
    value = <<-EOT
    bar
EOT
  }
}
```

in OpsLevel you get a value of `bar ` (extra space at the end)

This fixes that.