### PR TITLE
Db/bugfix bring back entity owner

### DIFF
--- a/.changes/unreleased/Bugfix-20231114-153317.yaml
+++ b/.changes/unreleased/Bugfix-20231114-153317.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix Owner.Id to properly use underlying EntityOwner struct
+time: 2023-11-14T15:33:17.920521-06:00

--- a/opslevel/datasource_opslevel_domain.go
+++ b/opslevel/datasource_opslevel_domain.go
@@ -51,7 +51,7 @@ func datasourceDomainRead(d *schema.ResourceData, client *opslevel.Client) error
 	d.Set("aliases", resource.Aliases)
 	d.Set("name", resource.Name)
 	d.Set("description", resource.Description)
-	d.Set("owner", resource.Owner.Id)
+	d.Set("owner", resource.Owner.Id())
 
 	return nil
 }

--- a/opslevel/datasource_opslevel_domains.go
+++ b/opslevel/datasource_opslevel_domains.go
@@ -57,7 +57,7 @@ func datasourceDomainsRead(d *schema.ResourceData, client *opslevel.Client) erro
 		ids[i] = string(item.Id)
 		names[i] = item.Name
 		descriptions[i] = item.Description
-		owners[i] = string(item.Owner.Id)
+		owners[i] = string(item.Owner.Id())
 	}
 
 	d.SetId(timeID())

--- a/opslevel/datasource_opslevel_scorecards.go
+++ b/opslevel/datasource_opslevel_scorecards.go
@@ -89,7 +89,7 @@ func datasourceScorecardsRead(d *schema.ResourceData, client *opslevel.Client) e
 		}
 		ids[i] = string(item.Id)
 		names[i] = item.Name
-		ownerIds[i] = string(item.Owner.Id)
+		ownerIds[i] = string(item.Owner.Id())
 		descriptions[i] = item.Description
 		filterIds[i] = string(item.Filter.Id)
 		passingChecks[i] = item.PassingChecks

--- a/opslevel/datasource_opslevel_system.go
+++ b/opslevel/datasource_opslevel_system.go
@@ -56,7 +56,7 @@ func datasourceSystemRead(d *schema.ResourceData, client *opslevel.Client) error
 	d.Set("aliases", resource.Aliases)
 	d.Set("name", resource.Name)
 	d.Set("description", resource.Description)
-	d.Set("owner", resource.Owner.Id)
+	d.Set("owner", resource.Owner.Id())
 	d.Set("domain", resource.Parent.Id)
 
 	return nil

--- a/opslevel/datasource_opslevel_systems.go
+++ b/opslevel/datasource_opslevel_systems.go
@@ -63,7 +63,7 @@ func datasourceSystemsRead(d *schema.ResourceData, client *opslevel.Client) erro
 		ids[i] = string(item.Id)
 		names[i] = item.Name
 		descriptions[i] = item.Description
-		owners[i] = string(item.Owner.Id)
+		owners[i] = string(item.Owner.Id())
 		domains[i] = string(item.Parent.Id)
 	}
 

--- a/opslevel/resource_opslevel_domain.go
+++ b/opslevel/resource_opslevel_domain.go
@@ -86,7 +86,7 @@ func resourceDomainRead(d *schema.ResourceData, client *opslevel.Client) error {
 	if err := d.Set("description", resource.Description); err != nil {
 		return err
 	}
-	if err := d.Set("owner", resource.Owner.Id); err != nil {
+	if err := d.Set("owner", resource.Owner.Id()); err != nil {
 		return err
 	}
 	if err := d.Set("note", resource.Note); err != nil {

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -165,7 +165,7 @@ func resourceInfrastructureRead(d *schema.ResourceData, client *opslevel.Client)
 	if err := d.Set("aliases", resource.Aliases); err != nil {
 		return err
 	}
-	if err := d.Set("owner", resource.Owner.Id); err != nil {
+	if err := d.Set("owner", resource.Owner.Id()); err != nil {
 		return err
 	}
 	if err := d.Set("provider_data", flattenInfraProviderData(resource)); err != nil {

--- a/opslevel/resource_opslevel_repository.go
+++ b/opslevel/resource_opslevel_repository.go
@@ -61,7 +61,6 @@ func resourceRepositoryCreate(d *schema.ResourceData, client *opslevel.Client) e
 
 func resourceRepositoryRead(d *schema.ResourceData, client *opslevel.Client) error {
 	repository, err := client.GetRepository(*opslevel.NewID(d.Id()))
-
 	if err != nil {
 		return err
 	}

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -121,7 +121,7 @@ func resourceScorecardRead(d *schema.ResourceData, client *opslevel.Client) erro
 	if err := d.Set("name", resource.Name); err != nil {
 		return err
 	}
-	if err := d.Set("owner_id", resource.Owner.Id); err != nil {
+	if err := d.Set("owner_id", resource.Owner.Id()); err != nil {
 		return err
 	}
 	if err := d.Set("passing_checks", resource.PassingChecks); err != nil {

--- a/opslevel/resource_opslevel_system.go
+++ b/opslevel/resource_opslevel_system.go
@@ -99,7 +99,7 @@ func resourceSystemRead(d *schema.ResourceData, client *opslevel.Client) error {
 	if err := d.Set("description", resource.Description); err != nil {
 		return err
 	}
-	if err := d.Set("owner", resource.Owner.Id); err != nil {
+	if err := d.Set("owner", resource.Owner.Id()); err != nil {
 		return err
 	}
 	if err := d.Set("domain", resource.Parent.Id); err != nil {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Fix Owner.Id to properly use underlying EntityOwner struct

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

1. Make `main.tf`
```tf
data "opslevel_filter" "demo" {
  filter {
    field = "name"
    value = "Demo"
  }
}
data "opslevel_domain" "domain_123" { identifier = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzUyNDg0Nw" }
data "opslevel_scorecard" "scorecard_123" { identifier = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzgyNQ" }
data "opslevel_system" "system_123" { identifier = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0Lzc4OTg3Mw" }
data "opslevel_team" "devs" { alias = "platform" }

resource "opslevel_domain" "test_domain" {
  name = "My Domain"
}

resource "opslevel_infrastructure" "test_infra" {
  schema = "Database"
  owner  = data.opslevel_team.devs.id
  provider_data {
    account = "dev"
    name    = "google cloud"
    type    = "BigQuery"
    url     = "https://console.cloud.google.com/..."
  }
  data = jsonencode({
    name                = "big-query"
    external_id         = "example_2_1234"
    zone                = "us-east-1"
    engine              = "bigquery"
    engine_version      = "1.28.0"
    endpoint            = "https://console.cloud.google.com/..."
    replica             = false
    publicly_accessible = false
    storage_size = {
      unit  = "GB"
      value = 700
    }
    storage_type = "gp3"
    storage_iops = {
      unit  = "per second"
      value = 12000
    }
  })
}

resource "opslevel_scorecard" "my_scorecard" {
  name                           = "My Scorecard"
  affects_overall_service_levels = true
  description                    = "This is my example scorecard"
  owner_id                       = data.opslevel_team.devs.id
  filter_id                      = data.opslevel_filter.demo.id
}

resource "opslevel_system" "test_system" {
  name        = "Chatty Chatter"
  description = "So many words, such bar bar bar"
  note        = "This is a note"
  owner       = data.opslevel_team.devs.id
  domain      = "my_domain"
}
```

2. Run `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_domain.test_domain will be created
  + resource "opslevel_domain" "test_domain" {
      + aliases      = (known after apply)
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "My Domain"
    }

  # opslevel_infrastructure.test_infra will be created
  + resource "opslevel_infrastructure" "test_infra" {
      + data         = jsonencode(
            {
              + endpoint            = "https://console.cloud.google.com/..."
              + engine              = "bigquery"
              + engine_version      = "1.28.0"
              + external_id         = "example_2_1234"
              + name                = "big-query"
              + publicly_accessible = false
              + replica             = false
              + storage_iops        = {
                  + unit  = "per second"
                  + value = 12000
                }
              + storage_size        = {
                  + unit  = "GB"
                  + value = 700
                }
              + storage_type        = "gp3"
              + zone                = "us-east-1"
            }
        )
      + id           = (known after apply)
      + last_updated = (known after apply)
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
      + schema       = "Database"

      + provider_data {
          + account = "dev"
          + name    = "google cloud"
          + type    = "BigQuery"
          + url     = "https://console.cloud.google.com/..."
        }
    }

  # opslevel_scorecard.my_scorecard will be created
  + resource "opslevel_scorecard" "my_scorecard" {
      + affects_overall_service_levels = true
      + aliases                        = (known after apply)
      + description                    = "This is my example scorecard"
      + filter_id                      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzMyNA"
      + id                             = (known after apply)
      + name                           = "My Scorecard"
      + owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
      + passing_checks                 = (known after apply)
      + service_count                  = (known after apply)
      + total_checks                   = (known after apply)
    }

  # opslevel_system.test_system will be created
  + resource "opslevel_system" "test_system" {
      + aliases      = (known after apply)
      + description  = "So many words, such bar bar bar"
      + domain       = "my_domain"
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "Chatty Chatter"
      + note         = "This is a note"
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

3. Run `terraform destory`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_domain.test_domain will be destroyed
  - resource "opslevel_domain" "test_domain" {
      - aliases = [
          - "my_domain_4",
        ] -> null
      - id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzgxNDE4Mg" -> null
      - name    = "My Domain" -> null
    }

  # opslevel_infrastructure.test_infra will be destroyed
  - resource "opslevel_infrastructure" "test_infra" {
      - aliases = [] -> null
      - data    = jsonencode(
            {
              - endpoint            = "https://console.cloud.google.com/..."
              - engine              = "bigquery"
              - engine_version      = "1.28.0"
              - external_id         = "example_2_1234"
              - name                = "big-query"
              - publicly_accessible = false
              - replica             = false
              - storage_iops        = {
                  - unit  = "per second"
                  - value = 12000
                }
              - storage_size        = {
                  - unit  = "GB"
                  - value = 700
                }
              - storage_type        = "gp3"
              - zone                = "us-east-1"
            }
        ) -> null
      - id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzgxNDE4Mw" -> null
      - owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
      - schema  = "Database" -> null

      - provider_data {
          - account = "dev" -> null
          - name    = "google cloud" -> null
          - type    = "BigQuery" -> null
          - url     = "https://console.cloud.google.com/..." -> null
        }
    }

  # opslevel_scorecard.my_scorecard will be destroyed
  - resource "opslevel_scorecard" "my_scorecard" {
      - affects_overall_service_levels = true -> null
      - aliases                        = [
          - "my_scorecard_4",
        ] -> null
      - description                    = "This is my example scorecard" -> null
      - filter_id                      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzMyNA" -> null
      - id                             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzg3NQ" -> null
      - name                           = "My Scorecard" -> null
      - owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
      - passing_checks                 = 0 -> null
      - service_count                  = 295 -> null
      - total_checks                   = 0 -> null
    }

  # opslevel_system.test_system will be destroyed
  - resource "opslevel_system" "test_system" {
      - aliases     = [
          - "chatty_chatter_4",
        ] -> null
      - description = "So many words, such bar bar bar" -> null
      - domain      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzUyNDg0Nw" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzgxNDE4NA" -> null
      - name        = "Chatty Chatter" -> null
      - note        = "This is a note" -> null
      - owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
    }

Plan: 0 to add, 0 to change, 4 to destroy.
2023-11-14T15:31:23.000-0600 [DEBUG] command: asking for input: "\nDo you really want to destroy all resources?"

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

Destroy complete! Resources: 4 destroyed.
```