### PR TITLE
Db/add affects overall service levels field to scorecards

### DIFF
--- a/.changes/unreleased/Feature-20231025-152708.yaml
+++ b/.changes/unreleased/Feature-20231025-152708.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add affects_overall_service_levels field to scorecards
+time: 2023-10-25T15:27:08.76529-05:00

--- a/examples/data-sources/opslevel_scorecard/data-source.tf
+++ b/examples/data-sources/opslevel_scorecard/data-source.tf
@@ -1,0 +1,8 @@
+data "opslevel_scorecard" "foo" {
+  identifier = "foo"
+}
+
+data "opslevel_scorecard" "bar" {
+  identifier = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Njcw"
+}
+

--- a/examples/data-sources/opslevel_scorecards/data-source.tf
+++ b/examples/data-sources/opslevel_scorecards/data-source.tf
@@ -2,5 +2,5 @@ data "opslevel_scorecards" "all" {
 }
 
 output "found" {
-  value = data.opslevel_scorecards.bar.all.ids[0]
+  value = data.opslevel_scorecards.all.ids[0]
 }

--- a/examples/data-sources/opslevel_scorecards/data-source.tf
+++ b/examples/data-sources/opslevel_scorecards/data-source.tf
@@ -1,0 +1,6 @@
+data "opslevel_scorecards" "all" {
+}
+
+output "found" {
+  value = data.opslevel_scorecards.bar.all.ids[0]
+}

--- a/examples/resources/opslevel_scorecard/resource.tf
+++ b/examples/resources/opslevel_scorecard/resource.tf
@@ -18,10 +18,10 @@ data "opslevel_filter" "tier_1" {
 
 resource "opslevel_scorecard" "my_scorecard" {
   name                           = "My Scorecard"
+  affects_overall_service_levels = true
   description                    = "This is my example scorecard"
   owner_id                       = data.opslevel_team.devs.id
   filter_id                      = data.opslevel_filter.tier_1.id
-  affects_overall_service_levels = true
 }
 
 // Example of how to assign a check to a scorecard

--- a/examples/resources/opslevel_scorecard/resource.tf
+++ b/examples/resources/opslevel_scorecard/resource.tf
@@ -17,10 +17,11 @@ data "opslevel_filter" "tier_1" {
 }
 
 resource "opslevel_scorecard" "my_scorecard" {
-  name        = "My Scorecard"
-  description = "This is my example scorecard"
-  owner_id    = data.opslevel_team.devs.id
-  filter_id   = data.opslevel_filter.tier_1.id
+  name                           = "My Scorecard"
+  description                    = "This is my example scorecard"
+  owner_id                       = data.opslevel_team.devs.id
+  filter_id                      = data.opslevel_filter.tier_1.id
+  affects_overall_service_levels = true
 }
 
 // Example of how to assign a check to a scorecard

--- a/opslevel/datasource_opslevel_scorecard.go
+++ b/opslevel/datasource_opslevel_scorecard.go
@@ -34,6 +34,11 @@ func datasourceScorecard() *schema.Resource {
 				Description: "The scorecard's filter.",
 				Computed:    true,
 			},
+			"affects_overall_service_levels": {
+				Type:        schema.TypeBool,
+				Description: "Specifies whether the checks on this scorecard affect services' overall maturity level.",
+				Computed:    true,
+			},
 
 			// computed fields
 			"aliases": {
@@ -73,6 +78,7 @@ func datasourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) er
 	d.Set("owner_id", resource.Id)
 	d.Set("description", resource.Description)
 	d.Set("filter_id", resource.Filter.Id)
+	d.Set("affects_overall_service_levels", resource.AffectsOverallServiceLevels)
 	d.Set("aliases", resource.Aliases)
 	d.Set("passing_checks", resource.PassingChecks)
 	d.Set("service_count", resource.ServiceCount)

--- a/opslevel/datasource_opslevel_scorecards.go
+++ b/opslevel/datasource_opslevel_scorecards.go
@@ -34,6 +34,11 @@ func datasourceScorecards() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"affects_overall_service_levels": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
+			},
 
 			// computed fields
 			"aliases": {
@@ -72,6 +77,7 @@ func datasourceScorecardsRead(d *schema.ResourceData, client *opslevel.Client) e
 	ownerIds := make([]string, count)
 	descriptions := make([]string, count)
 	filterIds := make([]string, count)
+	affectsOverallServiceLevels := make([]bool, count)
 	aliases := make([][]string, count)
 	passingChecks := make([]int, count)
 	serviceCounts := make([]int, count)
@@ -97,6 +103,7 @@ func datasourceScorecardsRead(d *schema.ResourceData, client *opslevel.Client) e
 	d.Set("owner_ids", ownerIds)
 	d.Set("descriptions", descriptions)
 	d.Set("filter_ids", filterIds)
+	d.Set("affects_overall_service_levels", affectsOverallServiceLevels)
 	d.Set("aliases", aliases)
 	d.Set("passing_checks", passingChecks)
 	d.Set("service_counts", serviceCounts)

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -37,6 +37,12 @@ func resourceScorecard() *schema.Resource {
 				ForceNew:    false,
 				Required:    true,
 			},
+			"affects_overall_service_levels": {
+				Type:        schema.TypeBool,
+				Description: "Specifies whether the checks on this scorecard affect services' overall maturity level.",
+				ForceNew:    false,
+				Required:    true,
+			},
 			"owner_id": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's owner.",
@@ -52,12 +58,6 @@ func resourceScorecard() *schema.Resource {
 			"filter_id": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's filter.",
-				ForceNew:    false,
-				Optional:    true,
-			},
-			"affects_overall_service_levels": {
-				Type:        schema.TypeBool,
-				Description: "Specifies whether the checks on this scorecard affect services' overall maturity level.",
 				ForceNew:    false,
 				Optional:    true,
 			},

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -10,10 +10,11 @@ func handleInput(d *schema.ResourceData) opslevel.ScorecardInput {
 	description := d.Get("description").(string)
 
 	input := opslevel.ScorecardInput{
-		Name:        d.Get("name").(string),
-		OwnerId:     *opslevel.NewID(d.Get("owner_id").(string)),
-		Description: &description,
-		FilterId:    opslevel.NewID(d.Get("filter_id").(string)),
+		Name:                        d.Get("name").(string),
+		OwnerId:                     *opslevel.NewID(d.Get("owner_id").(string)),
+		Description:                 &description,
+		FilterId:                    opslevel.NewID(d.Get("filter_id").(string)),
+		AffectsOverallServiceLevels: opslevel.Bool(d.Get("affects_overall_service_levels").(bool)),
 	}
 
 	return input
@@ -51,6 +52,12 @@ func resourceScorecard() *schema.Resource {
 			"filter_id": {
 				Type:        schema.TypeString,
 				Description: "The scorecard's filter.",
+				ForceNew:    false,
+				Optional:    true,
+			},
+			"affects_overall_service_levels": {
+				Type:        schema.TypeBool,
+				Description: "Specifies whether the checks on this scorecard affect services' overall maturity level.",
 				ForceNew:    false,
 				Optional:    true,
 			},
@@ -106,6 +113,9 @@ func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) erro
 		return err
 	}
 	if err := d.Set("filter_id", resource.Filter.Id); err != nil {
+		return err
+	}
+	if err := d.Set("affects_overall_service_levels", resource.AffectsOverallServiceLevels); err != nil {
 		return err
 	}
 	if err := d.Set("name", resource.Name); err != nil {


### PR DESCRIPTION
## Issues

[#71](https://github.com/OpsLevel/team-platform/issues/71)

## Changelog

Add `affects_overall_service_levels` field to scorecards

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

1. Write `main.tf` to test the scorecard's new `affects_overall_service_levels` field
```
# main.tf
data "opslevel_team" "devs" {
  alias = "platform"
}

data "opslevel_rubric_level" "good" {
  filter {
    field = "name"
    value = "Good"
  }
}

data "opslevel_filter" "demo" {
  filter {
    field = "name"
    value = "Demo"
  }
}

resource "opslevel_scorecard" "my_scorecard" {
  name                           = "My Scorecard"
  description                    = "This is my example scorecard"
  owner_id                       = data.opslevel_team.devs.id
  filter_id                      = data.opslevel_filter.demo.id
  affects_overall_service_levels = true
}
```

2. Create with `terraform apply`
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_scorecard.my_scorecard will be created
  + resource "opslevel_scorecard" "my_scorecard" {
      + affects_overall_service_levels = false
      + aliases                        = (known after apply)
      + description                    = "This is my example scorecard"
      + filter_id                      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzMyNA"
      + id                             = (known after apply)
      + name                           = "My Scorecard"
      + owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
      + passing_checks                 = (known after apply)
      + service_count                  = (known after apply)
      + total_checks                   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_scorecard.my_scorecard: Creating...
opslevel_scorecard.my_scorecard: Creation complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzgxNA]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

3. In `main.tf` change `affects_overall_service_levels` to `false`

4. Update with `terraform apply`
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_scorecard.my_scorecard will be updated in-place
  ~ resource "opslevel_scorecard" "my_scorecard" {
      ~ affects_overall_service_levels = false -> true
        id                             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzgxNA"
        name                           = "My Scorecard"
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_scorecard.my_scorecard: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzgxNA]
opslevel_scorecard.my_scorecard: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzgxNA]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

5. Run `terraform destroy`
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_scorecard.my_scorecard will be destroyed
  - resource "opslevel_scorecard" "my_scorecard" {
      - affects_overall_service_levels = true -> null
      - aliases                        = [
          - "my_scorecard",
        ] -> null
      - description                    = "This is my example scorecard" -> null
      - filter_id                      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzMyNA" -> null
      - id                             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzgxNA" -> null
      - name                           = "My Scorecard" -> null
      - owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
      - passing_checks                 = 0 -> null
      - service_count                  = 296 -> null
      - total_checks                   = 0 -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

opslevel_scorecard.my_scorecard: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzgxNA]
opslevel_scorecard.my_scorecard: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```