### PR TITLE
remove terraform: prefix from docs for task commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,20 +119,20 @@ After any code change you can just run the following to build and pull in the la
 
 ```sh
 # Build and initialize terraform workspace
-task terraform:setup
+task setup
 ```
 
 See other terraform tasks with `task --list`:
 
 ```sh
 # Run `terraform plan` in the "workspace" directory with:
-task terraform:plan
+task plan
 
 # Run `terraform apply` in the "workspace" directory with:
-task terraform:apply
+task apply
 
 # Run `terraform destroy` in the "workspace" directory with:
-task terraform:destroy
+task destroy
 ```
 
 Feel free to investigate the [Taskfile.yml](./Taskfile.yml) for details.


### PR DESCRIPTION
## Issues

When following the instructions in CONTRIBUTING.md I noticed that the `task terraform:<command>` lines referenced tasks that do not exist in the task file. I assume the prefix was removed at some point since omitting it ran the correct commands.
<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ] Updates to CONTRIBUTING.md task commands when setting up a workspace.
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
