### PR TITLE
add parent_team field to opslevel_team resource

### DIFF
--- a/.changes/unreleased/Feature-20231017-135010.yaml
+++ b/.changes/unreleased/Feature-20231017-135010.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Add parent_team field to opslevel_team resource
+time: 2023-10-17T13:50:10.351646-05:00

--- a/examples/resources/opslevel_team/resource.tf
+++ b/examples/resources/opslevel_team/resource.tf
@@ -2,6 +2,10 @@ data "opslevel_group" "foo" {
   identifier = "foo"
 }
 
+data "opslevel_team" "parent" {
+  alias = "platform"
+}
+
 resource "opslevel_team" "example" {
   name             = "foo"
   manager_email    = "john.doe@example.com"
@@ -9,6 +13,7 @@ resource "opslevel_team" "example" {
   responsibilities = "Responsible for foo frontend and backend"
   aliases          = ["bar", "baz"]
   group            = data.opslevel_group.foo.alias
+  parent_team      = data.opslevel_team.parent.id
 }
 
 output "team" {

--- a/examples/resources/opslevel_team/resource.tf
+++ b/examples/resources/opslevel_team/resource.tf
@@ -1,7 +1,3 @@
-data "opslevel_group" "foo" {
-  identifier = "foo"
-}
-
 data "opslevel_team" "parent" {
   alias = "platform"
 }
@@ -12,8 +8,7 @@ resource "opslevel_team" "example" {
   members          = ["john.doe@example.com", "jane.doe@example.com"]
   responsibilities = "Responsible for foo frontend and backend"
   aliases          = ["bar", "baz"]
-  group            = data.opslevel_group.foo.alias
-  parent_team      = data.opslevel_team.parent.id
+  parent           = data.opslevel_team.parent.id
 }
 
 output "team" {

--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -26,12 +26,12 @@ func datasourceTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"parent_team_alias": {
+			"parent_alias": {
 				Type:        schema.TypeString,
 				Description: "The alias of the parent team.",
 				Computed:    true,
 			},
-			"parent_team_id": {
+			"parent_id": {
 				Type:        schema.TypeString,
 				Description: "The id of the parent team.",
 				Computed:    true,
@@ -40,13 +40,13 @@ func datasourceTeam() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The name of the group the team belongs to.",
 				Computed:    true,
-				Deprecated:  "field 'group' on team is no longer supported please use the 'parent_team' field.",
+				Deprecated:  "field 'group' on team is no longer supported please use the 'parent' field.",
 			},
 			"group_id": {
 				Type:        schema.TypeString,
 				Description: "The id of the group the team belongs to.",
 				Computed:    true,
-				Deprecated:  "field 'group' on team is no longer supported please use the 'parent_team' field.",
+				Deprecated:  "field 'group' on team is no longer supported please use the 'parent' field.",
 			},
 		},
 	}
@@ -67,10 +67,10 @@ func datasourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
 	if err := d.Set("group_id", resource.Group.Id); err != nil {
 		return err
 	}
-	if err := d.Set("parent_team_alias", resource.ParentTeam.Alias); err != nil {
+	if err := d.Set("parent_alias", resource.ParentTeam.Alias); err != nil {
 		return err
 	}
-	if err := d.Set("parent_team_id", resource.ParentTeam.Id); err != nil {
+	if err := d.Set("parent_id", resource.ParentTeam.Id); err != nil {
 		return err
 	}
 

--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -26,15 +26,27 @@ func datasourceTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"parent_team_alias": {
+				Type:        schema.TypeString,
+				Description: "The alias of the parent team.",
+				Computed:    true,
+			},
+			"parent_team_id": {
+				Type:        schema.TypeString,
+				Description: "The id of the parent team.",
+				Computed:    true,
+			},
 			"group_alias": {
 				Type:        schema.TypeString,
 				Description: "The name of the group the team belongs to.",
 				Computed:    true,
+				Deprecated:  "field 'group' on team is no longer supported please use the 'parent_team' field.",
 			},
 			"group_id": {
 				Type:        schema.TypeString,
 				Description: "The id of the group the team belongs to.",
 				Computed:    true,
+				Deprecated:  "field 'group' on team is no longer supported please use the 'parent_team' field.",
 			},
 		},
 	}
@@ -53,6 +65,12 @@ func datasourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
 		return err
 	}
 	if err := d.Set("group_id", resource.Group.Id); err != nil {
+		return err
+	}
+	if err := d.Set("parent_team_alias", resource.ParentTeam.Alias); err != nil {
+		return err
+	}
+	if err := d.Set("parent_team_id", resource.ParentTeam.Id); err != nil {
 		return err
 	}
 

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -58,6 +58,7 @@ func resourceTeam() *schema.Resource {
 			"group": {
 				Type:        schema.TypeString,
 				Description: "The group this team belongs to. Only accepts group's Alias",
+				Deprecated:  "field 'group' on team is no longer supported please use the 'parent_team' field.",
 				ForceNew:    false,
 				Optional:    true,
 			},
@@ -65,6 +66,12 @@ func resourceTeam() *schema.Resource {
 				Type:        schema.TypeSet,
 				Description: "List of user emails that belong to the team. This list must contain the 'manager_email' value.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				ForceNew:    false,
+				Optional:    true,
+			},
+			"parent_team": {
+				Type:        schema.TypeString,
+				Description: "The parent team.",
 				ForceNew:    false,
 				Optional:    true,
 			},
@@ -170,6 +177,9 @@ func resourceTeamCreate(d *schema.ResourceData, client *opslevel.Client) error {
 	if group, ok := d.GetOk("group"); ok {
 		input.Group = opslevel.NewIdentifier(group.(string))
 	}
+	if parentTeam, ok := d.GetOk("parent_team"); ok {
+		input.ParentTeam = opslevel.NewIdentifier(parentTeam.(string))
+	}
 
 	membershipValidationErr := validateMembershipState(d)
 	if membershipValidationErr != nil {
@@ -219,6 +229,11 @@ func resourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
 	}
 	if _, ok := d.GetOk("group"); ok {
 		if err := d.Set("group", resource.Group.Alias); err != nil {
+			return err
+		}
+	}
+	if _, ok := d.GetOk("parent_team"); ok {
+		if err := d.Set("parent_team", resource.ParentTeam.Alias); err != nil {
 			return err
 		}
 	}
@@ -273,6 +288,13 @@ func resourceTeamUpdate(d *schema.ResourceData, client *opslevel.Client) error {
 			input.Group = opslevel.NewIdentifier(group.(string))
 		} else {
 			input.Group = nil
+		}
+	}
+	if d.HasChange("parent_team") {
+		if parentTeam, ok := d.GetOk("parent_team"); ok {
+			input.ParentTeam = opslevel.NewIdentifier(parentTeam.(string))
+		} else {
+			input.ParentTeam = nil
 		}
 	}
 

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -58,7 +58,7 @@ func resourceTeam() *schema.Resource {
 			"group": {
 				Type:        schema.TypeString,
 				Description: "The group this team belongs to. Only accepts group's Alias",
-				Deprecated:  "field 'group' on team is no longer supported please use the 'parent_team' field.",
+				Deprecated:  "field 'group' on team is no longer supported please use the 'parent' field.",
 				ForceNew:    false,
 				Optional:    true,
 			},
@@ -69,9 +69,9 @@ func resourceTeam() *schema.Resource {
 				ForceNew:    false,
 				Optional:    true,
 			},
-			"parent_team": {
+			"parent": {
 				Type:        schema.TypeString,
-				Description: "The parent team.",
+				Description: "The parent team. Only accepts team's Alias",
 				ForceNew:    false,
 				Optional:    true,
 			},
@@ -177,7 +177,7 @@ func resourceTeamCreate(d *schema.ResourceData, client *opslevel.Client) error {
 	if group, ok := d.GetOk("group"); ok {
 		input.Group = opslevel.NewIdentifier(group.(string))
 	}
-	if parentTeam, ok := d.GetOk("parent_team"); ok {
+	if parentTeam, ok := d.GetOk("parent"); ok {
 		input.ParentTeam = opslevel.NewIdentifier(parentTeam.(string))
 	}
 
@@ -232,8 +232,8 @@ func resourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
 			return err
 		}
 	}
-	if _, ok := d.GetOk("parent_team"); ok {
-		if err := d.Set("parent_team", resource.ParentTeam.Alias); err != nil {
+	if _, ok := d.GetOk("parent"); ok {
+		if err := d.Set("parent", resource.ParentTeam.Alias); err != nil {
 			return err
 		}
 	}
@@ -290,8 +290,8 @@ func resourceTeamUpdate(d *schema.ResourceData, client *opslevel.Client) error {
 			input.Group = nil
 		}
 	}
-	if d.HasChange("parent_team") {
-		if parentTeam, ok := d.GetOk("parent_team"); ok {
+	if d.HasChange("parent") {
+		if parentTeam, ok := d.GetOk("parent"); ok {
 			input.ParentTeam = opslevel.NewIdentifier(parentTeam.(string))
 		} else {
 			input.ParentTeam = nil


### PR DESCRIPTION
## Issues

[#118](https://github.com/OpsLevel/team-platform/issues/118)

## Changelog

Add `parent_team` field to `opslevel_team` resource.
Update commit hash to submodule (needs one more update after `opslevel-go` PR is merged) 

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

Using this (slightly edited) `main.tf`
```
data "opslevel_group" "foo" {
  identifier = "bar-group"
}

data "opslevel_team" "parent" {
  alias = "platform"
}

resource "opslevel_team" "tf-example" {
  name             = "terraform-test-team"
  manager_email    = "themanager@example.com"
  members          = ["themanager@example.com", "teammember@example.com"]
  responsibilities = "Important things"
  aliases          = ["bar", "baz"]
  group            = data.opslevel_group.foo.alias
  parent_team      = data.opslevel_team.parent.alias
}

output "team" {
  value = opslevel_team.tf-example.id
}

```

1. Terraform create
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_team.tf-example will be created
  + resource "opslevel_team" "tf-example" {
      + alias            = (known after apply)
      + aliases          = [
          + "bar",
          + "baz",
        ]
      + group            = "bar-group"
      + id               = (known after apply)
      + last_updated     = (known after apply)
      + manager_email    = "themanager@example.com"
      + members          = [
          + "themanager@example.com",
          + "teammember@example.com",
        ]
      + name             = "terraform-test-team"
      + parent_team      = "platform"
      + responsibilities = "Important things"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + team = (known after apply)
╷
│ Warning: "group": [DEPRECATED] field 'group' on team is no longer supported please use the 'parent_team' field.
│ 
│   with opslevel_team.tf-example,
│   on main.tf line 9, in resource "opslevel_team" "tf-example":
│    9: resource "opslevel_team" "tf-example" {
│ 
│ (and one more similar warning elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_team.tf-example: Creating...
opslevel_team.tf-example: Creation complete after 4s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg]
╷
│ Warning: "group": [DEPRECATED] field 'group' on team is no longer supported please use the 'parent_team' field.
│ 
│   with opslevel_team.tf-example,
│   on main.tf line 9, in resource "opslevel_team" "tf-example":
│    9: resource "opslevel_team" "tf-example" {
│ 
╵

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

team = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg"

```

2. Edit file to remove `parent_team`, then re-apply

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_team.tf-example will be updated in-place
  ~ resource "opslevel_team" "tf-example" {
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg"
        name             = "terraform-test-team"
      - parent_team      = "platform" -> null
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
╷
│ Warning: "group": [DEPRECATED] field 'group' on team is no longer supported please use the 'parent_team' field.
│ 
│   with opslevel_team.tf-example,
│   on main.tf line 9, in resource "opslevel_team" "tf-example":
│    9: resource "opslevel_team" "tf-example" {
│ 
│ (and one more similar warning elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_team.tf-example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg]
opslevel_team.tf-example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg]
╷
│ Warning: "group": [DEPRECATED] field 'group' on team is no longer supported please use the 'parent_team' field.
│ 
│   with opslevel_team.tf-example,
│   on main.tf line 9, in resource "opslevel_team" "tf-example":
│    9: resource "opslevel_team" "tf-example" {
│ 
╵

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

team = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg"
```

3. Terraform Destroy
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_team.tf-example will be destroyed
  - resource "opslevel_team" "tf-example" {
      - alias            = "terraform-test-team" -> null
      - aliases          = [
          - "bar",
          - "baz",
        ] -> null
      - id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg" -> null
      - last_updated     = "Tuesday, 17-Oct-23 14:34:19 CDT" -> null
      - manager_email    = "themanager@example.com" -> null
      - members          = [
          - "teammember@example.com",
          - "themanager@example.com",
        ] -> null
      - name             = "terraform-test-team" -> null
      - responsibilities = "Important things" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - team = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg" -> null
╷
│ Warning: "group": [DEPRECATED] field 'group' on team is no longer supported please use the 'parent_team' field.
│ 
│   with opslevel_team.tf-example,
│   on main.tf line 9, in resource "opslevel_team" "tf-example":
│    9: resource "opslevel_team" "tf-example" {
│ 
╵

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

opslevel_team.tf-example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTI5Mg]
opslevel_team.tf-example: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.

```