### PR TITLE
Db/fix taskfile paths for tf cmds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ examples/.terraform.lock.hcl
 .terraform.lock.hcl
 main.tf
 workspace/*.tf*
+workspace/.terraform.d/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,11 @@
 
 version: '3'
 
+vars:
+  # 'VERSION_DYNAMIC' needs to run in this scope before 'task build' begins
+  VERSION_DYNAMIC:
+    sh: echo "$(git describe --tags --abbrev=0 | tr -d 'v')$(date +%s)"
+
 includes:
   go:
     taskfile: "./opslevel/Taskfile.yml"
@@ -11,6 +16,26 @@ includes:
     aliases: [tf]
 
 tasks:
+
+  build:
+    desc: Build local opslevel terraform provider
+    platforms: [darwin]
+    vars:
+      BINARY: terraform-provider-opslevel_{{.VERSION_DYNAMIC}}
+      BINARY_PATH_BEFORE_VERSION: "workspace/.terraform.d/plugins/registry.terraform.io/opslevel/opslevel"
+      OS_ARCH:
+        sh: echo $(go env GOOS)_$(go env GOARCH)
+      VERSION_FROM_BINARY:
+        sh: echo {{.BINARY}} | cut -d '_' -f 2
+    cmds:
+      - go build -o {{.BINARY}} || exit 1
+      - chmod +x {{.BINARY}}
+      - mkdir -p {{.BINARY_PATH_BEFORE_VERSION}}/{{.VERSION_FROM_BINARY}}/{{.OS_ARCH}}
+      - mv {{.BINARY}} {{.BINARY_PATH_BEFORE_VERSION}}/{{.VERSION_FROM_BINARY}}/{{.OS_ARCH}}
+      - cmd: echo "Built terraform provider at:"
+        silent: true
+      - cmd: echo "{{.ROOT_DIR}}/{{.BINARY_PATH_BEFORE_VERSION}}/{{.VERSION_FROM_BINARY}}/{{.OS_ARCH}}/{{.BINARY}}"
+        silent: true
 
   install-changie:
     desc: Install changie
@@ -37,9 +62,10 @@ tasks:
   setup:
     desc: Setup env and tools
     cmds:
-      - task: go:setup
-      - task: terraform:setup
       - task: install-changie
+      - task: go:setup
+      - task: build
+      - task: terraform:setup
 
   test:
     desc: Run tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,7 @@ includes:
     taskfile: "./opslevel/Taskfile.yml"
   terraform:
     taskfile: "./workspace/Taskfile.yml"
+    dir: ./workspace
     aliases: [tf]
 
 tasks:

--- a/workspace/Taskfile.yml
+++ b/workspace/Taskfile.yml
@@ -123,7 +123,7 @@ tasks:
 
   terraform-command:
     internal: true
-    cmds: ["terraform -chdir={{.TF_CMD_DIR}} {{.TF_COMMAND}}"]
+    cmds: ["terraform -chdir={{.TF_CMD_DIR}} {{.TF_COMMAND}} {{.CLI_ARGS}}"]
     requires:
       vars: [TF_COMMAND, TF_CMD_DIR]
     preconditions:

--- a/workspace/Taskfile.yml
+++ b/workspace/Taskfile.yml
@@ -2,11 +2,6 @@
 
 version: '3'
 
-vars:
-  # 'VERSION_DYNAMIC' needs to run in this scope before tasks begin
-  VERSION_DYNAMIC:
-    sh: echo "$(git describe --tags --abbrev=0 | tr -d 'v')$(date +%s)"
-
 tasks:
 
   apply:
@@ -15,31 +10,11 @@ tasks:
       - task: terraform-command
         vars: { TF_COMMAND: "apply", TF_CMD_DIR: "{{.TASKFILE_DIR}}" }
 
-  build:
-    desc: Build terraform
-    platforms: [darwin]
-    vars:
-      BINARY: terraform-provider-opslevel_{{.VERSION_DYNAMIC}}
-      BINARY_PATH_BEFORE_VERSION: "${HOME}/.terraform.d/plugins/registry.terraform.io/opslevel/opslevel"
-      OS_ARCH:
-        sh: echo $(go env GOOS)_$(go env GOARCH)
-      VERSION_FROM_BINARY:
-        sh: echo {{.BINARY}} | cut -d '_' -f 2
-    cmds:
-      - go build -o {{.BINARY}} || exit 1
-      - chmod +x {{.BINARY}}
-      - mkdir -p {{.BINARY_PATH_BEFORE_VERSION}}/{{.VERSION_FROM_BINARY}}/{{.OS_ARCH}}
-      - mv {{.BINARY}} {{.BINARY_PATH_BEFORE_VERSION}}/{{.VERSION_FROM_BINARY}}/{{.OS_ARCH}}
-      - cmd: echo "Built terraform provider at:"
-        silent: true
-      - cmd: echo -e "  {{.BINARY_PATH_BEFORE_VERSION}}/{{.VERSION_FROM_BINARY}}/{{.OS_ARCH}}/{{.BINARY}}"
-        silent: true
-
   clean:
     desc: Clean up terraform files from "workspace"
-    prompt: Remove '*.tf' files from 'workspace' directory?
+    prompt: Remove '*.tfstate .terraform.lock.hcl ./terraform.* .terraform.d/** .terraform/**' from 'workspace' directory?
     cmds:
-      - cmd: rm *.tf *.tfstate
+      - cmd: rm -rf *.tfstate .terraform.lock.hcl ./terraform.* .terraform.d/ .terraform/
         ignore_error: true
 
   destroy:
@@ -79,10 +54,9 @@ tasks:
         vars: { TF_COMMAND: "plan", TF_CMD_DIR: "{{.TASKFILE_DIR}}" }
 
   setup:
-    desc: Build and initialize terraform workspace
+    desc: Initialize terraform workspace
     cmds:
       - task: install-terraform
-      - task: build
       - task: init
 
   ########################################

--- a/workspace/Taskfile.yml
+++ b/workspace/Taskfile.yml
@@ -131,7 +131,7 @@ tasks:
         msg: '"terraform" needed - run "brew install terraform"'
 
   validate:
-    # internal: true
+    internal: true
     desc: Run "terraform validate" in current directory
     dir: '{{.USER_WORKING_DIR}}'
     cmds:

--- a/workspace/Taskfile.yml
+++ b/workspace/Taskfile.yml
@@ -55,7 +55,8 @@ tasks:
     cmds:
       - './make_backend_tf.sh'
       - touch main.tf
-      - terraform init -upgrade
+      - task: terraform-command
+        vars: { TF_COMMAND: "init -upgrade", TF_CMD_DIR: "{{.TASKFILE_DIR}}" }
     preconditions:
       - sh: 'which terraform'
         msg: '"terraform" needed - run "brew install terraform"'

--- a/workspace/Taskfile.yml
+++ b/workspace/Taskfile.yml
@@ -135,7 +135,5 @@ tasks:
     desc: Run "terraform validate" in current directory
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
-      - echo $PWD
-      - echo {{.TASKFILE_DIR}}
       - task: terraform-command
         vars: { TF_COMMAND: "validate", TF_CMD_DIR: "{{.USER_WORKING_DIR}}" }

--- a/workspace/Taskfile.yml
+++ b/workspace/Taskfile.yml
@@ -3,7 +3,6 @@
 version: '3'
 
 vars:
-  WORKSPACE_DIR: "workspace"
   # 'VERSION_DYNAMIC' needs to run in this scope before tasks begin
   VERSION_DYNAMIC:
     sh: echo "$(git describe --tags --abbrev=0 | tr -d 'v')$(date +%s)"
@@ -14,7 +13,7 @@ tasks:
     desc: Run "terraform apply"
     cmds:
       - task: terraform-command
-        vars: { TF_COMMAND: "apply" }
+        vars: { TF_COMMAND: "apply", TF_CMD_DIR: "{{.TASKFILE_DIR}}" }
 
   build:
     desc: Build terraform
@@ -38,7 +37,6 @@ tasks:
 
   clean:
     desc: Clean up terraform files from "workspace"
-    dir: "{{.WORKSPACE_DIR}}"
     prompt: Remove '*.tf' files from 'workspace' directory?
     cmds:
       - cmd: rm *.tf *.tfstate
@@ -46,14 +44,12 @@ tasks:
 
   destroy:
     desc: Run "terraform destroy" in "workspace"
-    dir: "{{.WORKSPACE_DIR}}"
     cmds:
       - task: terraform-command
-        vars: { TF_COMMAND: "destroy" }
+        vars: { TF_COMMAND: "destroy", TF_CMD_DIR: "{{.TASKFILE_DIR}}" }
 
   init:
     desc: Run "terraform init" in "workspace"
-    dir: "{{.WORKSPACE_DIR}}"
     env:
       OPSLEVEL_TERRAFORM_SOURCE_VERSION: "0.8.7"
     cmds:
@@ -77,10 +73,9 @@ tasks:
 
   plan:
     desc: Run "terraform plan" in "workspace"
-    dir: "{{.WORKSPACE_DIR}}"
     cmds:
       - task: terraform-command
-        vars: { TF_COMMAND: "plan" }
+        vars: { TF_COMMAND: "plan", TF_CMD_DIR: "{{.TASKFILE_DIR}}" }
 
   setup:
     desc: Build and initialize terraform workspace
@@ -96,19 +91,17 @@ tasks:
   format:
     internal: true
     desc: Run terraform format
-    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - cmd: echo "Listing all terraform files that need formatting..."
       - task: terraform-command
-        vars: { TF_COMMAND: "fmt -recursive -check" }
+        vars: { TF_COMMAND: "fmt -recursive -check", TF_CMD_DIR: "{{.USER_WORKING_DIR}}" }
 
   format-fix:
     internal: true
     desc: Run terraform format
-    dir: '{{.USER_WORKING_DIR}}'
     cmds:
       - task: terraform-command
-        vars: { TF_COMMAND: "fmt -recursive -write=true" }
+        vars: { TF_COMMAND: "fmt -recursive -write=true", TF_CMD_DIR: "{{.USER_WORKING_DIR}}" }
 
   install-terraform:
     internal: true
@@ -130,17 +123,19 @@ tasks:
 
   terraform-command:
     internal: true
-    cmds: ["terraform {{.TF_COMMAND}}"]
+    cmds: ["terraform -chdir={{.TF_CMD_DIR}} {{.TF_COMMAND}}"]
     requires:
-      vars: [TF_COMMAND]
+      vars: [TF_COMMAND, TF_CMD_DIR]
     preconditions:
       - sh: 'which terraform'
         msg: '"terraform" needed - run "brew install terraform"'
 
   validate:
-    internal: true
+    # internal: true
     desc: Run "terraform validate" in current directory
     dir: '{{.USER_WORKING_DIR}}'
     cmds:
+      - echo $PWD
+      - echo {{.TASKFILE_DIR}}
       - task: terraform-command
-        vars: { TF_COMMAND: "validate" }
+        vars: { TF_COMMAND: "validate", TF_CMD_DIR: "{{.USER_WORKING_DIR}}" }


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Ensure the following tasks always run from the `./workspace` directory:
- `task tf:apply`
- `task tf:init`
- `task tf:plan`
- `task tf:destroy`

Ensure the following tasks always runs from `pwd`:
- `task tf:format`
- `task tf:format-fix`

- [X] List your changes here
- [ ] Make a `changie` entry, N/A only effects Taskfile tasks.

## Tophatting

Running the above mentioned `task tf:<cmd>`
