### PR TITLE
Update AWS IAM policy to include required S3 permissions

### DIFF
--- a/examples/resources/opslevel_integration_aws/resource.tf
+++ b/examples/resources/opslevel_integration_aws/resource.tf
@@ -45,6 +45,8 @@ resource "aws_iam_policy" "opslevel" {
           "s3:List*",
           "s3:GetBucketLocation",
           "s3:GetBucketTagging",
+          "s3:GetBucketPolicyStatus",
+          "s3:GetBucketVersioning",
           "sns:Get*",
           "sns:List*",
           "storagegateway:List*",


### PR DESCRIPTION
Adds the following permissions grants to the AWS policy example:

```
"s3:GetBucketPolicyStatus",
"s3:GetBucketVersioning",
```

OpsLevel requires both of these IAM grants to ensure we can sync certain information about s3 buckets.