### PR TITLE
Add a list of team memberships to the service datasource

### DIFF
--- a/.changes/unreleased/Feature-20231215-164432.yaml
+++ b/.changes/unreleased/Feature-20231215-164432.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: Ability to get a list of team members using the team datasource.
+time: 2023-12-15T16:44:32.057432-05:00

--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -287,6 +287,14 @@ func flattenMembersArray(members *opslevel.UserConnection) []string {
 	return output
 }
 
+func flattenMembershipsArray(members *opslevel.TeamMembershipConnection) []string {
+	output := []string{}
+	for _, membership := range members.Nodes {
+		output = append(output, string(membership.User.Id))
+	}
+	return output
+}
+
 func flattenTeamsArray(teams *opslevel.TeamConnection) []string {
 	output := []string{}
 	for _, team := range teams.Nodes {

--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -287,10 +287,13 @@ func flattenMembersArray(members *opslevel.UserConnection) []string {
 	return output
 }
 
-func flattenMembershipsArray(members *opslevel.TeamMembershipConnection) []string {
-	output := []string{}
+func mapMembershipsArray(members *opslevel.TeamMembershipConnection) []map[string]string {
+	output := []map[string]string{}
 	for _, membership := range members.Nodes {
-		output = append(output, string(membership.User.Id))
+		asMap := make(map[string]string)
+		asMap["email"] = membership.User.Email
+		asMap["role"] = membership.Role
+		output = append(output, asMap)
 	}
 	return output
 }

--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -26,6 +26,12 @@ func datasourceTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"members": {
+				Type:        schema.TypeList,
+				Description: "List of repositories connected to the service.",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"parent_alias": {
 				Type:        schema.TypeString,
 				Description: "The alias of the parent team.",
@@ -61,12 +67,18 @@ func datasourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
 	d.SetId(string(resource.Id))
 	d.Set("alias", resource.Alias)
 	d.Set("name", resource.Name)
+
 	if err := d.Set("group_alias", resource.Group.Alias); err != nil {
 		return err
 	}
 	if err := d.Set("group_id", resource.Group.Id); err != nil {
 		return err
 	}
+
+	if err := d.Set("members", flattenMembershipsArray(resource.Memberships)); err != nil {
+		return err
+	}
+
 	if err := d.Set("parent_alias", resource.ParentTeam.Alias); err != nil {
 		return err
 	}

--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -23,14 +23,28 @@ func datasourceTeam() *schema.Resource {
 				Optional:    true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Description: "The name of the team.",
+				Computed:    true,
 			},
 			"members": {
 				Type:        schema.TypeList,
 				Description: "List of repositories connected to the service.",
 				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:        schema.TypeString,
+							Description: "The email address of the team member.",
+							Computed:    true,
+						},
+						"role": {
+							Type:        schema.TypeString,
+							Description: "The role of the team member.",
+							Computed:    true,
+						},
+					},
+				},
 			},
 			"parent_alias": {
 				Type:        schema.TypeString,
@@ -75,7 +89,7 @@ func datasourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
 		return err
 	}
 
-	if err := d.Set("members", flattenMembershipsArray(resource.Memberships)); err != nil {
+	if err := d.Set("members", mapMembershipsArray(resource.Memberships)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/terraform-provider-opslevel/issues/143

## Changelog

- [x] Add way to fetch memberships (need user ID, email, role because there is no datasource for team memberships. Only the ID's are useless.)
- [x] Update the datasource schema
- [x] Make a `changie` entry

## Tophatting

```
$ cat main.tf
data "opslevel_team" "fetched_team" {
  alias = "platform"
}

output "fetched_memberships" {
  value = data.opslevel_team.fetched_team.members
}

$ terraform plan
Changes to Outputs:
  + fetched_memberships = [
      + {
          + email = "person1@opslevel.com"
          + role  = "contributor"
        },
      + {
          + email = "person2@opslevel.com"
          + role  = "contributor"
        },
    ]
```
