### PR TITLE
Bugfix for nil pointer deference

### DIFF
--- a/.changes/unreleased/Bugfix-20221215-055650.yaml
+++ b/.changes/unreleased/Bugfix-20221215-055650.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix nil pointer dereference on datasource opslevel_service
+time: 2022-12-15T05:56:50.575606-06:00

--- a/opslevel/datasource_opslevel_service.go
+++ b/opslevel/datasource_opslevel_service.go
@@ -138,7 +138,7 @@ func datasourceServiceRead(d *schema.ResourceData, client *opslevel.Client) erro
 	if err := d.Set("api_document_path", resource.ApiDocumentPath); err != nil {
 		return err
 	}
-	if err := d.Set("preferred_api_document_source", string(*resource.PreferredApiDocumentSource)); err != nil {
+	if err := d.Set("preferred_api_document_source", resource.PreferredApiDocumentSource); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes #48

We were not properly storing the field into the state.  Which is odd because we didn't do this in the resource for `opslevel_service` - https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/opslevel/resource_opslevel_service.go#L270