### PR TITLE
Support for aliases on  Infrastructure Resources

### DIFF
--- a/.changes/unreleased/Bugfix-20231107-162955.yaml
+++ b/.changes/unreleased/Bugfix-20231107-162955.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix index out of range when returning Service errors
+time: 2023-11-07T16:29:55.13703-05:00

--- a/.changes/unreleased/Feature-20231107-163024.yaml
+++ b/.changes/unreleased/Feature-20231107-163024.yaml
@@ -1,3 +1,3 @@
 kind: Feature
-body: Aliases support for Infrastructure Resources
+body: Add support for managing aliases on Infrastructure Resources
 time: 2023-11-07T16:30:24.334158-05:00

--- a/.changes/unreleased/Feature-20231107-163024.yaml
+++ b/.changes/unreleased/Feature-20231107-163024.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Aliases support for Infrastructure Resources
+time: 2023-11-07T16:30:24.334158-05:00

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -89,7 +89,7 @@ func reconcileInfraAliases(d *schema.ResourceData, resource *opslevel.Infrastruc
 			continue
 		}
 		// Delete
-		err := client.DeleteServiceAlias(existingAlias)
+		err := client.DeleteInfraAlias(existingAlias)
 		if err != nil {
 			return err
 		}

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -21,7 +21,8 @@ func resourceInfrastructure() *schema.Resource {
 			"aliases": {
 				Type:        schema.TypeList,
 				Description: "The aliases of the infrastructure resource.",
-				Computed:    true,
+				ForceNew:    false,
+				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"schema": {
@@ -80,6 +81,33 @@ func resourceInfrastructure() *schema.Resource {
 	}
 }
 
+func reconcileInfraAliases(d *schema.ResourceData, resource *opslevel.InfrastructureResource, client *opslevel.Client) error {
+	expectedAliases := getStringArray(d, "aliases")
+	existingAliases := resource.Aliases
+	for _, existingAlias := range existingAliases {
+		if stringInArray(existingAlias, expectedAliases) {
+			continue
+		}
+		// Delete
+		err := client.DeleteServiceAlias(existingAlias)
+		if err != nil {
+			return err
+		}
+	}
+	for _, expectedAlias := range expectedAliases {
+		if stringInArray(expectedAlias, existingAliases) {
+			continue
+		}
+		// Add
+		id := opslevel.NewID(resource.Id)
+		_, err := client.CreateAliases(*id, []string{expectedAlias})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func flattenInfraProviderData(resource *opslevel.InfrastructureResource) []map[string]any {
 	return []map[string]any{{
 		"account": resource.ProviderData.AccountName,
@@ -114,6 +142,12 @@ func resourceInfrastructureCreate(d *schema.ResourceData, client *opslevel.Clien
 		return err
 	}
 	d.SetId(resource.Id)
+
+	err = reconcileInfraAliases(d, resource, client)
+	if err != nil {
+		return err
+	}
+
 	return resourceInfrastructureRead(d, client)
 }
 
@@ -147,7 +181,7 @@ func resourceInfrastructureRead(d *schema.ResourceData, client *opslevel.Client)
 func resourceInfrastructureUpdate(d *schema.ResourceData, client *opslevel.Client) error {
 	id := d.Id()
 
-	_, err := client.UpdateInfrastructure(id, opslevel.InfraInput{
+	resource, err := client.UpdateInfrastructure(id, opslevel.InfraInput{
 		Schema:   d.Get("schema").(string),
 		Owner:    opslevel.NewID(d.Get("owner").(string)),
 		Provider: expandInfraProviderData(d),
@@ -155,6 +189,13 @@ func resourceInfrastructureUpdate(d *schema.ResourceData, client *opslevel.Clien
 	})
 	if err != nil {
 		return err
+	}
+
+	if d.HasChange("aliases") {
+		err = reconcileInfraAliases(d, resource, client)
+		if err != nil {
+			return err
+		}
 	}
 
 	d.Set("last_updated", timeLastUpdated())

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -234,7 +234,7 @@ func resourceServiceCreate(d *schema.ResourceData, client *opslevel.Client) erro
 		}
 		_, err := client.ServiceApiDocSettingsUpdate(string(resource.Id), docPath.(string), source)
 		if err != nil {
-			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.ManagedAliases[0])
+			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.Aliases[0])
 		}
 	}
 
@@ -338,9 +338,9 @@ func resourceServiceUpdate(d *schema.ResourceData, client *opslevel.Client) erro
 	}
 
 	if d.HasChange("aliases") {
-		tagsErr := reconcileServiceAliases(d, resource, client)
-		if tagsErr != nil {
-			return tagsErr
+		err = reconcileServiceAliases(d, resource, client)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -367,7 +367,7 @@ func resourceServiceUpdate(d *schema.ResourceData, client *opslevel.Client) erro
 		}
 		_, err := client.ServiceApiDocSettingsUpdate(string(resource.Id), docPath, docSource)
 		if err != nil {
-			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.ManagedAliases[0])
+			log.Error().Err(err).Msgf("failed to update service '%s' api doc settings", resource.Aliases[0])
 		}
 	}
 


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/112

Allow aliases to be managed on infra resources just like they are managed on services. 

**NOTE** that unlike services, infra resources don't have a slug/friendly_id that is placed inside the aliases array. So using `ManagedAliases` is not necessary! 

## Changelog

- [x] Add support for alias management on infra resources
- [x] Fix minor bugs in Service
- [x] Make a `changie` entry

## Tophatting

Create infra resource with no aliases:

```
~/repos/terraform-provider-opslevel/workspace infraresaliases !2 ❯ cat main.tf && task apply                                                                                                                                                                        5s Ruby 3.0.0 04:55:10 pm
resource "opslevel_infrastructure" "new_tf_infra" {
    schema = "Database"
    data = jsonencode({
        name = "a new infra res made in tf"
    })
    provider_data {
        account = "dev"
    }
}
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_infrastructure.new_tf_infra will be created
  + resource "opslevel_infrastructure" "new_tf_infra" {
      + data         = jsonencode(
            {
              + name = "a new infra res made in tf"
            }
        )
      + id           = (known after apply)
      + last_updated = (known after apply)
      + schema       = "Database"

      + provider_data {
          + account = "dev"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_infrastructure.new_tf_infra: Creating...
opslevel_infrastructure.new_tf_infra: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Add aliases:

```
~/repos/terraform-provider-opslevel/workspace infraresaliases !2 ❯ cat main.tf && task apply                                                                                                                                                                        4s Ruby 3.0.0 04:55:20 pm
resource "opslevel_infrastructure" "new_tf_infra" {
    schema = "Database"
    data = jsonencode({
        name = "a new infra res made in tf"
    })
    provider_data {
        account = "dev"
    }
    aliases = ["alias1", "alias2"]
}
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 
opslevel_infrastructure.new_tf_infra: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.new_tf_infra will be updated in-place
  ~ resource "opslevel_infrastructure" "new_tf_infra" {
      ~ aliases = [
          + "alias1",
          + "alias2",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_infrastructure.new_tf_infra: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng]
opslevel_infrastructure.new_tf_infra: Modifications complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Remove the aliases:

```
~/repos/terraform-provider-opslevel/workspace infraresaliases !2 ❯ cat main.tf && task apply                                                                                                                                                                        5s Ruby 3.0.0 04:55:38 pm
resource "opslevel_infrastructure" "new_tf_infra" {
    schema = "Database"
    data = jsonencode({
        name = "a new infra res made in tf"
    })
    provider_data {
        account = "dev"
    }
    aliases = []
}
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 
opslevel_infrastructure.new_tf_infra: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.new_tf_infra will be updated in-place
  ~ resource "opslevel_infrastructure" "new_tf_infra" {
      ~ aliases      = [
          - "alias1",
          - "alias2",
        ]
        id           = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng"
        # (3 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_infrastructure.new_tf_infra: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng]
opslevel_infrastructure.new_tf_infra: Modifications complete after 3s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc3ODI5Ng]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
