### PR TITLE
update CONTRIBUTING and terraform tasks in Taskfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ repository, check out a new branch, and push directly to that branch.
 1. Make sure you have a working
 [golang development environment](https://learn.gopherguides.com/courses/preparing-your-environment-for-go-development)
 setup.
-2. Ensure [task](https://taskfile.dev/) is installed then run:
+2. Ensure [task](https://taskfile.dev/installation/) is installed then run:
 
 ```sh
 # Run `task setup --dry` to see what will be installed before running
@@ -119,20 +119,22 @@ After any code change you can just run the following to build and pull in the la
 
 ```sh
 # Build and initialize terraform workspace
-task terraform:setup
+task terraform-setup
 ```
 
 See other terraform tasks with `task --list`:
 
 ```sh
-# Run `terraform plan` in the "workspace" directory with:
-task terraform:plan
+# To rebuild Go code and run "terraform plan" in "workspace", use:
+task plan
 
-# Run `terraform apply` in the "workspace" directory with:
-task terraform:apply
+# To rebuild Go code and run "terraform apply -auto-approve" in "workspace", use:
+task apply
 
-# Run `terraform destroy` in the "workspace" directory with:
-task terraform:destroy
+# WARNING: this will destroy all resources without approval.
+# Use "terraform destroy" if you are want confirmation before destroying all resources.
+# To rebuild Go code and run "terraform destroy -auto-approve" in "workspace", use:
+task destroy
 ```
 
 Feel free to investigate the [Taskfile.yml](./Taskfile.yml) for details.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,10 +16,11 @@ includes:
 tasks:
 
   apply:
-    desc: Run "terraform apply"
+    desc: Rebuild and run "terraform apply -auto-approve" in "{{.WORKSPACE_DIR}}"
     cmds:
+      - task: terraform-setup
       - task: terraform-command
-        vars: { TF_COMMAND: "apply", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
+        vars: { TF_COMMAND: "apply -auto-approve", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
 
   build:
     desc: Build local opslevel terraform provider
@@ -50,40 +51,17 @@ tasks:
         ignore_error: true
 
   destroy:
-    desc: Run "terraform destroy" in "{{.WORKSPACE_DIR}}"
+    desc: Rebuild and run "terraform destroy -auto-approve" in "{{.WORKSPACE_DIR}}"
     cmds:
+      - task: terraform-setup
       - task: terraform-command
-        vars: { TF_COMMAND: "destroy", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
+        vars: { TF_COMMAND: "destroy -auto-approve", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
 
   fix:
     desc: Fix formatting and linting
     cmds:
       - task: go:fix
       - task: format-fix
-
-  hard-apply:
-    desc: Rebuild and run "terraform apply -auto-approve"
-    cmds:
-      - task: build
-      - task: init
-      - task: terraform-command
-        vars: { TF_COMMAND: "apply -auto-approve", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
-
-  hard-destroy:
-    desc: Rebuild and run "terraform destroy -auto-approve"
-    cmds:
-      - task: build
-      - task: init
-      - task: terraform-command
-        vars: { TF_COMMAND: "destroy -auto-approve", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
-
-  hard-plan:
-    desc: Rebuild and run "terraform plan"
-    cmds:
-      - task: build
-      - task: init
-      - task: terraform-command
-        vars: { TF_COMMAND: "plan", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
 
   init:
     desc: Initialize terraform workspace
@@ -113,8 +91,9 @@ tasks:
       - task: format-check
 
   plan:
-    desc: Run "terraform plan" in "{{.WORKSPACE_DIR}}"
+    desc: Rebuild and run "terraform plan" in "{{.WORKSPACE_DIR}}"
     cmds:
+      - task: terraform-setup
       - task: terraform-command
         vars: { TF_COMMAND: "plan", TF_CMD_DIR: "{{.WORKSPACE_DIR}}" }
 
@@ -123,6 +102,12 @@ tasks:
     cmds:
       - task: install-changie
       - task: go:setup
+      - task: terraform-setup
+
+  setup-terraform:
+    desc: Setup env and tools
+    aliases: ["setup-tf", "tf-setup", "terraform-setup"]
+    cmds:
       - task: build
       - task: init
 


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

1. Update `CONTRIBUTING.md` to reflect recent updates to `task` commands in `Taskfile.yml`
2. Remove `task hard-apply`, `task hard-destroy`, and `task hard-plan`.
3. Update `task apply`, `task destroy`, and `task plan` do what `task hard-*` did.
    - Originally `task *` like were simple wrappers around `terraform *`. `task apply` was `terraform apply` in the "workspace" directory.
    - Now, `task apply` and `task destroy` also have `-auto-approve` - as well as rebuilding the Go code every time.


- [X] List your changes here
- [ ] Make a `changie` entry, N/A docs and Taskfile updates

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
