### PR TITLE
Add support for locked property assignments and allowed_in_config_files property definitions

### DIFF
--- a/.changes/unreleased/Feature-20240301-123335.yaml
+++ b/.changes/unreleased/Feature-20240301-123335.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add support for locked property assignments and allowed_in_config_files property
+  definitions
+time: 2024-03-01T12:33:35.980507-05:00

--- a/opslevel/datasource_opslevel_property_definition.go
+++ b/opslevel/datasource_opslevel_property_definition.go
@@ -13,7 +13,7 @@ func datasourcePropertyDefinition() *schema.Resource {
 			"allowed_in_config_files": {
 				Type:        schema.TypeBool,
 				Description: "Whether or not the property is allowed to be set in opslevel.yml config files.",
-				Required:    true,
+				Computed:    true,
 			},
 			"identifier": {
 				Type:        schema.TypeString,

--- a/opslevel/datasource_opslevel_property_definition.go
+++ b/opslevel/datasource_opslevel_property_definition.go
@@ -10,6 +10,11 @@ func datasourcePropertyDefinition() *schema.Resource {
 	return &schema.Resource{
 		Read: wrap(datasourcePropertyDefinitionRead),
 		Schema: map[string]*schema.Schema{
+			"allowed_in_config_files": {
+				Type:        schema.TypeBool,
+				Description: "Whether or not the property is allowed to be set in opslevel.yml config files.",
+				Required:    true,
+			},
 			"identifier": {
 				Type:        schema.TypeString,
 				Description: "The id or alias of the property definition to find.",
@@ -50,6 +55,9 @@ func datasourcePropertyDefinitionRead(d *schema.ResourceData, client *opslevel.C
 
 	d.SetId(string(resource.Id))
 
+	if err := d.Set("allowed_in_config_files", resource.AllowedInConfigFiles); err != nil {
+		return err
+	}
 	if err := d.Set("name", resource.Name); err != nil {
 		return err
 	}

--- a/opslevel/datasource_opslevel_property_definitions.go
+++ b/opslevel/datasource_opslevel_property_definitions.go
@@ -10,6 +10,11 @@ func datasourcePropertyDefinitions() *schema.Resource {
 	return &schema.Resource{
 		Read: wrap(datasourcePropertyDefinitionsRead),
 		Schema: map[string]*schema.Schema{
+			"allowed_in_config_files": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
+			},
 			"ids": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -46,12 +51,14 @@ func datasourcePropertyDefinitionsRead(d *schema.ResourceData, client *opslevel.
 	}
 
 	count := len(resources.Nodes)
+	allowedInConfigFiles := make([]bool, count)
 	ids := make([]string, count)
 	names := make([]string, count)
 	descriptions := make([]string, count)
 	schemas := make([]string, count)
 	propertyDisplayStatuses := make([]string, count)
 	for i, item := range resources.Nodes {
+		allowedInConfigFiles[i] = item.AllowedInConfigFiles
 		ids[i] = string(item.Id)
 		names[i] = item.Name
 		descriptions[i] = item.Description
@@ -60,6 +67,7 @@ func datasourcePropertyDefinitionsRead(d *schema.ResourceData, client *opslevel.
 	}
 
 	d.SetId(timeID())
+	d.Set("allowed_in_config_files", allowedInConfigFiles)
 	d.Set("ids", ids)
 	d.Set("names", names)
 	d.Set("descriptions", descriptions)

--- a/opslevel/resource_opslevel_property_assignment.go
+++ b/opslevel/resource_opslevel_property_assignment.go
@@ -31,7 +31,7 @@ func resourcePropertyAssignment() *schema.Resource {
 			},
 			"locked": {
 				Type:        schema.TypeBool,
-				Description: "Whether or not the property is allowed to be set in opslevel.yml config files.",
+				Description: "Locked = true if the property has been set in opslevel.yml.",
 				Computed:    true,
 			},
 			"owner": {

--- a/opslevel/resource_opslevel_property_assignment.go
+++ b/opslevel/resource_opslevel_property_assignment.go
@@ -29,6 +29,11 @@ func resourcePropertyAssignment() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
+			"locked": {
+				Type:        schema.TypeBool,
+				Description: "Whether or not the property is allowed to be set in opslevel.yml config files.",
+				Computed:    true,
+			},
 			"owner": {
 				Type:        schema.TypeString,
 				Description: "The ID or alias of the entity that the property has been assigned to.",
@@ -84,6 +89,9 @@ func resourcePropertyAssignmentRead(d *schema.ResourceData, client *opslevel.Cli
 	d.SetId(fmt.Sprintf("%s:%s", ownerId, definitionId))
 
 	if err := d.Set("definition", d.Get("definition")); err != nil {
+		return err
+	}
+	if err := d.Set("locked", d.Get("locked")); err != nil {
 		return err
 	}
 	if err := d.Set("owner", d.Get("owner")); err != nil {

--- a/opslevel/resource_opslevel_property_definition.go
+++ b/opslevel/resource_opslevel_property_definition.go
@@ -17,6 +17,13 @@ func resourcePropertyDefinition() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"allowed_in_config_files": {
+				Type:        schema.TypeBool,
+				Description: "Whether or not the property is allowed to be set in opslevel.yml config files.",
+				// not required on API end - but using required here will prevent us from needing to do the hack by using
+				// 2 booleans while we wait to migrate to the next SDK version.
+				Required: true,
+			},
 			"last_updated": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -54,6 +61,7 @@ func resourcePropertyDefinitionCreate(d *schema.ResourceData, client *opslevel.C
 		return err
 	}
 	input := opslevel.PropertyDefinitionInput{
+		AllowedInConfigFiles:  opslevel.RefOf(d.Get("allowed_in_config_files").(bool)),
 		Name:                  opslevel.RefOf(d.Get("name").(string)),
 		Description:           opslevel.RefOf(d.Get("description").(string)),
 		Schema:                newJSONSchema,
@@ -76,6 +84,9 @@ func resourcePropertyDefinitionRead(d *schema.ResourceData, client *opslevel.Cli
 		return err
 	}
 
+	if err := d.Set("allowed_in_config_files", resource.AllowedInConfigFiles); err != nil {
+		return err
+	}
 	if err := d.Set("name", resource.Name); err != nil {
 		return err
 	}
@@ -99,6 +110,7 @@ func resourcePropertyDefinitionUpdate(d *schema.ResourceData, client *opslevel.C
 		return err
 	}
 	input := opslevel.PropertyDefinitionInput{
+		AllowedInConfigFiles:  opslevel.RefOf(d.Get("allowed_in_config_files").(bool)),
 		Name:                  opslevel.RefOf(d.Get("name").(string)),
 		Description:           opslevel.RefOf(d.Get("description").(string)),
 		Schema:                newJSONSchema,


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/terraform-provider-opslevel/issues/203

https://github.com/OpsLevel/opslevel-go/pull/378

## Changelog

- [x] Update properties datasource
- [x] Update properties resource
- [x] Update property definitions dataresource
- [x] Update property definitions resource
- [x] Make a `changie` entry

## Tophatting

(tophatted during demo, here's what I used)

```
# hello demo!

data "opslevel_team" "team_platform" {
  alias = "platform"
}

data "opslevel_service" "proxysql" {
  alias = "proxysql_new"
}

resource "opslevel_property_definition" "is_ready" {
  allowed_in_config_files = true
  name = "Is Ready for Demo"
  description = "is this service ready for demo?"
  schema = jsonencode({ "enum": ["not_ready", "almost_ready", "fully_ready", "not_applicable"], "type": "string" })

  property_display_status = "visible"
}

resource "opslevel_property_assignment" "proxysql_readiness" {
  definition = opslevel_property_definition.is_ready.id
  owner = data.opslevel_service.proxysql.id
  value = jsonencode("almost_ready")
}

output "res_propdef" {
  value = opslevel_property_definition.is_ready
}

output "res_assignment" {
  value = opslevel_property_assignment.proxysql_readiness
}

data "opslevel_property_definition" "get_res_prop" {
  identifier = opslevel_property_definition.is_ready.id
}

```
