### PR TITLE
Add support for EntityType in Custom Actions

### DIFF
--- a/.changes/unreleased/Feature-20230515-115351.yaml
+++ b/.changes/unreleased/Feature-20230515-115351.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for Trigger Definition entity type
+time: 2023-05-15T11:53:51.391669-04:00

--- a/docs/resources/trigger_definition.md
+++ b/docs/resources/trigger_definition.md
@@ -107,6 +107,7 @@ Please contact [{{ action_owner.name }}]({{ action_owner.href }}) for more help.
 - `manual_inputs_definition` (String) The YAML definition of any custom inputs for this Trigger Definition.
 - `published` (Boolean) The published state of the Custom Action; true if the Trigger Definition is ready for use; false if it is a draft. Defaults to false.
 - `response_template` (String) The liquid template used to parse the response from the Webhook Action.
+- `entity_type` (String) The entity type to associate with the Trigger Definition. Optional, but must be one of `SERVICE` or `GLOBAL` if provided.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/hasura/go-graphql-client v0.9.2 // indirect
+	github.com/hasura/go-graphql-client v0.9.3 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -90,4 +90,4 @@ require (
 )
 
 // Uncomment for local development
-// replace github.com/opslevel/opslevel-go/v2023 => ./submodules/opslevel-go/
+replace github.com/opslevel/opslevel-go/v2023 => ./submodules/opslevel-go/

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/hasura/go-graphql-client v0.9.2 h1:4FyAeVOu+GcS1BaoELWNyxzaLY7s+g72LLH+qYItdEY=
-github.com/hasura/go-graphql-client v0.9.2/go.mod h1:AarJlxO1I59MPqU/TC7gQP0BMFgPEqUTt5LYPvykasw=
+github.com/hasura/go-graphql-client v0.9.3 h1:Xi3fqa2t9q4nJ2jM2AU8nB6qeAoMpbcYDiOSBnNAN1E=
+github.com/hasura/go-graphql-client v0.9.3/go.mod h1:AarJlxO1I59MPqU/TC7gQP0BMFgPEqUTt5LYPvykasw=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -559,8 +559,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/opslevel/opslevel-go/v2023 v2023.5.5 h1:m0mQSnykdr4A/aJr2Ymnf1cs7qjYhaGmaBIHz1fyt8Q=
-github.com/opslevel/opslevel-go/v2023 v2023.5.5/go.mod h1:l5JLYPjriHCEk1bBnvfVhWgmCJ3S62ujN8HLZMkZ17M=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opslevel/resource_opslevel_trigger_definition.go
+++ b/opslevel/resource_opslevel_trigger_definition.go
@@ -73,6 +73,13 @@ func resourceTriggerDefinition() *schema.Resource {
 				ForceNew:    false,
 				Optional:    true,
 			},
+			"entity_type": {
+				Type:         schema.TypeString,
+				Description:  "The entity type to associate with the Trigger Definition.",
+				ForceNew:     false,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(opslevel.AllCustomActionsEntityTypeEnum, false),
+			},
 		},
 	}
 }
@@ -105,6 +112,11 @@ func resourceTriggerDefinitionCreate(d *schema.ResourceData, client *opslevel.Cl
 
 	if published, ok := d.GetOk("published"); ok {
 		input.Published = opslevel.Bool(published.(bool))
+	}
+
+	if _, ok := d.GetOk("entity_type"); ok {
+		entityType := d.Get("entity_type").(string)
+		input.EntityType = opslevel.CustomActionsEntityTypeEnum(entityType)
 	}
 
 	resource, err := client.CreateTriggerDefinition(input)
@@ -149,6 +161,9 @@ func resourceTriggerDefinitionRead(d *schema.ResourceData, client *opslevel.Clie
 		return err
 	}
 	if err := d.Set("response_template", resource.ResponseTemplate); err != nil {
+		return err
+	}
+	if err := d.Set("entity_type", resource.EntityType); err != nil {
 		return err
 	}
 
@@ -198,6 +213,11 @@ func resourceTriggerDefinitionUpdate(d *schema.ResourceData, client *opslevel.Cl
 	if d.HasChange("response_template") {
 		responseTemplate := d.Get("response_template").(string)
 		input.ResponseTemplate = &responseTemplate
+	}
+
+	if d.HasChange("entity_type") {
+		entityType := d.Get("entity_type").(string)
+		input.EntityType = opslevel.CustomActionsEntityTypeEnum(entityType)
 	}
 
 	_, err := client.UpdateTriggerDefinition(input)

--- a/opslevel/resource_opslevel_trigger_definition.go
+++ b/opslevel/resource_opslevel_trigger_definition.go
@@ -163,8 +163,10 @@ func resourceTriggerDefinitionRead(d *schema.ResourceData, client *opslevel.Clie
 	if err := d.Set("response_template", resource.ResponseTemplate); err != nil {
 		return err
 	}
-	if err := d.Set("entity_type", resource.EntityType); err != nil {
-		return err
+	if _, ok := d.GetOk("entity_type"); ok {
+		if err := d.Set("entity_type", resource.EntityType); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This adds support for EntityType in Custom Actions.

Upstream change in opslevel-go is [here](https://github.com/OpsLevel/opslevel-go/pull/196)