### PR TITLE
add rubric_category datasource, with tests

### DIFF
--- a/opslevel/datasource_opslevel_rubric_category.go
+++ b/opslevel/datasource_opslevel_rubric_category.go
@@ -1,73 +1,113 @@
 package opslevel
 
-// import (
-// 	"fmt"
+import (
+	"context"
+	"fmt"
 
-// 	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// )
+// Ensure CategoryDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &CategoryDataSource{}
 
-// func datasourceRubricCategory() *schema.Resource {
-// 	return &schema.Resource{
-// 		Read: wrap(datasourceRubricCategoryRead),
-// 		Schema: map[string]*schema.Schema{
-// 			"filter": getDatasourceFilter(true, []string{"id", "name"}),
-// 			"name": {
-// 				Type:     schema.TypeString,
-// 				Computed: true,
-// 			},
-// 		},
-// 	}
-// }
+func NewCategoryDataSource() datasource.DataSource {
+	return &CategoryDataSource{}
+}
 
-// func filterRubricCategories(levels *opslevel.CategoryConnection, field string, value string) (*opslevel.Category, error) {
-// 	if value == "" {
-// 		return nil, fmt.Errorf("Please provide a non-empty value for filter's value")
-// 	}
+// CategoryDataSource manages a Category data source.
+type CategoryDataSource struct {
+	CommonDataSourceClient
+}
 
-// 	var output opslevel.Category
-// 	found := false
-// 	for _, item := range levels.Nodes {
-// 		switch field {
-// 		case "id":
-// 			if string(item.Id) == value {
-// 				output = item
-// 				found = true
-// 			}
-// 		case "name":
-// 			if item.Name == value {
-// 				output = item
-// 				found = true
-// 			}
-// 		}
-// 		if found {
-// 			break
-// 		}
-// 	}
+// CategoryDataSourceModel describes the data source data model.
+type CategoryDataSourceModel struct {
+	Filter FilterBlockModel `tfsdk:"filter"`
+	Id     types.String     `tfsdk:"id"`
+	Name   types.String     `tfsdk:"name"`
+}
 
-// 	if !found {
-// 		return nil, fmt.Errorf("Unable to find category with: %s==%s", field, value)
-// 	}
-// 	return &output, nil
-// }
+func NewCategoryDataSourceModel(ctx context.Context, category opslevel.Category, filter FilterBlockModel) CategoryDataSourceModel {
+	return CategoryDataSourceModel{
+		Filter: filter,
+		Id:     types.StringValue(string(category.Id)),
+		Name:   types.StringValue(category.Name),
+	}
+}
 
-// func datasourceRubricCategoryRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	results, err := client.ListCategories(nil)
-// 	if err != nil {
-// 		return err
-// 	}
+func (d *CategoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_rubric_category"
+}
 
-// 	field := d.Get("filter.0.field").(string)
-// 	value := d.Get("filter.0.value").(string)
+func (d *CategoryDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	validFieldNames := []string{"id", "name"}
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Rubric Category data source",
 
-// 	item, itemErr := filterRubricCategories(results, field, value)
-// 	if itemErr != nil {
-// 		return itemErr
-// 	}
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The ID of this resource.",
+				Computed:            true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the rubric category.",
+				Computed:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"filter": getDatasourceFilter(validFieldNames),
+		},
+	}
+}
 
-// 	d.SetId(string(item.Id))
-// 	d.Set("name", item.Name)
+func (d *CategoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data CategoryDataSourceModel
 
-// 	return nil
-// }
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	categories, err := d.client.ListCategories(nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read rubric_category datasource, got error: %s", err))
+		return
+	}
+
+	category, err := filterRubricCategories(categories.Nodes, data.Filter)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to filter rubric_category datasource, got error: %s", err))
+		return
+	}
+
+	categoryDataModel := NewCategoryDataSourceModel(ctx, *category, data.Filter)
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "read an OpsLevel Rubric Category data source")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &categoryDataModel)...)
+}
+
+func filterRubricCategories(categories []opslevel.Category, filter FilterBlockModel) (*opslevel.Category, error) {
+	if filter.Value.Equal(types.StringValue("")) {
+		return nil, fmt.Errorf("Please provide a non-empty value for filter's value")
+	}
+	for _, category := range categories {
+		switch filter.Field.ValueString() {
+		case "id":
+			if filter.Value.Equal(types.StringValue(string(category.Id))) {
+				return &category, nil
+			}
+		case "name":
+			if filter.Value.Equal(types.StringValue(category.Name)) {
+				return &category, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("Unable to find category with: %s==%s", filter.Field, filter.Value)
+}

--- a/opslevel/datasource_opslevel_tier.go
+++ b/opslevel/datasource_opslevel_tier.go
@@ -106,7 +106,6 @@ func (d *TierDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &tierDataModel)...)
 }
 
-// func filterTiers(levels []opslevel.Tier, field string, value string) (*opslevel.Tier, error) {
 func filterTiers(tiers []opslevel.Tier, filter FilterBlockModel) (*opslevel.Tier, error) {
 	if filter.Value.Equal(types.StringValue("")) {
 		return nil, fmt.Errorf("Please provide a non-empty value for filter's value")

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -158,6 +158,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 
 func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewCategoryDataSource,
 		NewDomainDataSource,
 		NewDomainDataSourcesAll,
 		NewFilterDataSource,

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -25,6 +25,20 @@ data "opslevel_filter" "mock_filter" {
   }
 }
 
+data "opslevel_rubric_category" "name_filter" {
+  filter {
+    field = "name"
+    value = "name-value"
+  }
+}
+
+data "opslevel_rubric_category" "id_filter" {
+  filter {
+    field = "id"
+    value = "Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+  }
+}
+
 data "opslevel_tier" "mock_tier" {
   filter {
     field = "alias"

--- a/tests/datasource_rubric_category.tftest.hcl
+++ b/tests/datasource_rubric_category.tftest.hcl
@@ -1,0 +1,49 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_datasource"
+}
+
+run "datasource_rubric_category_filter_by_id" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_category.id_filter.id != ""
+    error_message = "id in opslevel_rubric_category mock was not set"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_category.id_filter.name == "mock-rubric-category-name"
+    error_message = "wrong name in opslevel_rubric_category"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_category.id_filter.filter.field == "id"
+    error_message = "filter field should be id"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_category.id_filter.filter.value == "Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+    error_message = "filter value for opslevel_rubric_category.id_filter should be Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+  }
+
+}
+
+run "datasource_rubric_category_filter_by_name" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_category.name_filter.filter.field == "name"
+    error_message = "filter field should be name"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_category.name_filter.filter.value == "name-value"
+    error_message = "filter value for opslevel_rubric_category.name_filter should be name-value"
+  }
+
+}
+

--- a/tests/mock_datasource/rubric_category.tfmock.hcl
+++ b/tests/mock_datasource/rubric_category.tfmock.hcl
@@ -1,0 +1,9 @@
+mock_data "opslevel_rubric_category" {
+  defaults = {
+    name  = "mock-rubric-category-name"
+    # filter is not set here because its fields are not computed
+    # id intentionally omitted - will be assigned a random string
+  }
+}
+
+


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

## Changelog

Changes:
- Add `rubric_category` datasource with tests.

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_rubric_category" "security" {
  filter {
    field = "name"
    value = "Security"
  }
}

data "opslevel_rubric_category" "scalability" {
  filter {
    field = "id"
    value = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI0"
  }
}

output "cat_sec" {
  value = data.opslevel_rubric_category.security
}

output "cat_scalability" {
  value = data.opslevel_rubric_category.scalability
}
```

Run `terraform plan`
```terraform
data.opslevel_rubric_category.scalability: Reading...
data.opslevel_rubric_category.security: Reading...
data.opslevel_rubric_category.security: Read complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDIx]
data.opslevel_rubric_category.scalability: Read complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI0]

Changes to Outputs:
  + cat_scalability = {
      + filter = {
          + field = "id"
          + value = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI0"
        }
      + id     = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI0"
      + name   = "Scalability"
    }
  + cat_sec = {
      + filter = {
          + field = "name"
          + value = "Security"
        }
      + id     = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDIx"
      + name   = "Security"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```