### PR TITLE
replace dropped Bool func with RefOf func

### DIFF
--- a/opslevel/resource_opslevel_check_custom_event.go
+++ b/opslevel/resource_opslevel_check_custom_event.go
@@ -55,7 +55,7 @@ func resourceCheckCustomEventCreate(d *schema.ResourceData, client *opslevel.Cli
 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckCustomEventCreateInput](checkCreateInput)
 
 	input.IntegrationId = *opslevel.NewID(d.Get("integration").(string))
-	input.PassPending = opslevel.Bool(d.Get("pass_pending").(bool))
+	input.PassPending = opslevel.RefOf(d.Get("pass_pending").(bool))
 	input.ServiceSelector = d.Get("service_selector").(string)
 	input.SuccessCondition = d.Get("success_condition").(string)
 	input.ResultMessage = opslevel.RefOf(d.Get("message").(string))
@@ -114,7 +114,7 @@ func resourceCheckCustomEventUpdate(d *schema.ResourceData, client *opslevel.Cli
 	if d.HasChange("integration") {
 		input.IntegrationId = opslevel.NewID(d.Get("integration").(string))
 	}
-	input.PassPending = opslevel.Bool(d.Get("pass_pending").(bool))
+	input.PassPending = opslevel.RefOf(d.Get("pass_pending").(bool))
 	if d.HasChange("service_selector") {
 		input.ServiceSelector = opslevel.RefOf(d.Get("service_selector").(string))
 	}

--- a/opslevel/resource_opslevel_check_has_recent_deploy.go
+++ b/opslevel/resource_opslevel_check_has_recent_deploy.go
@@ -62,7 +62,7 @@ func resourceCheckHasRecentDeployUpdate(d *schema.ResourceData, client *opslevel
 	checkUpdateInput := getCheckUpdateInputFrom(d)
 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckHasRecentDeployUpdateInput](checkUpdateInput)
 	if d.HasChange("days") {
-		input.Days = opslevel.NewInt(d.Get("days").(int))
+		input.Days = opslevel.RefOf(d.Get("days").(int))
 	}
 
 	_, err := client.UpdateCheckHasRecentDeploy(*input)

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -45,7 +45,7 @@ func resourceCheckServiceOwnershipCreate(d *schema.ResourceData, client *opsleve
 	checkCreateInput := getCheckCreateInputFrom(d)
 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckServiceOwnershipCreateInput](checkCreateInput)
 
-	input.RequireContactMethod = opslevel.Bool(d.Get("require_contact_method").(bool))
+	input.RequireContactMethod = opslevel.RefOf(d.Get("require_contact_method").(bool))
 	if value, ok := d.GetOk("contact_method"); ok {
 		contactMethod := opslevel.ContactType(value.(string))
 		input.ContactMethod = opslevel.RefOf(string(contactMethod))
@@ -103,7 +103,7 @@ func resourceCheckServiceOwnershipRead(d *schema.ResourceData, client *opslevel.
 func resourceCheckServiceOwnershipUpdate(d *schema.ResourceData, client *opslevel.Client) error {
 	checkUpdateInput := getCheckUpdateInputFrom(d)
 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckServiceOwnershipUpdateInput](checkUpdateInput)
-	input.RequireContactMethod = opslevel.Bool(d.Get("require_contact_method").(bool))
+	input.RequireContactMethod = opslevel.RefOf(d.Get("require_contact_method").(bool))
 
 	if d.HasChange("contact_method") {
 		contactMethod := opslevel.ContactType(d.Get("contact_method").(string))

--- a/opslevel/resource_opslevel_integration_aws.go
+++ b/opslevel/resource_opslevel_integration_aws.go
@@ -61,7 +61,7 @@ func resourceIntegrationAWSCreate(d *schema.ResourceData, client *opslevel.Clien
 		Name:                 opslevel.RefOf(d.Get("name").(string)),
 		IAMRole:              opslevel.RefOf(d.Get("iam_role").(string)),
 		ExternalID:           opslevel.RefOf(d.Get("external_id").(string)),
-		OwnershipTagOverride: opslevel.Bool(d.Get("ownership_tag_overrides").(bool)),
+		OwnershipTagOverride: opslevel.RefOf(d.Get("ownership_tag_overrides").(bool)),
 	}
 
 	input.OwnershipTagKeys = getStringArray(d, "ownership_tag_keys")
@@ -106,7 +106,7 @@ func resourceIntegrationAWSUpdate(d *schema.ResourceData, client *opslevel.Clien
 		Name:                 opslevel.RefOf(d.Get("name").(string)),
 		IAMRole:              opslevel.RefOf(d.Get("iam_role").(string)),
 		ExternalID:           opslevel.RefOf(d.Get("external_id").(string)),
-		OwnershipTagOverride: opslevel.Bool(d.Get("ownership_tag_overrides").(bool)),
+		OwnershipTagOverride: opslevel.RefOf(d.Get("ownership_tag_overrides").(bool)),
 	}
 
 	input.OwnershipTagKeys = getStringArray(d, "ownership_tag_keys")

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -14,7 +14,7 @@ func handleInput(d *schema.ResourceData) opslevel.ScorecardInput {
 		OwnerId:                     *opslevel.NewID(d.Get("owner_id").(string)),
 		Description:                 &description,
 		FilterId:                    opslevel.NewID(d.Get("filter_id").(string)),
-		AffectsOverallServiceLevels: opslevel.Bool(d.Get("affects_overall_service_levels").(bool)),
+		AffectsOverallServiceLevels: opslevel.RefOf(d.Get("affects_overall_service_levels").(bool)),
 	}
 
 	return input

--- a/opslevel/resource_opslevel_trigger_definition.go
+++ b/opslevel/resource_opslevel_trigger_definition.go
@@ -120,7 +120,7 @@ func resourceTriggerDefinitionCreate(d *schema.ResourceData, client *opslevel.Cl
 		input.ResponseTemplate = opslevel.RefOf(responseTemplate)
 	}
 
-	input.Published = opslevel.Bool(d.Get("published").(bool))
+	input.Published = opslevel.RefOf(d.Get("published").(bool))
 
 	if _, ok := d.GetOk("entity_type"); ok {
 		entityType := d.Get("entity_type").(string)
@@ -217,7 +217,7 @@ func resourceTriggerDefinitionUpdate(d *schema.ResourceData, client *opslevel.Cl
 		input.FilterId = opslevel.NewID(d.Get("filter").(string))
 	}
 
-	input.Published = opslevel.Bool(d.Get("published").(bool))
+	input.Published = opslevel.RefOf(d.Get("published").(bool))
 
 	if d.HasChange("access_control") {
 		input.AccessControl = opslevel.RefOf(opslevel.CustomActionsTriggerDefinitionAccessControlEnum(d.Get("access_control").(string)))

--- a/opslevel/schema_checks.go
+++ b/opslevel/schema_checks.go
@@ -174,7 +174,7 @@ func setCheckUpdateInput(d *schema.ResourceData, p opslevel.CheckUpdateInputProv
 	if d.HasChange("name") {
 		input.Name = d.Get("name").(string)
 	}
-	input.Enabled = opslevel.Bool(d.Get("enabled").(bool))
+	input.Enabled = opslevel.RefOf(d.Get("enabled").(bool))
 	if d.HasChange("enable_on") {
 		enable_on := opslevel.NewISO8601Date(d.Get("enable_on").(string))
 		input.EnableOn = &enable_on


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

From `opslevel-go`, `Bool()` was removed with `RefOf` replacing it

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
