### PR TITLE
add property_definition datasource, with tests

### DIFF
--- a/opslevel/datasource_opslevel_property_definition.go
+++ b/opslevel/datasource_opslevel_property_definition.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/opslevel/opslevel-go/v2024"
@@ -63,8 +61,7 @@ func (d *PropertyDefinitionDataSource) Schema(ctx context.Context, req datasourc
 				Computed:            true,
 			},
 			"description": schema.StringAttribute{
-				MarkdownDescription: "The display name of the property definition.",
-				Optional:            true,
+				MarkdownDescription: "The description of the property definition.",
 				Computed:            true,
 			},
 			"identifier": schema.StringAttribute{
@@ -80,12 +77,8 @@ func (d *PropertyDefinitionDataSource) Schema(ctx context.Context, req datasourc
 				Computed:            true,
 			},
 			"property_display_status": schema.StringAttribute{
-				MarkdownDescription: "The display name of the property definition.",
-				Validators: []validator.String{
-					stringvalidator.OneOf(opslevel.AllPropertyDisplayStatusEnum...),
-				},
-				Optional: true,
-				Computed: true,
+				MarkdownDescription: "The display status of a custom property on service pages. (Options: 'visible' or 'hidden')",
+				Computed:            true,
 			},
 			"schema": schema.StringAttribute{
 				MarkdownDescription: "The schema of the property definition.",

--- a/opslevel/datasource_opslevel_property_definition.go
+++ b/opslevel/datasource_opslevel_property_definition.go
@@ -55,7 +55,7 @@ func (d *PropertyDefinitionDataSource) Metadata(ctx context.Context, req datasou
 func (d *PropertyDefinitionDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "PropertyDefinition data source",
+		MarkdownDescription: "Data source for Property Definitions",
 
 		Attributes: map[string]schema.Attribute{
 			"allowed_in_config_files": schema.BoolAttribute{
@@ -68,7 +68,7 @@ func (d *PropertyDefinitionDataSource) Schema(ctx context.Context, req datasourc
 				Computed:            true,
 			},
 			"identifier": schema.StringAttribute{
-				MarkdownDescription: "The id or alias of the property definition to find.",
+				MarkdownDescription: "The id or alias of the property definition",
 				Required:            true,
 			},
 			"id": schema.StringAttribute{

--- a/opslevel/datasource_opslevel_property_definition.go
+++ b/opslevel/datasource_opslevel_property_definition.go
@@ -72,7 +72,7 @@ func (d *PropertyDefinitionDataSource) Schema(ctx context.Context, req datasourc
 				Required:            true,
 			},
 			"id": schema.StringAttribute{
-				MarkdownDescription: "Terraform specific identifier.",
+				MarkdownDescription: "The ID of this resource.",
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{

--- a/opslevel/datasource_opslevel_property_definition.go
+++ b/opslevel/datasource_opslevel_property_definition.go
@@ -1,67 +1,118 @@
 package opslevel
 
-// import (
-// 	"github.com/opslevel/opslevel-go/v2024"
+import (
+	"context"
+	"fmt"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// )
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func datasourcePropertyDefinition() *schema.Resource {
-// 	return &schema.Resource{
-// 		Read: wrap(datasourcePropertyDefinitionRead),
-// 		Schema: map[string]*schema.Schema{
-// 			"identifier": {
-// 				Type:        schema.TypeString,
-// 				Description: "The id or alias of the property definition to find.",
-// 				Required:    true,
-// 			},
-// 			"name": {
-// 				Type:        schema.TypeString,
-// 				Description: "The display name of the property definition.",
-// 				Computed:    true,
-// 			},
-// 			"description": {
-// 				Type:        schema.TypeString,
-// 				Description: "The description of the property definition.",
-// 				Optional:    true,
-// 				Computed:    true,
-// 			},
-// 			"schema": {
-// 				Type:        schema.TypeString,
-// 				Description: "The schema of the property definition.",
-// 				Computed:    true,
-// 			},
-// 			"property_display_status": {
-// 				Type:        schema.TypeString,
-// 				Description: "The display status of a custom property on service pages. (Options: 'visible' or 'hidden')",
-// 				Optional:    true,
-// 				Computed:    true,
-// 			},
-// 		},
-// 	}
-// }
+// Ensure PropertyDefinitionDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &PropertyDefinitionDataSource{}
 
-// func datasourcePropertyDefinitionRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	identifier := d.Get("identifier").(string)
-// 	resource, err := client.GetPropertyDefinition(identifier)
-// 	if err != nil {
-// 		return err
-// 	}
+func NewPropertyDefinitionDataSource() datasource.DataSource {
+	return &PropertyDefinitionDataSource{}
+}
 
-// 	d.SetId(string(resource.Id))
+// PropertyDefinitionDataSource manages a PropertyDefinition data source.
+type PropertyDefinitionDataSource struct {
+	CommonDataSourceClient
+}
 
-// 	if err := d.Set("name", resource.Name); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("description", resource.Description); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("schema", resource.Schema.ToJSON()); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("property_display_status", string(resource.PropertyDisplayStatus)); err != nil {
-// 		return err
-// 	}
+// PropertyDefinitionDataSourceModel describes the data source data model.
+type PropertyDefinitionDataSourceModel struct {
+	AllowedInConfigFiles  types.Bool   `tfsdk:"allowed_in_config_files"`
+	Description           types.String `tfsdk:"description"`
+	Id                    types.String `tfsdk:"id"`
+	Identifier            types.String `tfsdk:"identifier"`
+	Name                  types.String `tfsdk:"name"`
+	PropertyDisplayStatus types.String `tfsdk:"property_display_status"`
+	Schema                types.String `tfsdk:"schema"`
+}
 
-// 	return nil
-// }
+func NewPropertyDefinitionDataSourceModel(ctx context.Context, propertydefinition opslevel.PropertyDefinition, identifier string) PropertyDefinitionDataSourceModel {
+	return PropertyDefinitionDataSourceModel{
+		AllowedInConfigFiles:  types.BoolValue(propertydefinition.AllowedInConfigFiles),
+		Description:           types.StringValue(propertydefinition.Description),
+		Id:                    types.StringValue(string(propertydefinition.Id)),
+		Identifier:            types.StringValue(identifier),
+		Name:                  types.StringValue(propertydefinition.Name),
+		PropertyDisplayStatus: types.StringValue(string(propertydefinition.PropertyDisplayStatus)),
+		Schema:                types.StringValue(propertydefinition.Schema.ToJSON()),
+	}
+}
+
+func (d *PropertyDefinitionDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_property_definition"
+}
+
+func (d *PropertyDefinitionDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "PropertyDefinition data source",
+
+		Attributes: map[string]schema.Attribute{
+			"allowed_in_config_files": schema.BoolAttribute{
+				MarkdownDescription: "Whether or not the property is allowed to be set in opslevel.yml config files.",
+				Computed:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "The display name of the property definition.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"identifier": schema.StringAttribute{
+				MarkdownDescription: "The id or alias of the property definition to find.",
+				Required:            true,
+			},
+			"id": schema.StringAttribute{
+				MarkdownDescription: "Terraform specific identifier.",
+				Computed:            true,
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The display name of the property definition.",
+				Computed:            true,
+			},
+			"property_display_status": schema.StringAttribute{
+				MarkdownDescription: "The display name of the property definition.",
+				Validators: []validator.String{
+					stringvalidator.OneOf(opslevel.AllPropertyDisplayStatusEnum...),
+				},
+				Optional: true,
+				Computed: true,
+			},
+			"schema": schema.StringAttribute{
+				MarkdownDescription: "The schema of the property definition.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (d *PropertyDefinitionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data PropertyDefinitionDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	propertydefinition, err := d.client.GetPropertyDefinition(data.Identifier.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read property definition datasource, got error: %s", err))
+		return
+	}
+	propertydefinitionDataModel := NewPropertyDefinitionDataSourceModel(ctx, *propertydefinition, data.Identifier.ValueString())
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "read an OpsLevel PropertyDefinition data source")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &propertydefinitionDataModel)...)
+}

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -161,6 +161,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewDomainDataSource,
 		NewDomainDataSourcesAll,
 		NewFilterDataSource,
+		NewPropertyDefinitionDataSource,
 		NewTierDataSource,
 	}
 }

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -1,8 +1,12 @@
+# Domain data sources
+
 data "opslevel_domain" "mock_domain" {
   identifier = "example"
 }
 
 data "opslevel_domains" "all" {}
+
+# Filter data sources
 
 data "opslevel_filter" "name_filter" {
   filter {
@@ -24,6 +28,13 @@ data "opslevel_filter" "mock_filter" {
     value = "stuff"
   }
 }
+
+# PropertyDefinition data sources
+data "opslevel_property_definition" "mock_property_definition" {
+  identifier = "mock-property_definition-alias"
+}
+
+# Tier data sources
 
 data "opslevel_tier" "mock_tier" {
   filter {

--- a/tests/datasource_property_definition.tftest.hcl
+++ b/tests/datasource_property_definition.tftest.hcl
@@ -30,7 +30,7 @@ run "datasource_property_definition_mocked_fields" {
 
   assert {
     condition     = data.opslevel_property_definition.mock_property_definition.name == "mock-property-definition-name"
-    error_message = "wrong name in mock opslevel_property_definition mock"
+    error_message = "wrong name in mock opslevel_property_definition"
   }
 
   assert {

--- a/tests/datasource_property_definition.tftest.hcl
+++ b/tests/datasource_property_definition.tftest.hcl
@@ -1,0 +1,61 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_datasource"
+}
+
+run "datasource_property_definition_mocked_fields" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.allowed_in_config_files == true
+    error_message = "allowed_in_config_files in mock opslevel_property_definition not set to true"
+  }
+
+  assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.description == "mock-property-definition-description"
+    error_message = "wrong description in mock opslevel_property_definition"
+  }
+
+  assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.id != ""
+    error_message = "id in mock opslevel_property_definition was not set"
+  }
+
+  assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.identifier == "mock-property_definition-alias"
+    error_message = "wrong identifier in mock opslevel_property_definition"
+  }
+
+  assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.name == "mock-property-definition-name"
+    error_message = "wrong name in mock opslevel_property_definition mock"
+  }
+
+  assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.schema == jsonencode(
+      {
+        "$ref" : "#/$defs/MyProp",
+        "$defs" : {
+          "MyProp" : {
+            "properties" : {
+              "name" : {
+                "type" : "string",
+                "title" : "the new name",
+                "description" : "The name of a friend",
+                "default" : "alex",
+                "examples" : ["joe", "lucy"]
+              }
+            },
+            "additionalProperties" : false,
+            "type" : "object",
+            "required" : ["name"]
+          }
+        }
+      }
+    )
+    error_message = "wrong schema in mock opslevel_property_definition"
+  }
+
+}

--- a/tests/datasource_property_definition.tftest.hcl
+++ b/tests/datasource_property_definition.tftest.hcl
@@ -34,7 +34,7 @@ run "datasource_property_definition_mocked_fields" {
   }
 
   assert {
-    condition     = data.opslevel_property_definition.mock_property_definition.schema == jsonencode(
+    condition = data.opslevel_property_definition.mock_property_definition.schema == jsonencode(
       {
         "$ref" : "#/$defs/MyProp",
         "$defs" : {

--- a/tests/datasource_property_definition.tftest.hcl
+++ b/tests/datasource_property_definition.tftest.hcl
@@ -34,6 +34,11 @@ run "datasource_property_definition_mocked_fields" {
   }
 
   assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.property_display_status == "visible"
+    error_message = "wrong property_display_status in mock opslevel_property_definition"
+  }
+
+  assert {
     condition = data.opslevel_property_definition.mock_property_definition.schema == jsonencode(
       {
         "$ref" : "#/$defs/MyProp",

--- a/tests/mock_datasource/property_definition.tfmock.hcl
+++ b/tests/mock_datasource/property_definition.tfmock.hcl
@@ -1,0 +1,13 @@
+mock_data "opslevel_property_definition" {
+  defaults = {
+    allowed_in_config_files = true
+    description             = "mock-property-definition-description"
+    # id intentionally omitted - will be assigned a random string
+    name                    = "mock-property-definition-name"
+    property_display_status = "visible"
+    # schema value result of running
+    # 'jsonencode({ "$ref" : "#/$defs/MyProp", "$defs" : { "MyProp" : { "properties" : { "name" : { "type" : "string", "title" : "the new name", "description" : "The name of a friend", "default" : "alex", "examples" : ["joe", "lucy"] } }, "additionalProperties" : false, "type" : "object", "required" : ["name"] } } })'
+    schema = "{\"$defs\":{\"MyProp\":{\"additionalProperties\":false,\"properties\":{\"name\":{\"default\":\"alex\",\"description\":\"The name of a friend\",\"examples\":[\"joe\",\"lucy\"],\"title\":\"the new name\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"$ref\":\"#/$defs/MyProp\"}"
+  }
+}
+


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

## Changelog

Changes:
- Add `property_definition` datasource with tests.

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_property_definition" "pd1" {
  identifier = "is_beta_feature"
}

output "pd_schema" {
  value = data.opslevel_property_definition.pd1
}
```

Run `terraform plan`
```terraform
data.opslevel_property_definition.pd1: Reading...
data.opslevel_property_definition.pd1: Read complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi85OA]

Changes to Outputs:
  + pd_schema = {
      + allowed_in_config_files = true
      + description             = ""
      + id                      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi85OA"
      + identifier              = "is_beta_feature"
      + name                    = "Is Beta Feature"
      + property_display_status = "visible"
      + schema                  = jsonencode(
            {
              + type = "boolean"
            }
        )
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```