### PR TITLE
Bugfix for when a Team's parent is unset or changed unexpectedly

### DIFF
--- a/.changes/unreleased/Bugfix-20231219-101147.yaml
+++ b/.changes/unreleased/Bugfix-20231219-101147.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: Fix bug where a Team's parent became unset or changed unexpectedly
+time: 2023-12-19T10:11:47.242426-05:00

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -233,7 +233,7 @@ func resourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
 	if err := d.Set("group", resource.Group.Alias); err != nil {
 		return err
 	}
-	if err := d.Set("parent", d.Get("parent")); err != nil {
+	if err := d.Set("parent", resource.ParentTeam.Alias); err != nil {
 		return err
 	}
 

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -289,12 +289,12 @@ func resourceTeamUpdate(d *schema.ResourceData, client *opslevel.Client) error {
 	if d.HasChange("group") {
 		return errors.New("groups are deprecated - create and update are disabled.")
 	}
-	if d.HasChange("parent") {
-		if parentTeam, ok := d.GetOk("parent"); ok {
-			input.ParentTeam = opslevel.NewIdentifier(parentTeam.(string))
-		} else {
-			input.ParentTeam = nil
-		}
+
+	parentTeam := d.Get("parent")
+	if parentTeam != "" {
+		input.ParentTeam = opslevel.NewIdentifier(parentTeam.(string))
+	} else {
+		input.ParentTeam = nil
 	}
 
 	resource, err := client.UpdateTeam(input)

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -58,12 +58,12 @@ func resourceTeam() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"email": {
 							Type:        schema.TypeString,
-							Description: "The email address or ID of the user to add to a team.",
+							Description: "The email address of the team member.",
 							Required:    true,
 						},
 						"role": {
 							Type:        schema.TypeString,
-							Description: "The type of relationship this membership implies.",
+							Description: "The role of the team member.",
 							Required:    true,
 						},
 					},
@@ -71,7 +71,7 @@ func resourceTeam() *schema.Resource {
 			},
 			"parent": {
 				Type:        schema.TypeString,
-				Description: "The parent team. Only accepts team's Alias",
+				Description: "The alias of the parent team.",
 				ForceNew:    false,
 				Optional:    true,
 			},


### PR DESCRIPTION
## Issues

This is a customer reported bug. A customer noticed that the `parent` on a team could be unset or could be changed unexpectedly. The customer reported [this on version 0.8.13.] (https://registry.terraform.io/providers/OpsLevel/opslevel/0.8.13/docs)

The customer noted that this happens when updating members, but that is coincidental. It can happen when updating anything about a team. 

The cause is a `d.Get()` value being used in the read a Team resource function, which is a clear typo. Also, a `d.HasChange()` call which can result in `input.Parent = nil` being sent in the team update input.

https://github.com/OpsLevel/team-platform/issues/156

## Changelog

- [x] Read the actual retrieved parent value of a Team
- [x] Change the update function to stop using `GetOk`, it's unreliable. (added in last commit, it's important)
- [x] Update some field descriptions to be consistent with the datasource (they are also easier to read).
- [x] Make a `changie` entry

## Tophatting

### Before

Create a team with a parent. Works fine.

```
$ task apply 
  # opslevel_team.bugfixteam will be created
  + resource "opslevel_team" "bugfixteam" {
      + aliases      = [
          + "bft",
        ]
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "bugfix team"
      + parent       = "platform"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Now add a team member. The parent gets removed by the update call, but terraform doesn't detect this.

```
$ task apply
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzMg"
        name    = "bugfix team"
        # (2 unchanged attributes hidden)

      + member {
          + email = "taimoor+orange@opslevel.com"
          + role  = "manager"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Note that if we change the parent, it works. But then the same bug (unsetting parent) will happen in future updates.

```
$ task apply
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzMg"
        name         = "bugfix team"
      ~ parent       = "platform" -> "engineering"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### After

Create the team, the parent should be set. ✅ 

```
  # opslevel_team.bugfixteam will be created
  + resource "opslevel_team" "bugfixteam" {
      + aliases      = [
          + "bft",
        ]
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "bugfix team"
      + parent       = "platform"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Add a member. The parent should be unchanged. ✅ 

```
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzNw"
        name    = "bugfix team"
        # (2 unchanged attributes hidden)

      + member {
          + email = "taimoor+orange@opslevel.com"
          + role  = "manager"
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Unset the parent, it should be removed. ✅ 

```
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzOQ"
        name         = "bugfix team"
      - parent       = "platform" -> null
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Re-add the parent. ✅ 

```
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzOQ"
        name         = "bugfix team"
      + parent       = "platform"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Then change it to another team. ✅ 

```
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzOQ"
        name         = "bugfix team"
      ~ parent       = "platform" -> "engineering"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Try adding another member, parent should be unchanged. ✅ 

```
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzOQ"
        name         = "bugfix team"
        # (3 unchanged attributes hidden)

      + member {
          + email = "kyle+orange@opslevel.com"
          + role  = "contributor"
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Try removing all members, parent should be unchanged. ✅ 

```
  # opslevel_team.bugfixteam will be updated in-place
  ~ resource "opslevel_team" "bugfixteam" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDIzOQ"
        name         = "bugfix team"
        # (3 unchanged attributes hidden)

      - member {
          - email = "taimoor+orange@opslevel.com" -> null
          - role  = "manager" -> null
        }
      - member {
          - email = "kyle+orange@opslevel.com" -> null
          - role  = "contributor" -> null
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```