### PR TITLE
Fix owner_alias to owner migration by replacing GetOK() with Get()

### DIFF
--- a/.changes/unreleased/Bugfix-20231123-142256.yaml
+++ b/.changes/unreleased/Bugfix-20231123-142256.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug where the error 'can pass only one of owner owner_alias' was thrown
+  when updating services
+time: 2023-11-23T14:22:56.464506-05:00

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -188,13 +188,13 @@ func reconcileTags(d *schema.ResourceData, service *opslevel.Service, client *op
 func resourceServiceCreate(d *schema.ResourceData, client *opslevel.Client) error {
 	// owner_alias is deprecated, allow user to use one or the other but not both.
 	var ownerField *opslevel.IdentifierInput
-	owner, ownerUsed := d.GetOk("owner")
-	ownerAlias, ownerAliasUsed := d.GetOk("owner_alias")
-	if ownerUsed && ownerAliasUsed {
+	owner := d.Get("owner")
+	ownerAlias := d.Get("owner_alias")
+	if owner != "" && ownerAlias != "" {
 		return errors.New("can pass only one of: 'owner' or 'owner_alias'")
-	} else if ownerUsed {
+	} else if owner != "" {
 		ownerField = opslevel.NewIdentifier(owner.(string))
-	} else if ownerAliasUsed {
+	} else if ownerAlias != "" {
 		ownerField = opslevel.NewIdentifier(ownerAlias.(string))
 	}
 
@@ -323,14 +323,14 @@ func resourceServiceUpdate(d *schema.ResourceData, client *opslevel.Client) erro
 	if d.HasChange("tier_alias") {
 		input.Tier = d.Get("tier_alias").(string)
 	}
-	ownerUsed := d.HasChange("owner")
-	ownerAliasUsed := d.HasChange("owner_alias")
-	if ownerUsed && ownerAliasUsed {
+	owner := d.Get("owner")
+	ownerAlias := d.Get("owner_alias")
+	if owner != "" && ownerAlias != "" {
 		return errors.New("can pass only one of: 'owner' or 'owner_alias'")
-	} else if ownerUsed {
-		input.Owner = opslevel.NewIdentifier(d.Get("owner").(string))
-	} else if ownerAliasUsed {
-		input.Owner = opslevel.NewIdentifier(d.Get("owner_alias").(string))
+	} else if owner != "" {
+		input.Owner = opslevel.NewIdentifier(owner.(string))
+	} else if ownerAlias != "" {
+		input.Owner = opslevel.NewIdentifier(ownerAlias.(string))
 	}
 	if d.HasChange("lifecycle_alias") {
 		input.Lifecycle = d.Get("lifecycle_alias").(string)


### PR DESCRIPTION
## Issues

https://gitlab.com/jklabsinc/OpsLevel/-/issues/9951

TL;DR customer reported a bug where changing the `owner` field for an `owner_alias` and vice versa causes an error to be shown. That error is caused by the if statement that relies on `GetOk()`. 

## Changelog

- [x] Replace if statements
- [x] Make a `changie` entry

## Tophatting

All of these pass and there are no errors shown, only deprecation warnings when owner_alias is used.

Create a new service with owner_alias.

```
  # opslevel_service.bugsv2 will be created
  + resource "opslevel_service" "bugsv2" {
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "Bugged Service 2"
      + owner_alias  = "bugging_team"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Replace the owner_alias with owner.

```
  # opslevel_service.bugsv2 will be updated in-place
  ~ resource "opslevel_service" "bugsv2" {
        id          = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84NzUwOQ"
        name        = "Bugged Service 2"
      + owner       = "bugging_team"
      - owner_alias = "bugging_team" -> null
        tags        = []
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Opposite way works too.

```
  # opslevel_service.bugsv2 will be updated in-place
  ~ resource "opslevel_service" "bugsv2" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84NzUwOQ"
        name         = "Bugged Service 2"
      - owner        = "bugging_team" -> null
      + owner_alias  = "bugging_team"
        tags         = []
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Tested a completely different alias just out of curiosity.

```
  # opslevel_service.bugsv2 will be updated in-place
  ~ resource "opslevel_service" "bugsv2" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84NzUwOQ"
        name         = "Bugged Service 2"
      ~ owner_alias  = "bugging_team" -> "platform"
        tags         = []
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Updating to use both owner and owner_alias should fail.

```
  # opslevel_service.bugsv2 will be updated in-place
  ~ resource "opslevel_service" "bugsv2" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84NzUwOQ"
        name         = "Bugged Service 2"
      + owner        = "Platform"
        tags         = []
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
│ Error: can pass only one of: 'owner' or 'owner_alias'
│ 
│   with opslevel_service.bugsv2,
│   on main.tf line 13, in resource "opslevel_service" "bugsv2":
│   13: resource "opslevel_service" "bugsv2" {
│ 
╵
task: Failed to run task "apply": task: Failed to run task "terraform-command": exit status 1
```

So should creating a new service with both fields.

```
  # opslevel_service.bugsv3 will be created
  + resource "opslevel_service" "bugsv3" {
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "Bugged Service 3"
      + owner        = "platform"
      + owner_alias  = "platform"
    }

Plan: 1 to add, 1 to change, 0 to destroy.

│ Error: can pass only one of: 'owner' or 'owner_alias'
│ 
│   with opslevel_service.bugsv3,
│   on main.tf line 18, in resource "opslevel_service" "bugsv3":
│   18: resource "opslevel_service" "bugsv3" {
│ 
╵
task: Failed to run task "apply": task: Failed to run task "terraform-command": exit status 1
```