### PR TITLE
Db/provider manages global custom actions

### DIFF
--- a/.changes/unreleased/Feature-20230912-153021.yaml
+++ b/.changes/unreleased/Feature-20230912-153021.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add extendedTeamAccess field to trigger definitions
+time: 2023-09-12T15:30:21.239598-05:00

--- a/examples/data-sources/opslevel_webhook_action/data-source.tf
+++ b/examples/data-sources/opslevel_webhook_action/data-source.tf
@@ -1,3 +1,0 @@
-data "opslevel_webhook_action" "example" {
-  identifier = "example"
-}

--- a/examples/data-sources/opslevel_webhook_action/data-source.tf
+++ b/examples/data-sources/opslevel_webhook_action/data-source.tf
@@ -1,0 +1,3 @@
+data "opslevel_webhook_action" "example" {
+  identifier = "example"
+}

--- a/examples/resources/opslevel_trigger_definition/resource.tf
+++ b/examples/resources/opslevel_trigger_definition/resource.tf
@@ -46,6 +46,7 @@ resource "opslevel_trigger_definition" "example" {
   filter = data.opslevel_filter.tier_1.id
   action = opslevel_webhook_action.example.id
   access_control = "everyone"
+  extended_team_access = ["team_1", "team_2"]
   manual_inputs_definition = <<EOT
 ---
 version: 1

--- a/opslevel/resource_opslevel_trigger_definition.go
+++ b/opslevel/resource_opslevel_trigger_definition.go
@@ -92,9 +92,15 @@ func resourceTriggerDefinition() *schema.Resource {
 }
 
 func resourceTriggerDefinitionCreate(d *schema.ResourceData, client *opslevel.Client) error {
-	extended_teams := []opslevel.IdentifierInput{}
-	for _, team := range getStringArray(d, "extended_team_access") {
-		extended_teams = append(extended_teams, *opslevel.NewIdentifier(team))
+	var extended_teams *[]opslevel.IdentifierInput
+
+	extendedTeamAccessArray := getStringArray(d, "extended_team_access")
+	if len(extendedTeamAccessArray) > 0 {
+		my_teams := []opslevel.IdentifierInput{}
+		for _, team := range extendedTeamAccessArray {
+			my_teams = append(my_teams, *opslevel.NewIdentifier(team))
+		}
+		extended_teams = &my_teams
 	}
 
 	input := opslevel.CustomActionsTriggerDefinitionCreateInput{
@@ -102,7 +108,7 @@ func resourceTriggerDefinitionCreate(d *schema.ResourceData, client *opslevel.Cl
 		Owner:              *opslevel.NewID(d.Get("owner").(string)),
 		Action:             *opslevel.NewID(d.Get("action").(string)),
 		AccessControl:      opslevel.CustomActionsTriggerDefinitionAccessControlEnum(d.Get("access_control").(string)),
-		ExtendedTeamAccess: &extended_teams,
+		ExtendedTeamAccess: extended_teams,
 	}
 
 	if _, ok := d.GetOk("description"); ok {

--- a/opslevel/resource_opslevel_trigger_definition.go
+++ b/opslevel/resource_opslevel_trigger_definition.go
@@ -92,23 +92,19 @@ func resourceTriggerDefinition() *schema.Resource {
 }
 
 func resourceTriggerDefinitionCreate(d *schema.ResourceData, client *opslevel.Client) error {
-	var extended_teams *[]opslevel.IdentifierInput
-
-	extendedTeamAccessArray := getStringArray(d, "extended_team_access")
-	if len(extendedTeamAccessArray) > 0 {
-		my_teams := []opslevel.IdentifierInput{}
-		for _, team := range extendedTeamAccessArray {
-			my_teams = append(my_teams, *opslevel.NewIdentifier(team))
-		}
-		extended_teams = &my_teams
+	extended_teams := []opslevel.IdentifierInput{}
+	for _, team := range getStringArray(d, "extended_team_access") {
+		extended_teams = append(extended_teams, *opslevel.NewIdentifier(team))
 	}
 
 	input := opslevel.CustomActionsTriggerDefinitionCreateInput{
-		Name:               d.Get("name").(string),
-		Owner:              *opslevel.NewID(d.Get("owner").(string)),
-		Action:             *opslevel.NewID(d.Get("action").(string)),
-		AccessControl:      opslevel.CustomActionsTriggerDefinitionAccessControlEnum(d.Get("access_control").(string)),
-		ExtendedTeamAccess: extended_teams,
+		Name:          d.Get("name").(string),
+		Owner:         *opslevel.NewID(d.Get("owner").(string)),
+		Action:        *opslevel.NewID(d.Get("action").(string)),
+		AccessControl: opslevel.CustomActionsTriggerDefinitionAccessControlEnum(d.Get("access_control").(string)),
+	}
+	if len(extended_teams) > 0 {
+		input.ExtendedTeamAccess = &extended_teams
 	}
 
 	if _, ok := d.GetOk("description"); ok {


### PR DESCRIPTION
https://github.com/OpsLevel/team-platform/issues/37

Tophatting
Step 1: wrote terraform file

```tf
data "opslevel_team" "test_team" {
  alias = "test_team"
}

data "opslevel_team" "testing_team" {
  alias = "testing_team"
}

resource "opslevel_trigger_definition" "foo_trigger_definition" {
  name                 = "foo-trigger-definition"
  action               = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8yMzg"
  owner                = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yOTQ"
  access_control       = "everyone"
  extended_team_access = [data.opslevel_team.test_team.alias, data.opslevel_team.testing_team.alias]
}
```

Step 2: terraform apply

```tf
  Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
    + create

  Terraform will perform the following actions:

    # opslevel_trigger_definition.foo_trigger_definition will be created
    + resource "opslevel_trigger_definition" "foo_trigger_definition" {
        + access_control       = "everyone"
        + action               = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8yMzg"
        + extended_team_access = [
            + "test_team",
            + "testing_team",
          ]
        + id                   = (known after apply)
        + name                 = "foo-trigger-definition"
        + owner                = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yOTQ"
        + published            = false
      }

  Plan: 1 to add, 0 to change, 0 to destroy.

  Do you want to perform these actions?
    Terraform will perform the actions described above.
    Only 'yes' will be accepted to approve.

    Enter a value: yes

  opslevel_trigger_definition.foo_trigger_definition: Creating...
  opslevel_trigger_definition.foo_trigger_definition: Creation complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjE5]

  Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Step 3: modify terraform file - removed extended teams from `extended_team_access`

Step 4: apply again

```tf
  Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
    ~ update in-place

  Terraform will perform the following actions:

    # opslevel_trigger_definition.foo_trigger_definition will be updated in-place
    ~ resource "opslevel_trigger_definition" "foo_trigger_definition" {
        ~ extended_team_access = [
            - "test_team",
            - "testing_team",
          ]
          id                   = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjE5"
          name                 = "foo-trigger-definition"
          # (4 unchanged attributes hidden)
      }

  Plan: 0 to add, 1 to change, 0 to destroy.

  Do you want to perform these actions?
    Terraform will perform the actions described above.
    Only 'yes' will be accepted to approve.

    Enter a value: yes

  opslevel_trigger_definition.foo_trigger_definition: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjE5]
  opslevel_trigger_definition.foo_trigger_definition: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjE5]

  Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Step 5: destroy

```tf
  Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
    - destroy

  Terraform will perform the following actions:

    # opslevel_trigger_definition.foo_trigger_definition will be destroyed
    - resource "opslevel_trigger_definition" "foo_trigger_definition" {
        - access_control       = "everyone" -> null
        - action               = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8yMzg" -> null
        - extended_team_access = [] -> null
        - id                   = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjE5" -> null
        - name                 = "foo-trigger-definition" -> null
        - owner                = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yOTQ" -> null
        - published            = false -> null
      }

  Plan: 0 to add, 0 to change, 1 to destroy.

  Do you really want to destroy all resources?
    Terraform will destroy all your managed infrastructure, as shown above.
    There is no undo. Only 'yes' will be accepted to confirm.

    Enter a value: yes

  opslevel_trigger_definition.foo_trigger_definition: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vMjE5]
  opslevel_trigger_definition.foo_trigger_definition: Destruction complete after 0s

  Destroy complete! Resources: 1 destroyed.
```

All CRUD operations succeeded!