### PR TITLE
prevent null bool in filter predicate

### DIFF
--- a/.changes/unreleased/Bugfix-20240103-113615.yaml
+++ b/.changes/unreleased/Bugfix-20240103-113615.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: '[BREAKING CHANGE] require filter predicate case_sensitive bool to prevent bug
+  where value cannot be set to false'
+time: 2024-01-03T11:36:15.475217-05:00

--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -213,13 +213,11 @@ func expandFilterPredicates(d *schema.ResourceData) []opslevel.FilterPredicate {
 	for _, item := range d.Get("predicate").([]interface{}) {
 		data := item.(map[string]interface{})
 		predicate := opslevel.FilterPredicate{
-			Type:    opslevel.PredicateTypeEnum(data["type"].(string)),
-			Value:   strings.TrimSpace(data["value"].(string)),
-			Key:     opslevel.PredicateKeyEnum(data["key"].(string)),
-			KeyData: strings.TrimSpace(data["key_data"].(string)),
-		}
-		if caseSensitive, ok := d.GetOk("case_sensitive"); ok {
-			predicate.CaseSensitive = opslevel.Bool(caseSensitive.(bool))
+			Type:          opslevel.PredicateTypeEnum(data["type"].(string)),
+			Value:         strings.TrimSpace(data["value"].(string)),
+			Key:           opslevel.PredicateKeyEnum(data["key"].(string)),
+			KeyData:       strings.TrimSpace(data["key_data"].(string)),
+			CaseSensitive: opslevel.Bool(data["case_sensitive"].(bool)),
 		}
 		output = append(output, predicate)
 	}

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -65,7 +65,7 @@ func resourceFilter() *schema.Resource {
 							Type:        schema.TypeBool,
 							Description: "Option for determining whether to compare strings case-sensitively.\n\n",
 							ForceNew:    false,
-							Optional:    true,
+							Required:    true,
 						},
 					},
 				},


### PR DESCRIPTION
## Issues

This fixes a customer reported bug https://github.com/OpsLevel/terraform-provider-opslevel/issues/179 which is caused by https://github.com/hashicorp/terraform/issues/25872. Also kind of part of https://github.com/OpsLevel/team-platform/issues/158

**We cannot have null bools in terraform.** The current provider does not support differentiating between zero values `""`  `false` or `0`. 

The solution here is to require customers to set this to either `true` or `false`. There is another hack we can optionally do, which is:

1. Treat the boolean as a string
2. If `d.Get(booleanKeyThatsReallyAString) == ""`, use a nil `*bool`, otherwise if it's `"true"` use `true`, same with `"false"` and `false`.

The latter solution is way more hacky, and the users would have to adapt their configs anyways.

**I don't see a way to fix this without users having to modify their terraform config files.**

## Changelog

- [x] Update filter predicate `case_sensitive` field
- [x] Make a `changie` entry

## Tophatting

Tested locally
