### PR TITLE
Add support for case sensitive on filter predicates

### DIFF
--- a/.changes/unreleased/Feature-20231006-093301.yaml
+++ b/.changes/unreleased/Feature-20231006-093301.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add support for `case_sensitive` field on filter predicates
+time: 2023-10-06T09:33:01.887073-05:00

--- a/examples/resources/opslevel_filter/resource.tf
+++ b/examples/resources/opslevel_filter/resource.tf
@@ -31,3 +31,14 @@ resource "opslevel_filter" "tier3" {
     key_data = "tier3"
   }
 }
+
+resource "opslevel_filter" "case_sensitive" {
+  name = "foo"
+  predicate {
+    key            = "tags"
+    type           = "equals"
+    key_data       = "my-custom-tag"
+    value          = "hello-world"
+    case_sensitive = true
+  }
+}

--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -213,23 +213,25 @@ func expandFilterPredicates(d *schema.ResourceData) []opslevel.FilterPredicate {
 	for _, item := range d.Get("predicate").([]interface{}) {
 		data := item.(map[string]interface{})
 		output = append(output, opslevel.FilterPredicate{
-			Type:    opslevel.PredicateTypeEnum(data["type"].(string)),
-			Value:   strings.TrimSpace(data["value"].(string)),
-			Key:     opslevel.PredicateKeyEnum(data["key"].(string)),
-			KeyData: strings.TrimSpace(data["key_data"].(string)),
+			Type:          opslevel.PredicateTypeEnum(data["type"].(string)),
+			Value:         strings.TrimSpace(data["value"].(string)),
+			Key:           opslevel.PredicateKeyEnum(data["key"].(string)),
+			KeyData:       strings.TrimSpace(data["key_data"].(string)),
+			CaseSensitive: opslevel.Bool(data["case_sensitive"].(bool)),
 		})
 	}
 	return output
 }
 
-func flattenFilterPredicates(input []opslevel.FilterPredicate) []map[string]string {
-	output := []map[string]string{}
+func flattenFilterPredicates(input []opslevel.FilterPredicate) []map[string]any {
+	output := make([]map[string]any, 0, len(input))
 	for _, predicate := range input {
-		output = append(output, map[string]string{
-			"key":      string(predicate.Key),
-			"key_data": predicate.KeyData,
-			"type":     string(predicate.Type),
-			"value":    predicate.Value,
+		output = append(output, map[string]any{
+			"key":            string(predicate.Key),
+			"key_data":       predicate.KeyData,
+			"type":           string(predicate.Type),
+			"value":          predicate.Value,
+			"case_sensitive": predicate.CaseSensitive,
 		})
 	}
 	return output

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -28,7 +28,7 @@ func resourceCheckServiceOwnership() *schema.Resource {
 				Description:  "The type of contact method that is required.",
 				ForceNew:     false,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice(opslevel.AllServiceOwnershipCheckContactType, true),
+				ValidateFunc: validation.StringInSlice(opslevel.AllContactType, true),
 			},
 			"tag_key": {
 				Type:        schema.TypeString,
@@ -49,7 +49,7 @@ func resourceCheckServiceOwnershipCreate(d *schema.ResourceData, client *opsleve
 		input.RequireContactMethod = opslevel.Bool(requireContactMethod.(bool))
 	}
 	if value, ok := d.GetOk("contact_method"); ok {
-		contactMethod := opslevel.ServiceOwnershipCheckContactType(value.(string))
+		contactMethod := opslevel.ContactType(value.(string))
 		input.ContactMethod = &contactMethod
 	}
 	if tagKey, ok := d.GetOk("tag_key"); ok {
@@ -114,11 +114,7 @@ func resourceCheckServiceOwnershipUpdate(d *schema.ResourceData, client *opsleve
 	}
 
 	if d.HasChange("contact_method") {
-		contactMethod := opslevel.ServiceOwnershipCheckContactType(d.Get("contact_method").(string))
-
-		if contactMethod == "" {
-			contactMethod = opslevel.ServiceOwnershipCheckContactType("ANY")
-		}
+		contactMethod := opslevel.ContactType(d.Get("contact_method").(string))
 		input.ContactMethod = &contactMethod
 	}
 

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -61,6 +61,12 @@ func resourceFilter() *schema.Resource {
 							ForceNew:    false,
 							Optional:    true,
 						},
+						"case_sensitive": {
+							Type:        schema.TypeBool,
+							Description: "Option for determining whether to compare strings case-sensitively.\n\n",
+							ForceNew:    false,
+							Optional:    true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Issues
https://github.com/OpsLevel/team-platform/issues/95

## Changelog

- [ ] Add field `case_sensitive` to the resource for managing filters
- [X] Make a `changie` entry

## Tophatting

Added example to show how to use this new field

```tf
resource "opslevel_filter" "case_sensitive" {
  name = "foo"
  predicate {
    key            = "tags"
    type           = "equals"
    key_data       = "my-custom-tag"
    value          = "hello-world"
    case_sensitive = true
  }
}
```
