### PR TITLE
Scorecard datasource

### DIFF
--- a/.changes/unreleased/Feature-20230831-112138.yaml
+++ b/.changes/unreleased/Feature-20230831-112138.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add datasource for scorecards
+time: 2023-08-31T11:21:38.61878-04:00

--- a/opslevel/datasource_opslevel_scorecard.go
+++ b/opslevel/datasource_opslevel_scorecard.go
@@ -12,32 +12,27 @@ func datasourceScorecard() *schema.Resource {
 			"identifier": {
 				Type:        schema.TypeString,
 				Description: "The id or alias of the scorecard to find.",
-				ForceNew:    true,
-				Optional:    true,
+				Required:    true,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's name.",
-				ForceNew:    false,
-				Required:    true,
+				Computed:    true,
 			},
 			"owner_id": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's owner.",
-				ForceNew:    false,
-				Required:    true,
+				Computed:    true,
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's description.",
-				ForceNew:    false,
-				Optional:    true,
+				Computed:    true,
 			},
 			"filter_id": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's filter.",
-				ForceNew:    false,
-				Optional:    true,
+				Computed:    true,
 			},
 
 			// computed fields
@@ -77,7 +72,7 @@ func datasourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) er
 	d.Set("name", resource.Name)
 	d.Set("owner_id", resource.Id)
 	d.Set("description", resource.Description)
-	d.Set("filter_id", resource.Filter.FilterId)
+	d.Set("filter_id", resource.Filter.Id)
 	d.Set("aliases", resource.Aliases)
 	d.Set("passing_checks", resource.PassingChecks)
 	d.Set("service_count", resource.ServiceCount)

--- a/opslevel/datasource_opslevel_scorecard.go
+++ b/opslevel/datasource_opslevel_scorecard.go
@@ -1,0 +1,87 @@
+package opslevel
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/opslevel/opslevel-go/v2023"
+)
+
+func datasourceScorecard() *schema.Resource {
+	return &schema.Resource{
+		Read: wrap(datasourceScorecardRead),
+		Schema: map[string]*schema.Schema{
+			"identifier": {
+				Type:        schema.TypeString,
+				Description: "The id or alias of the scorecard to find.",
+				ForceNew:    true,
+				Optional:    true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's name.",
+				ForceNew:    false,
+				Required:    true,
+			},
+			"owner_id": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's owner.",
+				ForceNew:    false,
+				Required:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's description.",
+				ForceNew:    false,
+				Optional:    true,
+			},
+			"filter_id": {
+				Type:        schema.TypeString,
+				Description: "The scorecard's filter.",
+				ForceNew:    false,
+				Optional:    true,
+			},
+
+			// computed fields
+			"aliases": {
+				Type:        schema.TypeList,
+				Description: "The scorecard's aliases.",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"passing_checks": {
+				Type:        schema.TypeInt,
+				Description: "The scorecard's number of checks that are passing.",
+				Computed:    true,
+			},
+			"service_count": {
+				Type:        schema.TypeInt,
+				Description: "The scorecard's number of services matched.",
+				Computed:    true,
+			},
+			"total_checks": {
+				Type:        schema.TypeInt,
+				Description: "The scorecard's total number of checks.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func datasourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) error {
+	identifier := d.Get("identifier").(string)
+	resource, err := client.GetScorecard(identifier)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(string(resource.Id))
+	d.Set("name", resource.Name)
+	d.Set("owner_id", resource.Id)
+	d.Set("description", resource.Description)
+	d.Set("filter_id", resource.Filter.FilterId)
+	d.Set("aliases", resource.Aliases)
+	d.Set("passing_checks", resource.PassingChecks)
+	d.Set("service_count", resource.ServiceCount)
+	d.Set("total_checks", resource.ChecksCount)
+
+	return nil
+}

--- a/opslevel/datasource_opslevel_scorecards.go
+++ b/opslevel/datasource_opslevel_scorecards.go
@@ -19,17 +19,17 @@ func datasourceScorecards() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"owner_id": {
+			"owner_ids": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"description": {
+			"descriptions": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"filter_id": {
+			"filter_ids": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -72,13 +72,14 @@ func datasourceScorecardsRead(d *schema.ResourceData, client *opslevel.Client) e
 	ownerIds := make([]string, count)
 	descriptions := make([]string, count)
 	filterIds := make([]string, count)
-	aliases := make([]string, count)
+	aliases := make([][]string, count)
 	passingChecks := make([]int, count)
 	serviceCounts := make([]int, count)
 	totalChecks := make([]int, count)
 	for i, item := range resp.Nodes {
 		if len(item.Aliases) > 0 {
-			aliases[i] = item.Aliases[0]
+			aliases[i] = make([]string, 1)
+			aliases[i][0] = item.Aliases[0]
 		}
 		ids[i] = string(item.Id)
 		names[i] = item.Name

--- a/opslevel/datasource_opslevel_scorecards.go
+++ b/opslevel/datasource_opslevel_scorecards.go
@@ -1,0 +1,105 @@
+package opslevel
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/opslevel/opslevel-go/v2023"
+)
+
+func datasourceScorecards() *schema.Resource {
+	return &schema.Resource{
+		Read: wrap(datasourceScorecardsRead),
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"owner_id": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"description": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"filter_id": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			// computed fields
+			"aliases": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeList},
+			},
+			"passing_checks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"service_counts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"total_checks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+		},
+	}
+}
+
+func datasourceScorecardsRead(d *schema.ResourceData, client *opslevel.Client) error {
+	resp, err := client.ListScorecards(nil)
+	if err != nil {
+		return err
+	}
+
+	count := len(resp.Nodes)
+	ids := make([]string, count)
+	names := make([]string, count)
+	ownerIds := make([]string, count)
+	descriptions := make([]string, count)
+	filterIds := make([]string, count)
+	aliases := make([]string, count)
+	passingChecks := make([]int, count)
+	serviceCounts := make([]int, count)
+	totalChecks := make([]int, count)
+	for i, item := range resp.Nodes {
+		if len(item.Aliases) > 0 {
+			aliases[i] = item.Aliases[0]
+		}
+		ids[i] = string(item.Id)
+		names[i] = item.Name
+		ownerIds[i] = string(item.Owner.Id())
+		descriptions[i] = item.Description
+		filterIds[i] = string(item.Filter.Id)
+		passingChecks[i] = item.PassingChecks
+		serviceCounts[i] = item.ServiceCount
+		totalChecks[i] = item.ChecksCount
+	}
+
+	d.SetId(timeID())
+	d.Set("ids", ids)
+	d.Set("names", names)
+	d.Set("owner_ids", ownerIds)
+	d.Set("descriptions", descriptions)
+	d.Set("filter_ids", filterIds)
+	d.Set("aliases", aliases)
+	d.Set("passing_checks", passingChecks)
+	d.Set("service_counts", serviceCounts)
+	d.Set("total_checks", totalChecks)
+
+	return nil
+}

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -53,6 +53,8 @@ func Provider() terraform.ResourceProvider {
 			"opslevel_rubric_categories": datasourceRubricCategories(),
 			"opslevel_rubric_level":      datasourceRubricLevel(),
 			"opslevel_rubric_levels":     datasourceRubricLevels(),
+			"opslevel_scorecard":         datasourceScorecard(),
+			"opslevel_scorecards":        datasourceScorecards(),
 			"opslevel_service":           datasourceService(),
 			"opslevel_services":          datasourceServices(),
 			"opslevel_system":            datasourceSystem(),


### PR DESCRIPTION
https://github.com/OpsLevel/team-platform/issues/66

## Tophatting

```
$ cat scorecard.tf
data "opslevel_scorecards" "all_scorecards" {
# no query filter present since API doesn't support them yet
}

output "fetch_all_scorecards" {
  value = data.opslevel_scorecards.all_scorecards
}

data "opslevel_scorecard" "my-scorecard" {
  identifier = "test2"
}

output "my-scorecard" {
  value = data.opslevel_scorecard.my-scorecard
}
$ task tf-plan
Changes to Outputs:
  + fetch_all_scorecards = {
      + aliases        = [
          + [
              + "test_scorecard",
            ],
          + [
              + "rds_scorecard",
            ],
          + [
              + "test2",
            ],
        ]
      + descriptions   = [
          + "test description",
          + "",
          + "scorecard no filter",
        ]
      + filter_ids     = [
          + "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1OA",
          + "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzI1NzQ",
          + "",
        ]
      + id             = "1693420797"
      + ids            = [
          + "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzYwNw",
          + "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY4NA",
          + "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY4Nw",
        ]
      + names          = [
          + "Test scorecard",
          + "rds scorecard",
          + "test2",
        ]
      + owner_ids      = [
          + "Z2lkOi8vb3BzbGV2ZWwvTmFtZXNwYWNlczo6R3JvdXAvMzE",
          + "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5",
          + "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5",
        ]
      + passing_checks = [
          + 73,
          + 0,
          + 0,
        ]
      + service_counts = [
          + 285,
          + 2,
          + 285,
        ]
      + total_checks   = [
          + 306,
          + 0,
          + 0,
        ]
    }
  + my-scorecard         = {
      + aliases        = [
          + "test2",
        ]
      + description    = "scorecard no filter"
      + filter_id      = ""
      + id             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY4Nw"
      + identifier     = "test2"
      + name           = "test2"
      + owner_id       = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzY4Nw"
      + passing_checks = 0
      + service_count  = 285
      + total_checks   = 0
    }

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
~/s/gith/O/terraform-provider-opslevel/workspace scorecards-datasource ?3 ❯                                                                               02:39:57 PM
```