### PR TITLE
on opslevel-go setup, ensure fresh go.work files

### DIFF
--- a/opslevel/Taskfile.yml
+++ b/opslevel/Taskfile.yml
@@ -56,7 +56,8 @@ tasks:
     internal: true
     cmds:
       - git submodule update --init --remote
-      - go work init || true
+      - rm go.work go.work.sum || true
+      - go work init
       - go work use . submodules/opslevel-go
       - echo "Workspace ready!"
 


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Ensure that `go.work` and `go.work.sum` are updated every time `task setup` is invoked.

- [X] List your changes here
- [ ] Make a `changie` entry, N/A local setup update

## Tophatting

`task setup` and `task ci` work 
