### PR TITLE
deprecate ownerAlias

### DIFF
--- a/.changes/unreleased/Deprecated-20231024-125941.yaml
+++ b/.changes/unreleased/Deprecated-20231024-125941.yaml
@@ -1,3 +1,0 @@
-kind: Deprecated
-body: BREAKING CHANGE deprecated owner_alias on Services
-time: 2023-10-24T12:59:41.572713-04:00

--- a/.changes/unreleased/Deprecated-20231024-125941.yaml
+++ b/.changes/unreleased/Deprecated-20231024-125941.yaml
@@ -1,0 +1,3 @@
+kind: Deprecated
+body: BREAKING CHANGE deprecated owner_alias on Services
+time: 2023-10-24T12:59:41.572713-04:00

--- a/.changes/unreleased/Refactor-20231023-150009.yaml
+++ b/.changes/unreleased/Refactor-20231023-150009.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: BREAKING CHANGE ownerAlias deprecated on service inputs
+time: 2023-10-23T15:00:09.266762-04:00

--- a/.changes/unreleased/Refactor-20231023-150009.yaml
+++ b/.changes/unreleased/Refactor-20231023-150009.yaml
@@ -1,3 +1,3 @@
 kind: Refactor
-body: BREAKING CHANGE ownerAlias deprecated on service inputs
+body: owner_alias deprecated on service inputs
 time: 2023-10-23T15:00:09.266762-04:00

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ resource "opslevel_service" "foo-frontend" {
 
   lifecycle_alias = "beta"
   tier_alias = "tier_3"
-  owner_alias = opslevel_team.foo.alias
+  owner = opslevel_team.foo.alias
 
   tags = [
     "environment:production",

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -39,7 +39,7 @@ data "opslevel_service" "bar" {
 - `language` (String) The primary programming language that the service is written in.
 - `lifecycle_alias` (String) The lifecycle stage of the service.
 - `name` (String) The display name of the service.
-- `owner_alias` (String) The team that owns the service.
+- `owner` (String) The team that owns the service.
 - `owner_id` (String) The team ID that owns the service.
 - `preferred_api_document_source` (String) The API document source (PUSH or PULL) used to determine the displayed document. If null, we use the order push and then pull.
 - `product` (String) A product is an application that your end user interacts with. Multiple services can work together to power a single product.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ resource "opslevel_service" "foo-frontend" {
 
   lifecycle_alias = "beta"
   tier_alias      = "tier_3"
-  owner_alias     = opslevel_team.foo.alias
+  owner           = opslevel_team.foo.alias
 
   tags = [
     "environment:production",

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -43,7 +43,7 @@ resource "opslevel_service" "foo" {
 
   lifecycle_alias = data.opslevel_lifecycle.beta.alias
   tier_alias      = data.opslevel_tier.tier3.alias
-  owner_alias     = opslevel_team.foo.alias
+  owner           = opslevel_team.foo.alias
 
   api_document_path             = "/swagger.json"
   preferred_api_document_source = "PULL" //or "PUSH"
@@ -73,7 +73,7 @@ output "foo_aliases" {
 - `language` (String) The primary programming language that the service is written in.
 - `last_updated` (String)
 - `lifecycle_alias` (String) The lifecycle stage of the service.
-- `owner_alias` (String) The team that owns the service.
+- `owner` (String) The team that owns the service.
 - `preferred_api_document_source` (String) The API document source (PUSH or PULL) used to determine the displayed document. If null, we use the order push and then pull.
 - `product` (String) A product is an application that your end user interacts with. Multiple services can work together to power a single product.
 - `tags` (List of String) A list of tags applied to the service.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -17,7 +17,7 @@ resource "opslevel_service" "foo-frontend" {
 
   lifecycle_alias = "beta"
   tier_alias      = "tier_3"
-  owner_alias     = opslevel_team.foo.alias
+  owner           = opslevel_team.foo.alias
 
   tags = [
     "environment:production",

--- a/examples/resources/opslevel_service/resource.tf
+++ b/examples/resources/opslevel_service/resource.tf
@@ -28,7 +28,7 @@ resource "opslevel_service" "foo" {
 
   lifecycle_alias = data.opslevel_lifecycle.beta.alias
   tier_alias      = data.opslevel_tier.tier3.alias
-  owner_alias     = opslevel_team.foo.alias
+  owner           = opslevel_team.foo.alias
 
   api_document_path             = "/swagger.json"
   preferred_api_document_source = "PULL" //or "PUSH"

--- a/opslevel/datasource_opslevel_service.go
+++ b/opslevel/datasource_opslevel_service.go
@@ -52,7 +52,7 @@ func datasourceService() *schema.Resource {
 				Description: "The software tier that the service belongs to.",
 				Computed:    true,
 			},
-			"owner_alias": {
+			"owner": {
 				Type:        schema.TypeString,
 				Description: "The team that owns the service.",
 				Computed:    true,
@@ -118,7 +118,7 @@ func datasourceServiceRead(d *schema.ResourceData, client *opslevel.Client) erro
 	if err := d.Set("tier_alias", resource.Tier.Alias); err != nil {
 		return err
 	}
-	if err := d.Set("owner_alias", resource.Owner.Alias); err != nil {
+	if err := d.Set("owner", resource.Owner.Alias); err != nil {
 		return err
 	}
 	if err := d.Set("owner_id", resource.Owner.Id); err != nil {

--- a/opslevel/datasource_opslevel_service.go
+++ b/opslevel/datasource_opslevel_service.go
@@ -57,6 +57,12 @@ func datasourceService() *schema.Resource {
 				Description: "The team that owns the service.",
 				Computed:    true,
 			},
+			"owner_alias": {
+				Type:        schema.TypeString,
+				Description: "The team that owns the service.",
+				Computed:    true,
+				Deprecated:  "field 'owner_alias' on service is no longer supported please use the 'owner' field.",
+			},
 			"owner_id": {
 				Type:        schema.TypeString,
 				Description: "The team ID that owns the service.",
@@ -119,6 +125,9 @@ func datasourceServiceRead(d *schema.ResourceData, client *opslevel.Client) erro
 		return err
 	}
 	if err := d.Set("owner", resource.Owner.Alias); err != nil {
+		return err
+	}
+	if err := d.Set("owner_alias", resource.Owner.Alias); err != nil {
 		return err
 	}
 	if err := d.Set("owner_id", resource.Owner.Id); err != nil {

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -63,11 +63,18 @@ func resourceService() *schema.Resource {
 				ForceNew:    false,
 				Optional:    true,
 			},
+			"owner": {
+				Type:        schema.TypeString,
+				Description: "The team that owns the service.",
+				ForceNew:    false,
+				Optional:    true,
+			},
 			"owner_alias": {
 				Type:        schema.TypeString,
 				Description: "The team that owns the service.",
 				ForceNew:    false,
 				Optional:    true,
+				Deprecated:  "field 'owner_alias' on service is no longer supported please use the 'owner' field.",
 			},
 			"lifecycle_alias": {
 				Type:        schema.TypeString,
@@ -185,7 +192,7 @@ func resourceServiceCreate(d *schema.ResourceData, client *opslevel.Client) erro
 		Language:    d.Get("language").(string),
 		Framework:   d.Get("framework").(string),
 		Tier:        d.Get("tier_alias").(string),
-		Owner:       opslevel.NewIdentifier(d.Get("owner_alias").(string)),
+		Owner:       opslevel.NewIdentifier(d.Get("owner").(string)),
 		Lifecycle:   d.Get("lifecycle_alias").(string),
 	}
 	resource, err := client.CreateService(input)
@@ -247,7 +254,7 @@ func resourceServiceRead(d *schema.ResourceData, client *opslevel.Client) error 
 	if err := d.Set("tier_alias", resource.Tier.Alias); err != nil {
 		return err
 	}
-	if err := d.Set("owner_alias", resource.Owner.Alias); err != nil {
+	if err := d.Set("owner", resource.Owner.Alias); err != nil {
 		return err
 	}
 	if err := d.Set("lifecycle_alias", resource.Lifecycle.Alias); err != nil {
@@ -296,8 +303,8 @@ func resourceServiceUpdate(d *schema.ResourceData, client *opslevel.Client) erro
 	if d.HasChange("tier_alias") {
 		input.Tier = d.Get("tier_alias").(string)
 	}
-	if d.HasChange("owner_alias") {
-		input.Owner = opslevel.NewIdentifier(d.Get("owner_alias").(string))
+	if d.HasChange("owner") {
+		input.Owner = opslevel.NewIdentifier(d.Get("owner").(string))
 	}
 	if d.HasChange("lifecycle_alias") {
 		input.Lifecycle = d.Get("lifecycle_alias").(string)

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -2,9 +2,10 @@ package opslevel
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/rs/zerolog/log"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opslevel/opslevel-go/v2023"
@@ -184,7 +185,7 @@ func resourceServiceCreate(d *schema.ResourceData, client *opslevel.Client) erro
 		Language:    d.Get("language").(string),
 		Framework:   d.Get("framework").(string),
 		Tier:        d.Get("tier_alias").(string),
-		Owner:       d.Get("owner_alias").(string),
+		Owner:       opslevel.NewIdentifier(d.Get("owner_alias").(string)),
 		Lifecycle:   d.Get("lifecycle_alias").(string),
 	}
 	resource, err := client.CreateService(input)
@@ -296,7 +297,7 @@ func resourceServiceUpdate(d *schema.ResourceData, client *opslevel.Client) erro
 		input.Tier = d.Get("tier_alias").(string)
 	}
 	if d.HasChange("owner_alias") {
-		input.Owner = d.Get("owner_alias").(string)
+		input.Owner = opslevel.NewIdentifier(d.Get("owner_alias").(string))
 	}
 	if d.HasChange("lifecycle_alias") {
 		input.Lifecycle = d.Get("lifecycle_alias").(string)

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -319,10 +319,13 @@ func resourceServiceUpdate(d *schema.ResourceData, client *opslevel.Client) erro
 	if d.HasChange("tier_alias") {
 		input.Tier = d.Get("tier_alias").(string)
 	}
-	if d.HasChange("owner") {
+	ownerUsed := d.HasChange("owner")
+	ownerAliasUsed := d.HasChange("owner_alias")
+	if ownerUsed && ownerAliasUsed {
+		return errors.New("can pass only one of: 'owner' or 'owner_alias'")
+	} else if ownerUsed {
 		input.Owner = opslevel.NewIdentifier(d.Get("owner").(string))
-	}
-	if d.HasChange("owner_alias") {
+	} else if ownerAliasUsed {
 		input.Owner = opslevel.NewIdentifier(d.Get("owner_alias").(string))
 	}
 	if d.HasChange("lifecycle_alias") {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/opslevel-go/issues/276

## Changelog

- [x] Add `owner` and deprecate `owner_alias` on Services.
- [x] Make a `changie` entry

## Tophatting

... See latest comment for most up to date tophatting. Bug mentioned below still applies. 

**The resource gets created fine and I can see it on the website. Same thing happens when updating the name of the service. A ticket exists for this: https://github.com/OpsLevel/terraform-provider-opslevel/issues/129 we closed it but I think we should re-open.**