### PR TITLE
Add a list of repository ID's to the service datasource

### DIFF
--- a/.changes/unreleased/Feature-20231215-141513.yaml
+++ b/.changes/unreleased/Feature-20231215-141513.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Ability to get list of repositories on a service using service datasource.
+time: 2023-12-15T14:15:13.154362-05:00

--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -279,6 +279,14 @@ func flattenTagArray(tags []opslevel.Tag) []string {
 	return output
 }
 
+func flattenServiceRepositoriesArray(repositories *opslevel.ServiceRepositoryConnection) []string {
+	output := []string{}
+	for _, rep := range repositories.Edges {
+		output = append(output, string(rep.Node.Id))
+	}
+	return output
+}
+
 func flattenMembersArray(members *opslevel.UserConnection) []string {
 	output := []string{}
 	for _, member := range members.Nodes {

--- a/opslevel/datasource_opslevel_service.go
+++ b/opslevel/datasource_opslevel_service.go
@@ -95,6 +95,12 @@ func datasourceService() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"repositories": {
+				Type:        schema.TypeList,
+				Description: "List of repositories connected to the service.",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -141,6 +147,9 @@ func datasourceServiceRead(d *schema.ResourceData, client *opslevel.Client) erro
 		return err
 	}
 	if err := d.Set("tags", flattenTagArray(resource.Tags.Nodes)); err != nil {
+		return err
+	}
+	if err := d.Set("repositories", flattenServiceRepositoriesArray(resource.Repositories)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/terraform-provider-opslevel/issues/141

## Changelog

- [x] Add function to get repository ID's from a `ServiceRepositoryConnection`.
- [x] Add `repositories` to the datasource schema
- [x] Make a `changie` entry

## Tophatting

A service with 2 repositories.

```
$ cat main.tf
data "opslevel_service" "fetched_service" {
    alias = "XXX"
}

output "fetched_repositories" {
  value = data.opslevel_service.fetched_service.repositories
}

$ terraform apply
Changes to Outputs:
  + fetched_repositories = [
      + "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRsYWIvMjQ4NzA",
      + "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvOTY3",
    ]
```

A service with no repositories:

```
Changes to Outputs:
  + fetched_repositories = []
```
