### PR TITLE
upgrade opslevel-go version to v2023.07.28

### DIFF
--- a/.changes/unreleased/Feature-20230810-144653.yaml
+++ b/.changes/unreleased/Feature-20230810-144653.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Bump opslevel-go version to support more filter predicate keys and types
+time: 2023-08-10T14:46:53.925085-04:00

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/opslevel/opslevel-go/v2023 v2023.7.17
+	github.com/opslevel/opslevel-go/v2023 v2023.7.28
 	github.com/rs/zerolog v1.29.1
 )
 
@@ -58,7 +58,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/klauspost/compress v1.16.5 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/cli v1.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -517,6 +517,8 @@ github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -577,6 +579,8 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/opslevel/opslevel-go/v2023 v2023.7.17 h1:PwCAdu1BVg9Wou4BDOAQI7fjIfrHT6/Q3mfQkAIQLHA=
 github.com/opslevel/opslevel-go/v2023 v2023.7.17/go.mod h1:9m/iNQxhVfHaNj+c40PWSH1yA68XiG90QE5i2Um4JxA=
+github.com/opslevel/opslevel-go/v2023 v2023.7.28 h1:XbuWQHqIkb5zFnYd/IF1AwrATaCE3xcj0KE98F3e2g8=
+github.com/opslevel/opslevel-go/v2023 v2023.7.28/go.mod h1:Ogb2xcEo717WZiwJOy5vtvmgApHjKiD/W5r/U9a8VF0=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Summary

Support more filter predicate keys and types that were added to opslevel-go: https://github.com/OpsLevel/opslevel-go/pull/226

## Tophatting

```
$ cat workspace/test.tf
resource "opslevel_filter" "f1" {
  name = "foo"
  predicate {
    key      = "filter_id"
    type     = "matches"
    key_data = "some-other-filter"
  }
}

resource "opslevel_filter" "f2" {
  name = "foo"
  predicate {
    key      = "filter_id"
    type     = "does_not_match"
    key_data = "some-other-filter"
  }
}

resource "opslevel_filter" "f3" {
  name = "foo"
  predicate {
    key      = "name"
    type     = "does_not_match_regex"
    key_data = "^opslevel"
  }
}%                                                                                                                                                                                                                    
$ ./plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_filter.f1 will be created
  + resource "opslevel_filter" "f1" {
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "foo"

      + predicate {
          + key      = "filter_id"
          + key_data = "some-other-filter"
          + type     = "matches"
        }
    }

  # opslevel_filter.f2 will be created
  + resource "opslevel_filter" "f2" {
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "foo"

      + predicate {
          + key      = "filter_id"
          + key_data = "some-other-filter"
          + type     = "does_not_match"
        }
    }

  # opslevel_filter.f3 will be created
  + resource "opslevel_filter" "f3" {
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "foo"

      + predicate {
          + key      = "name"
          + key_data = "^opslevel"
          + type     = "does_not_match_regex"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```

Since the opslevel-go version was bumped it knows that these keys and types exist.