### PR TITLE
update version during release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release delete ${{ steps.next_version.outputs.version_tag }} || true
+      - name: Set Package Version
+        run: |
+          cat << EOF > opslevel/version.go
+          package opslevel
+
+          const version string = "${{ steps.next_version.outputs.version_tag }}"
+          EOF
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,13 +74,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release delete ${{ steps.next_version.outputs.version_tag }} || true
-      - name: Set Package Version
-        run: |
-          cat << EOF > opslevel/version.go
-          package opslevel
-
-          const version string = "${{ steps.next_version.outputs.version_tag }}"
-          EOF
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X opslevel.version={{.Version}}'
+      - '-s -w -X github.com/opslevel/terraform-provider-opslevel/opslevel.version={{.Version}}'
     goos:
       - windows
       - linux

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,7 +29,7 @@ tasks:
       BINARY: terraform-provider-opslevel_{{.VERSION_DYNAMIC}}
       LOCATION: "${HOME}/.terraform.d/plugins/registry.terraform.io/opslevel/opslevel/{{.VERSION_DYNAMIC}}/{{OS}}_{{ARCH}}"
     cmds:
-      - go build -o {{.BINARY}} || exit 1
+      - go build -ldflags="-s -w -X github.com/opslevel/terraform-provider-opslevel/opslevel.version={{.VERSION_DYNAMIC}}" -o {{.BINARY}} || exit 1
       - chmod +x {{.BINARY}}
       - mkdir -p {{.LOCATION}}
       - mv {{.BINARY}} {{.LOCATION}}/{{.BINARY}}


### PR DESCRIPTION
## Issues

[Unify Version output across all tools and libraries](https://github.com/OpsLevel/team-platform/issues/213)

## Changelog

Somehow updating the version with the usual Go build flag `-X opslevel.version={{.Version}}` is not work. [{{.Version}} is legit](https://goreleaser.com/customization/templates/#common-fields). This is taking a page out of `opslevel-go`'s release book.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A CI only

## Tophatting

release it
