### PR TITLE
Managed Aliases on Service

### DIFF
--- a/.changes/unreleased/Bugfix-20231106-131911.yaml
+++ b/.changes/unreleased/Bugfix-20231106-131911.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Use managed aliases for Service
+time: 2023-11-06T13:19:11.012755-05:00

--- a/opslevel/datasource_opslevel_service.go
+++ b/opslevel/datasource_opslevel_service.go
@@ -137,7 +137,7 @@ func datasourceServiceRead(d *schema.ResourceData, client *opslevel.Client) erro
 		return err
 	}
 
-	if err := d.Set("aliases", resource.Aliases); err != nil {
+	if err := d.Set("aliases", resource.ManagedAliases); err != nil {
 		return err
 	}
 	if err := d.Set("tags", flattenTagArray(resource.Tags.Nodes)); err != nil {

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -131,7 +131,7 @@ func validateServiceTags(i interface{}, k string) (warnings []string, errors []e
 
 func reconcileServiceAliases(d *schema.ResourceData, service *opslevel.Service, client *opslevel.Client) error {
 	expectedAliases := getStringArray(d, "aliases")
-	existingAliases := service.Aliases
+	existingAliases := service.ManagedAliases
 	for _, existingAlias := range existingAliases {
 		if stringInArray(existingAlias, expectedAliases) {
 			continue
@@ -234,7 +234,7 @@ func resourceServiceCreate(d *schema.ResourceData, client *opslevel.Client) erro
 		}
 		_, err := client.ServiceApiDocSettingsUpdate(string(resource.Id), docPath.(string), source)
 		if err != nil {
-			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.Aliases[0])
+			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.ManagedAliases[0])
 		}
 	}
 
@@ -277,7 +277,7 @@ func resourceServiceRead(d *schema.ResourceData, client *opslevel.Client) error 
 		return err
 	}
 
-	if err := d.Set("aliases", resource.Aliases); err != nil {
+	if err := d.Set("aliases", resource.ManagedAliases); err != nil {
 		return err
 	}
 	if err := d.Set("tags", flattenTagArray(resource.Tags.Nodes)); err != nil {
@@ -367,7 +367,7 @@ func resourceServiceUpdate(d *schema.ResourceData, client *opslevel.Client) erro
 		}
 		_, err := client.ServiceApiDocSettingsUpdate(string(resource.Id), docPath, docSource)
 		if err != nil {
-			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.Aliases[0])
+			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.ManagedAliases[0])
 		}
 	}
 


### PR DESCRIPTION
## Issues

This should fix https://github.com/OpsLevel/terraform-provider-opslevel/issues/129 and https://github.com/OpsLevel/team-platform/issues/135 where slugs were being treated as aliases.

## Changelog

- [x] Use managed aliases instead
- [x] Make a `changie` entry

## Tophatting

Uncommented each block one by one. Notice no errors are thrown, slugs are not treated as aliases!

```
# resource "opslevel_service" "tfsvc" {
#   name = "some new service"
#   aliases = []
# }

# resource "opslevel_service" "tfsvc" {
#   name = "some new service"
#   aliases = ["custom1"]
# }

# resource "opslevel_service" "tfsvc" {
#   name = "some new service"
#   aliases = []
# }
```

```
~/repos/terraform-provider-opslevel/workspace managedalias ❯ task apply                                                                                                    6s Ruby 3.0.0 01:17:45 pm
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_service.tfsvc will be created
  + resource "opslevel_service" "tfsvc" {
      + aliases      = []
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "some new service"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_service.tfsvc: Creating...
opslevel_service.tfsvc: Creation complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
~/repos/terraform-provider-opslevel/workspace managedalias ❯ task apply                                                                                                    5s Ruby 3.0.0 01:17:59 pm
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 
opslevel_service.tfsvc: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.tfsvc will be updated in-place
  ~ resource "opslevel_service" "tfsvc" {
      ~ aliases = [
          + "custom1",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw"
        name    = "some new service"
        tags    = []
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_service.tfsvc: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw]
opslevel_service.tfsvc: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
~/repos/terraform-provider-opslevel/workspace managedalias ❯ task apply                                                                                                    6s Ruby 3.0.0 01:18:16 pm
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 
opslevel_service.tfsvc: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.tfsvc will be updated in-place
  ~ resource "opslevel_service" "tfsvc" {
      ~ aliases      = [
          - "custom1",
        ]
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw"
        name         = "some new service"
        tags         = []
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_service.tfsvc: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw]
opslevel_service.tfsvc: Modifications complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mzc5Nw]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
