### PR TITLE
fix nilaway in taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,7 +31,6 @@ tasks:
       - go get -u
       - go mod tidy
       - golangci-lint run --fix
-      - nilaway -fix -test=false ./...
       - task: terraform-format-fix
 
   lint:
@@ -39,7 +38,7 @@ tasks:
     cmds:
       - test -z "$(gofumpt -d -e . | tee /dev/stderr)"
       - golangci-lint run
-      - nilaway -test=false ./...
+      - nilaway -test=false -include-pkgs='github.com/opslevel/terraform-provider-opslevel' ./...
       - task: terraform-validate
       - task: terraform-format-check
 


### PR DESCRIPTION
* Don't use `-fix` since it's experimental and it's better for devs to manually resolve this.
* Use `-include-pkgs` to greatly speed up CI.
