### PR TITLE
System - allow unsetting owner, identified bug where lots of fields cannot be unset

### DIFF
--- a/.changes/unreleased/Bugfix-20231109-171226.yaml
+++ b/.changes/unreleased/Bugfix-20231109-171226.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug where creating/updating a system without specifying 'owner'/'parent'
+  would throw an ID related error
+time: 2023-11-09T17:12:26.987375-05:00

--- a/.changes/unreleased/Bugfix-20231109-171226.yaml
+++ b/.changes/unreleased/Bugfix-20231109-171226.yaml
@@ -1,4 +1,3 @@
 kind: Bugfix
-body: Fix bug where creating/updating a system without specifying 'owner'/'parent'
-  would throw an ID related error
+body: Fix bug where a system's owner cannot be unset on update
 time: 2023-11-09T17:12:26.987375-05:00


### PR DESCRIPTION
## Issues

A bug with creating systems was identified here: https://github.com/OpsLevel/opslevel-go/pull/295

## Changelog

- [x] Allow user to unset `owner` on System resource
- [x] Make a `changie` entry

## Tophatting

1. Create system with owner
2. Change owner
3. Delete owner

```
~/repos/terraform-provider-opslevel/workspace system-patches ❯ task apply                                                                                                                                                                                                                                              х 200 Ruby 3.0.0 01:22:37 PM
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_system.test3_system will be created
  + resource "opslevel_system" "test3_system" {
      + aliases      = (known after apply)
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "test3 system"
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_system.test3_system: Creating...
opslevel_system.test3_system: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
~/repos/terraform-provider-opslevel/workspace system-patches ❯ task apply                                                                                                                                                                                                                                                 5s Ruby 3.0.0 01:22:45 PM
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 
opslevel_system.test3_system: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_system.test3_system will be updated in-place
  ~ resource "opslevel_system" "test3_system" {
        id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA"
        name    = "test3 system"
      ~ owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTEwOA"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_system.test3_system: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA]
opslevel_system.test3_system: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
~ ❯ opslevel get system test3_system                                                                                 Ruby 3.0.0 01:22:26 pm
{
  "Id": "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA",
  "Aliases": [
    "test3_system"
  ],
  "Name": "test3 system",
  "Description": "",
  "HTMLUrl": "https://app.opslevel.com/catalog/systems/test3_system",
  "Owner": {
    "OnGroup": {
      "id": "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTEwOA"
    },
    "OnTeam": {
      "alias": "platform_2",
      "id": "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTEwOA"
    }
  },
  "Parent": {
    "Id": null,
    "Aliases": null,
    "Name": "",
    "Description": "",
    "HTMLUrl": "",
    "Owner": {
      "OnGroup": {
        "id": null
      },
      "OnTeam": {
        "id": null
      }
    },
    "Note": ""
  },
  "Note": ""
}

~/repos/terraform-provider-opslevel/workspace system-patches ❯ task apply                                                                                                                                                                                                                                              х INT Ruby 3.0.0 01:23:26 PM
task: [terraform-command] terraform -chdir=/Users/taimoorahmad/repos/terraform-provider-opslevel/workspace apply 
opslevel_system.test3_system: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_system.test3_system will be updated in-place
  ~ resource "opslevel_system" "test3_system" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA"
        name         = "test3 system"
      - owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMTEwOA" -> null
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_system.test3_system: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA]
opslevel_system.test3_system: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
~ ❯ opslevel get system test3_system                                                                                 Ruby 3.0.0 01:23:15 pm
{
  "Id": "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc5NDQ1OA",
  "Aliases": [
    "test3_system"
  ],
  "Name": "test3 system",
  "Description": "",
  "HTMLUrl": "https://app.opslevel.com/catalog/systems/test3_system",
  "Owner": {
    "OnGroup": {
      "id": null
    },
    "OnTeam": {
      "id": null
    }
  },
  "Parent": {
    "Id": null,
    "Aliases": null,
    "Name": "",
    "Description": "",
    "HTMLUrl": "",
    "Owner": {
      "OnGroup": {
        "id": null
      },
      "OnTeam": {
        "id": null
      }
    },
    "Note": ""
  },
  "Note": ""
}

```