### PR TITLE
Only manage team memberships if they were defined before in the config

### DIFF
--- a/.changes/unreleased/Feature-20231129-141715.yaml
+++ b/.changes/unreleased/Feature-20231129-141715.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add support for managing Teams without unassigning team members if members were
+  not previously defined in terraform
+time: 2023-11-29T14:17:15.209888-05:00


### PR DESCRIPTION
## Issues

Some customers are defining Teams in terraform, but are not defining team memberships in their configurations (*.tf files) using `member {}` blocks. They are unable to run this provider because doing so results in all members being unassigned since they are not defined in terraform. 

One option for them is to export their members into their terraform config using the CLI.

The other option is for the terraform provider to only touch Team Memberships if they are defined or were previously defined **at any point before in the configuration.** 

Related, export members from web into terraform using CLI: https://github.com/OpsLevel/cli/pull/206

Related, ability to use `member {}` blocks in terraform: https://github.com/OpsLevel/terraform-provider-opslevel/pull/144

## Changelog

- [x] Change read function on Team to look at memberships only if they are being set right now or were set in the past.
- [x] Make a `changie` entry

## Tophatting

### Create a new team without any managed members, make sure terraform doesn't try to unassign members on updates

Create the team

```
  # opslevel_team.test_team will be created
  + resource "opslevel_team" "test_team" {
      + aliases          = [
          + "special_team",
        ]
      + id               = (known after apply)
      + last_updated     = (known after apply)
      + name             = "special team"
      + responsibilities = "hello world"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

On the website, add 2 contributors and 1 manager.

<img width="742" alt="image" src="https://github.com/OpsLevel/terraform-provider-opslevel/assets/139589712/eb5d5cb3-491e-4b4c-a972-d153ded1c7ca">

Run the plan. Expected is to see no changes, since no `member {}` is defined in the config. 

```
opslevel_team.test_team: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMzI5OA]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Try again by running an update, but without managing team memberships.

```
  # opslevel_team.test_team will be updated in-place
  ~ resource "opslevel_team" "test_team" {
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMzI5OA"
        name             = "special team"
      ~ responsibilities = "hello world" -> "i changed this"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

**This shows that you can manage a team that has no `member {}` blocks without the provider trying to unassign everyone.**

Add a single `member {}` block. This should cause terraform to reconcile team memberships, removing the 3 current members with Doug since it is now managing members too. 

```
  # opslevel_team.test_team will be updated in-place
  ~ resource "opslevel_team" "test_team" {
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMzI5OQ"
        name             = "special team"
        # (3 unchanged attributes hidden)

      ~ member {
          ~ email = "taimoor+orange@opslevel.com" -> "doug+orange@opslevel.com"
            # (1 unchanged attribute hidden)
        }
      - member {
          - email = "david+orange@opslevel.com" -> null
          - role  = "contributor" -> null
        }
      - member {
          - email = "kyle+orange@opslevel.com" -> null
          - role  = "contributor" -> null
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

<img width="744" alt="image" src="https://github.com/OpsLevel/terraform-provider-opslevel/assets/139589712/c2366b0f-f920-46b1-b0d8-bc2280b239ed">

Remove the last member. 

```
  # opslevel_team.test_team will be updated in-place
  ~ resource "opslevel_team" "test_team" {
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMzI5OQ"
        name             = "special team"
        # (3 unchanged attributes hidden)

      - member {
          - email = "doug+orange@opslevel.com" -> null
          - role  = "manager" -> null
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

<img width="744" alt="image" src="https://github.com/OpsLevel/terraform-provider-opslevel/assets/139589712/13ab5a04-a0f8-4f28-b82b-5f6e9af13e72">

Now from here, we are in the state where the configuration has no members, and the object itself has no members. BUT, `GetOk()` returns `true` if something was **ever** set in the configuration. So I expect that it will try to reconcile team memberships if I add some in the website. 

<img width="734" alt="image" src="https://github.com/OpsLevel/terraform-provider-opslevel/assets/139589712/1f031fbc-5756-48c8-8dc5-64831c186268">

```
  # opslevel_team.test_team will be updated in-place
  ~ resource "opslevel_team" "test_team" {
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMzI5OQ"
        name             = "special team"
        # (3 unchanged attributes hidden)

      - member {
          - email = "taimoor+orange@opslevel.com" -> null
          - role  = "manager" -> null
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```