### PR TITLE
update CONTRIBUTING docs, go.mod

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,19 @@ First make sure you have working [golang development environment](https://learn.
 
 Ensure [task](https://taskfile.dev/) is installed then run:
 
+To test local code against a feature branch in the `opslevel-go` repository, run:
+
 ```sh
-# Sets up opslevel-go submodule then sets up src/go.work
+# initializes opslevel-go submodule then sets up src/go.work
 task workspace
+
+# git checkouts my-feature-branch in the src/submodules/opslevel-go directory
+git -C ./src/submodules/opslevel-go checkout --track origin/my-feature-branch
 ```
+
+Code imported from `github.com/opslevel/opslevel-go` will now be sourced from the
+local `my-feature-branch`.
+
 
 ## Pointing Terraform to local OpsLevel running on your machine
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,11 +69,11 @@ Ensure [task](https://taskfile.dev/) is installed then run:
 To test local code against a feature branch in the `opslevel-go` repository, run:
 
 ```sh
-# initializes opslevel-go submodule then sets up src/go.work
+# initializes opslevel-go submodule then sets up go.work
 task workspace
 
-# git checkouts my-feature-branch in the src/submodules/opslevel-go directory
-git -C ./src/submodules/opslevel-go checkout --track origin/my-feature-branch
+# git checkouts my-feature-branch in the submodules/opslevel-go directory
+git -C ./submodules/opslevel-go checkout --track origin/my-feature-branch
 ```
 
 Code imported from `github.com/opslevel/opslevel-go` will now be sourced from the

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,3 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
-
-// Uncomment for local development
-//replace github.com/opslevel/opslevel-go/v2023 => ./submodules/opslevel-go/


### PR DESCRIPTION
Removed old way of setting up go workspace in favor or `task workspace`

Proven to work in CI see [this success story](https://github.com/OpsLevel/terraform-provider-opslevel/pull/105)