### PR TITLE
Support scorecards

### DIFF
--- a/.changes/unreleased/Feature-20230824-161018.yaml
+++ b/.changes/unreleased/Feature-20230824-161018.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add support for scorecards (no datasource)
+time: 2023-08-24T16:10:18.831406-04:00

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,15 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21
-      - name: Run Unit Tests
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Tests
         run: |-
-          go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+          task workspace
+          task test
       - name: Upload Coverage
         run: |-
           bash <(curl -s https://codecov.io/bash)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -138,14 +138,18 @@ tasks:
     env:
       TF_ACC: true
     cmds:
-      - go test -v -cover -race ./... {{ .CLI_ARGS }}
+      - go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
 
   workspace:
     desc: Setup workspace for terraform-provider-opslevel & opslevel-go development
     cmds:
       - git submodule update --init
-        # The ":" is a no-op that keeps things rolling
-      - go work init || ":"
+      - go work init || exit 0
       - go work use . submodules/opslevel-go
-      - task: terraform-build-init
       - echo "Workspace ready!"
+
+  workspace-all:
+    desc: Setup workspace for terraform-provider-opslevel & opslevel-go development
+    cmds:
+      - task: workspace
+      - task: terraform-build-init

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -104,6 +104,8 @@ tasks:
       FILES_TO_DELETE:
         sh: ls -1 "{{.WORKSPACE_DIR}}" | grep -v -e 'main.tf' -e 'backend.tf'
     cmds:
+      # TODO: this is broken because of line spaces! (the \n character)
+      # task: "Remove 'whatever.tf\nterraform.tfstate\nterraform.tfstate.backup' from ...
       - for: { var: FILES_TO_DELETE }
         cmd: rm -rf {{ .ITEM }}
 

--- a/examples/resources/opslevel_scorecard/import.sh
+++ b/examples/resources/opslevel_scorecard/import.sh
@@ -1,0 +1,1 @@
+terraform import opslevel_scorecard.my_scorecard Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MDI0

--- a/examples/resources/opslevel_scorecard/resource.tf
+++ b/examples/resources/opslevel_scorecard/resource.tf
@@ -1,0 +1,24 @@
+data "opslevel_team" "devs" {
+  alias = "developers"
+}
+
+data "opslevel_filter" "tier_1" {
+  filter {
+    field = "name"
+    value = "Tier 1 Services"
+  }
+}
+
+resource "opslevel_scorecard" "my_scorecard" {
+    name = "My Scorecard"
+    description = "This is my example scorecard"
+    ownerId = data.opslevel_team.devs.id
+    filterId = data.opslevel_filter.tier_1.id
+}
+
+// Example of how to assign a check to a scorecard
+resource "opslevel_check_manual" "my_check" {
+  name      = "My Check"
+  category  = resource.opslevel_scorecard.my_scorecard.id
+  ...
+}

--- a/examples/resources/opslevel_scorecard/resource.tf
+++ b/examples/resources/opslevel_scorecard/resource.tf
@@ -18,7 +18,7 @@ resource "opslevel_scorecard" "my_scorecard" {
 
 // Example of how to assign a check to a scorecard
 resource "opslevel_check_manual" "my_check" {
-  name      = "My Check"
+  name      = "My check that uses a scorecard"
   category  = resource.opslevel_scorecard.my_scorecard.id
   ...
 }

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -2,11 +2,12 @@ package opslevel
 
 import (
 	"fmt"
+	"log"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/opslevel/opslevel-go/v2023"
-	"log"
-	"time"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -87,6 +88,7 @@ func Provider() terraform.ResourceProvider {
 			"opslevel_repository":                  resourceRepository(),
 			"opslevel_rubric_level":                resourceRubricLevel(),
 			"opslevel_rubric_category":             resourceRubricCategory(),
+			"opslevel_scorecard":                   resourceScorecard(),
 			"opslevel_service":                     resourceService(),
 			"opslevel_service_dependency":          resourceServiceDependency(),
 			"opslevel_service_repository":          resourceServiceRepository(),

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -5,6 +5,20 @@ import (
 	"github.com/opslevel/opslevel-go/v2023"
 )
 
+func handleInput(d *schema.ResourceData) opslevel.ScorecardInput {
+	// optional fields
+	description := d.Get("description").(string)
+
+	input := opslevel.ScorecardInput{
+		Name:        d.Get("name").(string),
+		OwnerId:     *opslevel.NewID(d.Get("owner_id").(string)),
+		Description: &description,
+		FilterId:    opslevel.NewID(d.Get("filter_id").(string)),
+	}
+
+	return input
+}
+
 func resourceScorecard() *schema.Resource {
 	return &schema.Resource{
 		Description: "Manages a scorecard",
@@ -68,15 +82,7 @@ func resourceScorecard() *schema.Resource {
 }
 
 func resourceScorecardCreate(d *schema.ResourceData, client *opslevel.Client) error {
-	ownerId := opslevel.NewID(d.Get("owner_id").(string))
-	filterId := opslevel.NewID(d.Get("filter_id").(string))
-
-	input := opslevel.ScorecardInput{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(*string),
-		OwnerId:     *ownerId,
-		FilterId:    filterId,
-	}
+	input := handleInput(d)
 
 	resource, err := client.CreateScorecard(input)
 	if err != nil {
@@ -99,13 +105,13 @@ func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) erro
 	if err := d.Set("description", resource.Description); err != nil {
 		return err
 	}
-	if err := d.Set("filter", resource.Filter); err != nil {
+	if err := d.Set("filter_id", resource.Filter.Id); err != nil {
 		return err
 	}
 	if err := d.Set("name", resource.Name); err != nil {
 		return err
 	}
-	if err := d.Set("owner", resource.Owner); err != nil {
+	if err := d.Set("owner_id", resource.Owner.Id()); err != nil {
 		return err
 	}
 	if err := d.Set("passing_checks", resource.PassingChecks); err != nil {
@@ -122,15 +128,7 @@ func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) erro
 }
 
 func resourceScorecardUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-	ownerId := opslevel.NewID(d.Get("owner_id").(string))
-	filterId := opslevel.NewID(d.Get("filter_id").(string))
-
-	input := opslevel.ScorecardInput{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(*string),
-		OwnerId:     *ownerId,
-		FilterId:    filterId,
-	}
+	input := handleInput(d)
 
 	_, err := client.UpdateScorecard(d.Id(), input)
 	if err != nil {

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -43,9 +43,10 @@ func resourceScorecard() *schema.Resource {
 
 			// computed fields
 			"aliases": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeList,
 				Description: "The scorecard's aliases.",
 				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"passingChecks": {
 				Type:        schema.TypeInt,

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -22,7 +22,7 @@ func resourceScorecard() *schema.Resource {
 				ForceNew:    false,
 				Required:    true,
 			},
-			"ownerId": {
+			"owner_id": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's owner.",
 				ForceNew:    false,
@@ -34,7 +34,7 @@ func resourceScorecard() *schema.Resource {
 				ForceNew:    false,
 				Optional:    true,
 			},
-			"filterId": {
+			"filter_id": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's filter.",
 				ForceNew:    false,
@@ -48,17 +48,17 @@ func resourceScorecard() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"passingChecks": {
+			"passing_checks": {
 				Type:        schema.TypeInt,
 				Description: "The scorecard's number of checks that are passing.",
 				Computed:    true,
 			},
-			"serviceCount": {
+			"service_count": {
 				Type:        schema.TypeInt,
 				Description: "The scorecard's number of services matched.",
 				Computed:    true,
 			},
-			"totalChecks": {
+			"total_checks": {
 				Type:        schema.TypeInt,
 				Description: "The scorecard's total number of checks.",
 				Computed:    true,
@@ -68,8 +68,8 @@ func resourceScorecard() *schema.Resource {
 }
 
 func resourceScorecardCreate(d *schema.ResourceData, client *opslevel.Client) error {
-	ownerId := opslevel.NewID(d.Get("ownerId").(string))
-	filterId := opslevel.NewID(d.Get("filterId").(string))
+	ownerId := opslevel.NewID(d.Get("owner_id").(string))
+	filterId := opslevel.NewID(d.Get("filter_id").(string))
 
 	input := opslevel.ScorecardInput{
 		Name:        d.Get("name").(string),
@@ -108,13 +108,13 @@ func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) erro
 	if err := d.Set("owner", resource.Owner); err != nil {
 		return err
 	}
-	if err := d.Set("passingChecks", resource.PassingChecks); err != nil {
+	if err := d.Set("passing_checks", resource.PassingChecks); err != nil {
 		return err
 	}
-	if err := d.Set("serviceCount", resource.ServiceCount); err != nil {
+	if err := d.Set("service_count", resource.ServiceCount); err != nil {
 		return err
 	}
-	if err := d.Set("totalChecks", resource.ChecksCount); err != nil {
+	if err := d.Set("total_checks", resource.ChecksCount); err != nil {
 		return err
 	}
 
@@ -122,8 +122,8 @@ func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) erro
 }
 
 func resourceScorecardUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-	ownerId := opslevel.NewID(d.Get("ownerId").(string))
-	filterId := opslevel.NewID(d.Get("filterId").(string))
+	ownerId := opslevel.NewID(d.Get("owner_id").(string))
+	filterId := opslevel.NewID(d.Get("filter_id").(string))
 
 	input := opslevel.ScorecardInput{
 		Name:        d.Get("name").(string),

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -40,6 +40,38 @@ func resourceScorecard() *schema.Resource {
 				ForceNew:    false,
 				Optional:    true,
 			},
+
+			// computed fields
+			"aliases": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's aliases.",
+				Computed:    true,
+			},
+			"filter": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's filter.",
+				Computed:    true,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's owner.",
+				Computed:    true,
+			},
+			"passingChecks": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's number of checks that are passing.",
+				Computed:    true,
+			},
+			"serviceCount": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's number of services matched.",
+				Computed:    true,
+			},
+			"totalChecks": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's total number of checks.",
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -1,0 +1,134 @@
+package opslevel
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/opslevel/opslevel-go/v2023"
+)
+
+func resourceScorecard() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages a scorecard",
+		Create:      wrap(resourceScorecardCreate),
+		Read:        wrap(resourceScorecardRead),
+		Update:      wrap(resourceScorecardUpdate),
+		Delete:      wrap(resourceScorecardDelete),
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's name.",
+				ForceNew:    false,
+				Required:    true,
+			},
+			"ownerId": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's owner.",
+				ForceNew:    false,
+				Required:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's description.",
+				ForceNew:    false,
+				Optional:    true,
+			},
+			"filterId": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's filter.",
+				ForceNew:    false,
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func resourceScorecardCreate(d *schema.ResourceData, client *opslevel.Client) error {
+	ownerId := opslevel.NewID(d.Get("ownerId").(string))
+	filterId := opslevel.NewID(d.Get("filterId").(string))
+
+	input := opslevel.ScorecardInput{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(*string),
+		OwnerId:     *ownerId,
+		FilterId:    filterId,
+	}
+
+	resource, err := client.CreateScorecard(input)
+	if err != nil {
+		return err
+	}
+	d.SetId(string(resource.Id))
+
+	return resourceScorecardRead(d, client)
+}
+
+func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) error {
+	resource, err := client.GetScorecard(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("aliases", resource.Aliases); err != nil {
+		return err
+	}
+	if err := d.Set("description", resource.Description); err != nil {
+		return err
+	}
+	if err := d.Set("filter", resource.Filter); err != nil {
+		return err
+	}
+	if err := d.Set("name", resource.Name); err != nil {
+		return err
+	}
+	if err := d.Set("owner", resource.Owner); err != nil {
+		return err
+	}
+	if err := d.Set("passingChecks", resource.PassingChecks); err != nil {
+		return err
+	}
+	if err := d.Set("serviceCount", resource.ServiceCount); err != nil {
+		return err
+	}
+	if err := d.Set("totalChecks", resource.ChecksCount); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceScorecardUpdate(d *schema.ResourceData, client *opslevel.Client) error {
+	input := opslevel.ScorecardInput{}
+
+	if d.HasChange("name") {
+		input.Name = d.Get("name").(string)
+	}
+	if d.HasChange("description") {
+		input.Description = d.Get("description").(*string)
+	}
+	if d.HasChange("ownerId") {
+		ownerId := opslevel.NewID(d.Get("ownerId").(string))
+		input.OwnerId = *ownerId
+	}
+	if d.HasChange("filterId") {
+		filterId := opslevel.NewID(d.Get("filterId").(string))
+		input.FilterId = filterId
+	}
+
+	_, err := client.UpdateScorecard(d.Id(), input)
+	if err != nil {
+		return err
+	}
+	return resourceScorecardRead(d, client)
+}
+
+func resourceScorecardDelete(d *schema.ResourceData, client *opslevel.Client) error {
+	_, err := client.DeleteScorecard(d.Id())
+	if err != nil {
+		return err
+	}
+	d.SetId("")
+
+	return nil
+}

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -47,28 +47,18 @@ func resourceScorecard() *schema.Resource {
 				Description: "The scorecard's aliases.",
 				Computed:    true,
 			},
-			"filter": {
-				Type:        schema.TypeString,
-				Description: "The scorecard's filter.",
-				Computed:    true,
-			},
-			"owner": {
-				Type:        schema.TypeString,
-				Description: "The scorecard's owner.",
-				Computed:    true,
-			},
 			"passingChecks": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Description: "The scorecard's number of checks that are passing.",
 				Computed:    true,
 			},
 			"serviceCount": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Description: "The scorecard's number of services matched.",
 				Computed:    true,
 			},
 			"totalChecks": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Description: "The scorecard's total number of checks.",
 				Computed:    true,
 			},
@@ -131,27 +121,21 @@ func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) erro
 }
 
 func resourceScorecardUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-	input := opslevel.ScorecardInput{}
+	ownerId := opslevel.NewID(d.Get("ownerId").(string))
+	filterId := opslevel.NewID(d.Get("filterId").(string))
 
-	if d.HasChange("name") {
-		input.Name = d.Get("name").(string)
-	}
-	if d.HasChange("description") {
-		input.Description = d.Get("description").(*string)
-	}
-	if d.HasChange("ownerId") {
-		ownerId := opslevel.NewID(d.Get("ownerId").(string))
-		input.OwnerId = *ownerId
-	}
-	if d.HasChange("filterId") {
-		filterId := opslevel.NewID(d.Get("filterId").(string))
-		input.FilterId = filterId
+	input := opslevel.ScorecardInput{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(*string),
+		OwnerId:     *ownerId,
+		FilterId:    filterId,
 	}
 
 	_, err := client.UpdateScorecard(d.Id(), input)
 	if err != nil {
 		return err
 	}
+
 	return resourceScorecardRead(d, client)
 }
 


### PR DESCRIPTION
https://github.com/OpsLevel/team-platform/issues/33

Relies on https://github.com/OpsLevel/opslevel-go/pull/233

## Tophatting

Step 1: wrote terraform file

```
resource "opslevel_team" "platform_team" {
    name = "platform"
}

resource "opslevel_filter" "rds_filter" {
  name = "rds apps"
  predicate {
    key      = "tags"
    key_data = "db"
    type     = "equals"
    value = "rds"
  }
}

resource "opslevel_scorecard" "rds_scorecard" {
  name = "rds scorecard"
  description = "scorecard for apps using rds"
  owner_id = opslevel_team.platform_team.id
  filter_id = opslevel_filter.rds_filter.id
}

resource "opslevel_scorecard" "min_scorecard" {
  name = "minimal scorecard"
  owner_id = opslevel_team.platform_team.id
}
```

Step 2: terraform apply

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_filter.rds_filter will be created
  + resource "opslevel_filter" "rds_filter" {
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "rds apps"

      + predicate {
          + key      = "tags"
          + key_data = "db"
          + type     = "equals"
          + value    = "rds"
        }
    }

  # opslevel_scorecard.min_scorecard will be created
  + resource "opslevel_scorecard" "min_scorecard" {
      + aliases        = (known after apply)
      + id             = (known after apply)
      + name           = "minimal scorecard"
      + owner_id       = (known after apply)
      + passing_checks = (known after apply)
      + service_count  = (known after apply)
      + total_checks   = (known after apply)
    }

  # opslevel_scorecard.rds_scorecard will be created
  + resource "opslevel_scorecard" "rds_scorecard" {
      + aliases        = (known after apply)
      + description    = "scorecard for apps using rds"
      + filter_id      = (known after apply)
      + id             = (known after apply)
      + name           = "rds scorecard"
      + owner_id       = (known after apply)
      + passing_checks = (known after apply)
      + service_count  = (known after apply)
      + total_checks   = (known after apply)
    }

  # opslevel_team.platform_team will be created
  + resource "opslevel_team" "platform_team" {
      + alias        = (known after apply)
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "platform"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```

Step 3: make modification to terraform file. `s/scorecard for apps using rds/this was changed in tf` and `s/minimal scorecard/min sc`

Step 4: apply again

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_scorecard.min_scorecard will be updated in-place
  ~ resource "opslevel_scorecard" "min_scorecard" {
        id             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY2NQ"
      ~ name           = "minimal scorecard" -> "min sc"
        # (5 unchanged attributes hidden)
    }

  # opslevel_scorecard.rds_scorecard will be updated in-place
  ~ resource "opslevel_scorecard" "rds_scorecard" {
      ~ description    = "scorecard for apps using rds" -> "this was changed in rds"
        id             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY2Ng"
        name           = "rds scorecard"
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```

Step 5: destroy

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_filter.rds_filter will be destroyed
  - resource "opslevel_filter" "rds_filter" {
      - id   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzI1MzM" -> null
      - name = "rds apps" -> null

      - predicate {
          - key      = "tags" -> null
          - key_data = "db" -> null
          - type     = "equals" -> null
          - value    = "rds" -> null
        }
    }

  # opslevel_scorecard.min_scorecard will be destroyed
  - resource "opslevel_scorecard" "min_scorecard" {
      - aliases        = [
          - "min_sc",
        ] -> null
      - id             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY2NQ" -> null
      - name           = "min sc" -> null
      - owner_id       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85MDA1" -> null
      - passing_checks = 0 -> null
      - service_count  = 283 -> null
      - total_checks   = 0 -> null
    }

  # opslevel_scorecard.rds_scorecard will be destroyed
  - resource "opslevel_scorecard" "rds_scorecard" {
      - aliases        = [
          - "rds_scorecard",
        ] -> null
      - description    = "this was changed in rds" -> null
      - filter_id      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzI1MzM" -> null
      - id             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY2Ng" -> null
      - name           = "rds scorecard" -> null
      - owner_id       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85MDA1" -> null
      - passing_checks = 0 -> null
      - service_count  = 0 -> null
      - total_checks   = 0 -> null
    }

  # opslevel_team.platform_team will be destroyed
  - resource "opslevel_team" "platform_team" {
      - alias = "platform" -> null
      - id    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85MDA1" -> null
      - name  = "platform" -> null
    }

Plan: 0 to add, 0 to change, 4 to destroy.
```

**All CRUD operations succeeded!**