### PR TITLE
fix typos, add User and InfrastructureResource examples

### DIFF
--- a/examples/resources/opslevel_tag/resource.tf
+++ b/examples/resources/opslevel_tag/resource.tf
@@ -3,49 +3,67 @@ data "opslevel_repository" "foo" {
 }
 
 resource "opslevel_tag" "foo_repo" {
-  resource_type = "Repository"
-  resource_id   = data.opslevel_repository.foo.id
+  resource_type       = "Repository"
+  resource_identifier = data.opslevel_repository.foo.id
 
   key   = "type"
   value = "frontend"
 }
 
 resource "opslevel_tag" "bar_repo" {
-  resource_type = "Repository"
-  resource_id   = "github.com:organization/example-2"
+  resource_type       = "Repository"
+  resource_identifier = "github.com:organization/example-2"
 
   key   = "type"
   value = "backend"
 }
 
 resource "opslevel_tag" "foo_domain" {
-  resource_type = "Domain"
-  resource_id   = "test-team"
+  resource_type       = "Domain"
+  resource_identifier = "test-team"
 
   key   = "space"
   value = "craft"
 }
 
 resource "opslevel_tag" "foo_service" {
-  resource_type = "Service"
-  resource_id   = "test-service"
+  resource_type       = "Service"
+  resource_identifier = "test-service"
 
   key   = "yacht"
   value = "racing"
 }
 
 resource "opslevel_tag" "foo_system" {
-  resource_type = "System"
-  resource_id   = "test-system"
+  resource_type       = "System"
+  resource_identifier = "test-system"
 
   key   = "crisp"
   value = "audio"
 }
 
 resource "opslevel_tag" "foo_team" {
-  resource_type = "Team"
-  resource_id   = "platform"
+  resource_type       = "Team"
+  resource_identifier = "platform"
 
   key   = "goals"
   value = "automation"
 }
+
+resource "opslevel_tag" "foo_infra" {
+  resource_type       = "InfrastructureResource"
+  resource_identifier = "foo-id"
+
+  key   = "type"
+  value = "storage"
+}
+
+
+resource "opslevel_tag" "foo_user" {
+  resource_type       = "User"
+  resource_identifier = "user-id"
+
+  key   = "role"
+  value = "dev"
+}
+


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Updating examples for `opslevel_tag`s. 
- `resource_id` should be `resource_identifier`
- Added examples for `InfrastructureResource` and `User` resources

- [X] List your changes here
- [ ] Make a `changie` entry <- N/A, docs update

## Tophatting

N/A - will be reflected [here](https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/resources/tag)
