### PR TITLE
fix updates to owner and description fields, can assign alias not just id

### DIFF
--- a/.changes/unreleased/Bugfix-20240124-103647.yaml
+++ b/.changes/unreleased/Bugfix-20240124-103647.yaml
@@ -1,3 +1,3 @@
 kind: Bugfix
-body: fix updates to owner and description fields, can assign alias not just id
+body: on property_assignment resources the fields owner and definition can use alias not just id, fix an infinite plan bug because we store the wrong thing into the terraform state 
 time: 2024-01-24T10:36:47.402589-06:00

--- a/.changes/unreleased/Bugfix-20240124-103647.yaml
+++ b/.changes/unreleased/Bugfix-20240124-103647.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix updates to owner and description fields, can assign alias not just id
+time: 2024-01-24T10:36:47.402589-06:00

--- a/opslevel/resource_opslevel_property_assignment.go
+++ b/opslevel/resource_opslevel_property_assignment.go
@@ -83,10 +83,10 @@ func resourcePropertyAssignmentRead(d *schema.ResourceData, client *opslevel.Cli
 	// if resource was fetched correctly, attach the id to the resource
 	d.SetId(fmt.Sprintf("%s:%s", ownerId, definitionId))
 
-	if err := d.Set("definition", string(resource.Definition.Id)); err != nil {
+	if err := d.Set("definition", d.Get("definition")); err != nil {
 		return err
 	}
-	if err := d.Set("owner", string(resource.Owner.Id())); err != nil {
+	if err := d.Set("owner", d.Get("owner")); err != nil {
 		return err
 	}
 	if err := d.Set("value", string(*resource.Value)); err != nil {


### PR DESCRIPTION
…t id

## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Fix updates to `owner` and `description` fields of Property Assignment resources. Before only ids were accepted even if an alias was provided.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
