### PR TITLE
add rubric_level datasource, with tests

### DIFF
--- a/opslevel/datasource_opslevel_rubric_level.go
+++ b/opslevel/datasource_opslevel_rubric_level.go
@@ -1,94 +1,136 @@
 package opslevel
 
-// import (
-// 	"fmt"
-// 	"strconv"
+import (
+	"context"
+	"fmt"
+	"strconv"
 
-// 	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// )
+// Ensure LevelDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &LevelDataSource{}
 
-// func datasourceRubricLevel() *schema.Resource {
-// 	return &schema.Resource{
-// 		Read: wrap(datasourceRubricLevelRead),
-// 		Schema: map[string]*schema.Schema{
-// 			"filter": getDatasourceFilter(true, []string{"alias", "id", "index", "name"}),
-// 			"alias": {
-// 				Type:     schema.TypeString,
-// 				Computed: true,
-// 			},
-// 			"index": {
-// 				Type:     schema.TypeInt,
-// 				Computed: true,
-// 			},
-// 			"name": {
-// 				Type:     schema.TypeString,
-// 				Computed: true,
-// 			},
-// 		},
-// 	}
-// }
+func NewLevelDataSource() datasource.DataSource {
+	return &LevelDataSource{}
+}
 
-// func filterRubricLevels(levels []opslevel.Level, field string, value string) (*opslevel.Level, error) {
-// 	if value == "" {
-// 		return nil, fmt.Errorf("Please provide a non-empty value for filter's value")
-// 	}
+// LevelDataSource manages a Level data source.
+type LevelDataSource struct {
+	CommonDataSourceClient
+}
 
-// 	var output opslevel.Level
-// 	found := false
-// 	for _, item := range levels {
-// 		switch field {
-// 		case "alias":
-// 			if item.Alias == value {
-// 				output = item
-// 				found = true
-// 			}
-// 		case "id":
-// 			if string(item.Id) == value {
-// 				output = item
-// 				found = true
-// 			}
-// 		case "index":
-// 			if v, err := strconv.Atoi(value); err == nil && item.Index == v {
-// 				output = item
-// 				found = true
-// 			}
-// 		case "name":
-// 			if item.Name == value {
-// 				output = item
-// 				found = true
-// 			}
-// 		}
-// 		if found {
-// 			break
-// 		}
-// 	}
+// LevelDataSourceModel describes the data source data model.
+type LevelDataSourceModel struct {
+	Alias  types.String     `tfsdk:"alias"`
+	Filter FilterBlockModel `tfsdk:"filter"`
+	Id     types.String     `tfsdk:"id"`
+	Index  types.Int64      `tfsdk:"index"`
+	Name   types.String     `tfsdk:"name"`
+}
 
-// 	if !found {
-// 		return nil, fmt.Errorf("Unable to find level with: %s==%s", field, value)
-// 	}
-// 	return &output, nil
-// }
+func NewLevelDataSourceModel(ctx context.Context, level opslevel.Level, filter FilterBlockModel) LevelDataSourceModel {
+	return LevelDataSourceModel{
+		Alias:  types.StringValue(string(level.Alias)),
+		Filter: filter,
+		Id:     types.StringValue(string(level.Id)),
+		Index:  types.Int64Value(int64(level.Index)),
+		Name:   types.StringValue(string(level.Name)),
+	}
+}
 
-// func datasourceRubricLevelRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	results, err := client.ListLevels()
-// 	if err != nil {
-// 		return err
-// 	}
+func (d *LevelDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_rubric_level"
+}
 
-// 	field := d.Get("filter.0.field").(string)
-// 	value := d.Get("filter.0.value").(string)
+func (d *LevelDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	validFieldNames := []string{"alias", "id", "index", "name"}
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Rubric Level data source",
 
-// 	item, itemErr := filterRubricLevels(results, field, value)
-// 	if itemErr != nil {
-// 		return itemErr
-// 	}
+		Attributes: map[string]schema.Attribute{
+			"alias": schema.StringAttribute{
+				MarkdownDescription: "An alias of the rubric level to find by.",
+				Computed:            true,
+			},
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The ID of this resource.",
+				Computed:            true,
+			},
+			"index": schema.Int64Attribute{
+				MarkdownDescription: "An integer allowing this level to be inserted between others.",
+				Computed:            true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The display name of the rubric level.",
+				Computed:    true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"filter": getDatasourceFilter(validFieldNames),
+		},
+	}
+}
 
-// 	d.SetId(string(item.Id))
-// 	d.Set("alias", item.Alias)
-// 	d.Set("index", item.Index)
-// 	d.Set("name", item.Name)
+func (d *LevelDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data LevelDataSourceModel
 
-// 	return nil
-// }
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	levels, err := d.client.ListLevels()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read rubric_level datasource, got error: %s", err))
+		return
+	}
+
+	level, err := filterRubricLevels(levels, data.Filter)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to filter rubric_level datasource, got error: %s", err))
+		return
+	}
+
+	levelDataModel := NewLevelDataSourceModel(ctx, *level, data.Filter)
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "read an OpsLevel Rubric Level data source")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &levelDataModel)...)
+}
+
+func filterRubricLevels(levels []opslevel.Level, filter FilterBlockModel) (*opslevel.Level, error) {
+	if filter.Value.Equal(types.StringValue("")) {
+		return nil, fmt.Errorf("Please provide a non-empty value for filter's value")
+	}
+	for _, level := range levels {
+		switch filter.Field.ValueString() {
+		case "alias":
+			if filter.Value.Equal(types.StringValue(level.Alias)) {
+				return &level, nil
+			}
+		case "id":
+			if filter.Value.Equal(types.StringValue(string(level.Id))) {
+				return &level, nil
+			}
+		case "index":
+			index := strconv.Itoa(int(level.Index))
+			if filter.Value.Equal(types.StringValue(index)) {
+				return &level, nil
+			}
+		case "name":
+			if filter.Value.Equal(types.StringValue(level.Name)) {
+				return &level, nil
+			}
+
+		}
+	}
+
+	return nil, fmt.Errorf("Unable to find rubric level with: %s==%s", filter.Field, filter.Value)
+}

--- a/opslevel/datasource_opslevel_tier.go
+++ b/opslevel/datasource_opslevel_tier.go
@@ -50,24 +50,23 @@ func (d *TierDataSource) Metadata(ctx context.Context, req datasource.MetadataRe
 func (d *TierDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	validFieldNames := []string{"alias", "id", "index", "name"}
 	resp.Schema = schema.Schema{
-		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Tier data source",
 
 		Attributes: map[string]schema.Attribute{
 			"alias": schema.StringAttribute{
-				MarkdownDescription: "Terraform specific identifier.",
+				MarkdownDescription: "The human-friendly, unique identifier for the tier.",
 				Computed:            true,
 			},
 			"id": schema.StringAttribute{
-				MarkdownDescription: "Terraform specific identifier.",
+				MarkdownDescription: "The unique identifier for the tier.",
 				Computed:            true,
 			},
 			"index": schema.Int64Attribute{
-				MarkdownDescription: "Terraform specific identifier.",
+				MarkdownDescription: "The numerical representation of the tier.",
 				Computed:            true,
 			},
 			"name": schema.StringAttribute{
-				Description: "The name of the domain.",
+				Description: "The display name of the tier.",
 				Computed:    true,
 			},
 		},

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -161,6 +161,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewDomainDataSource,
 		NewDomainDataSourcesAll,
 		NewFilterDataSource,
+		NewLevelDataSource,
 		NewPropertyDefinitionDataSource,
 		NewTierDataSource,
 	}

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -30,8 +30,39 @@ data "opslevel_filter" "mock_filter" {
 }
 
 # PropertyDefinition data sources
+
 data "opslevel_property_definition" "mock_property_definition" {
   identifier = "mock-property_definition-alias"
+}
+
+# rubric Level data sources
+
+data "opslevel_rubric_level" "alias_filter" {
+  filter {
+    field = "alias"
+    value = "alias-value"
+  }
+}
+
+data "opslevel_rubric_level" "id_filter" {
+  filter {
+    field = "id"
+    value = "Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+  }
+}
+
+data "opslevel_rubric_level" "index_filter" {
+  filter {
+    field = "index"
+    value = 123
+  }
+}
+
+data "opslevel_rubric_level" "name_filter" {
+  filter {
+    field = "name"
+    value = "name-value"
+  }
 }
 
 # Tier data sources

--- a/tests/datasource_rubric_level.tftest.hcl
+++ b/tests/datasource_rubric_level.tftest.hcl
@@ -19,8 +19,8 @@ run "datasource_rubric_level_mocked_fields" {
   }
 
   assert {
-    condition     = data.opslevel_rubric_level.id_filter.index == 0
-    error_message = "index in opslevel_rubric_level should default to int type 0"
+    condition     = data.opslevel_rubric_level.id_filter.index == 321
+    error_message = "wrong index in opslevel_rubric_level"
   }
 
   assert {

--- a/tests/datasource_rubric_level.tftest.hcl
+++ b/tests/datasource_rubric_level.tftest.hcl
@@ -1,0 +1,98 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_datasource"
+}
+
+run "datasource_rubric_level_mocked_fields" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.id_filter.alias == "mock-rubric-level-alias"
+    error_message = "wrong alias in opslevel_rubric_level mock"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.id_filter.id != ""
+    error_message = "id in opslevel_rubric_level mock was not set"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.id_filter.index == 0
+    error_message = "index in opslevel_rubric_level should default to int type 0"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.id_filter.name == "mock-rubric-level-name"
+    error_message = "wrong name in opslevel_rubric_level"
+  }
+}
+
+run "datasource_rubric_level_filter_by_alias" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.alias_filter.filter.field == "alias"
+    error_message = "filter field for opslevel_rubric_level.alias_filter should be alias"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.alias_filter.filter.value == "alias-value"
+    error_message = "filter value for opslevel_rubric_level.alias_filter should be alias-value"
+  }
+
+}
+
+run "datasource_rubric_level_filter_by_id" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.id_filter.filter.field == "id"
+    error_message = "filter field should be id"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.id_filter.filter.value == "Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+    error_message = "filter value for opslevel_rubric_level.id_filter should be Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+  }
+
+}
+
+run "datasource_rubric_level_filter_by_index" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.index_filter.filter.field == "index"
+    error_message = "filter field should be id"
+  }
+
+  assert {
+    condition     = tonumber(data.opslevel_rubric_level.index_filter.filter.value) == 123
+    error_message = "filter value for opslevel_rubric_level.index_filter should be 123"
+  }
+
+}
+
+run "datasource_rubric_level_filter_by_name" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.name_filter.filter.field == "name"
+    error_message = "filter field should be name"
+  }
+
+  assert {
+    condition     = data.opslevel_rubric_level.name_filter.filter.value == "name-value"
+    error_message = "filter value for opslevel_rubric_level.name_filter should be name-value"
+  }
+
+}

--- a/tests/datasource_rubric_level.tftest.hcl
+++ b/tests/datasource_rubric_level.tftest.hcl
@@ -70,7 +70,7 @@ run "datasource_rubric_level_filter_by_index" {
 
   assert {
     condition     = data.opslevel_rubric_level.index_filter.filter.field == "index"
-    error_message = "filter field should be id"
+    error_message = "filter field should be index"
   }
 
   assert {

--- a/tests/datasource_tier.tftest.hcl
+++ b/tests/datasource_tier.tftest.hcl
@@ -63,6 +63,22 @@ run "datasource_tier_filter_by_id" {
 
 }
 
+run "datasource_tier_filter_by_index" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_tier.index_filter.filter.field == "index"
+    error_message = "filter field should be id"
+  }
+
+  assert {
+    condition     = tonumber(data.opslevel_tier.index_filter.filter.value) == 123
+    error_message = "filter value for opslevel_tier.index_filter should be 123"
+  }
+
+}
 run "datasource_tier_filter_by_name" {
   providers = {
     opslevel = opslevel.fake

--- a/tests/datasource_tier.tftest.hcl
+++ b/tests/datasource_tier.tftest.hcl
@@ -19,8 +19,8 @@ run "datasource_tier_mocked_fields" {
   }
 
   assert {
-    condition     = data.opslevel_tier.mock_tier.index == 0
-    error_message = "index in opslevel_tier should default to int type 0"
+    condition     = data.opslevel_tier.mock_tier.index == 321
+    error_message = "wrong index in opslevel_tier"
   }
 
   assert {

--- a/tests/mock_datasource/rubric_level.tfmock.hcl
+++ b/tests/mock_datasource/rubric_level.tfmock.hcl
@@ -1,9 +1,9 @@
 mock_data "opslevel_rubric_level" {
   defaults = {
     alias = "mock-rubric-level-alias"
-    name  = "mock-rubric-level-name"
     # filter is not set here because its fields are not computed
     # id intentionally omitted - will be assigned a random string
-    # index intentionally omitted - defaults to number type 0
+    index = 321
+    name  = "mock-rubric-level-name"
   }
 }

--- a/tests/mock_datasource/rubric_level.tfmock.hcl
+++ b/tests/mock_datasource/rubric_level.tfmock.hcl
@@ -1,0 +1,9 @@
+mock_data "opslevel_rubric_level" {
+  defaults = {
+    alias = "mock-rubric-level-alias"
+    name  = "mock-rubric-level-name"
+    # filter is not set here because its fields are not computed
+    # id intentionally omitted - will be assigned a random string
+    # index intentionally omitted - defaults to number type 0
+  }
+}

--- a/tests/mock_datasource/tier.tfmock.hcl
+++ b/tests/mock_datasource/tier.tfmock.hcl
@@ -1,10 +1,10 @@
 mock_data "opslevel_tier" {
   defaults = {
     alias = "mock-tier-alias"
-    name  = "mock-tier-name"
     # filter is not set here because its fields are not computed
     # id intentionally omitted - will be assigned a random string
-    # index intentionally omitted - defaults to number type 0
+    index = 321
+    name  = "mock-tier-name"
   }
 }
 


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

## Changelog

Changes:
- Add `rubric_level` datasource with tests.

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_rubric_level" "good" {
  filter {
    field = "alias"
    value = "good"
  }
}

data "opslevel_rubric_level" "second" {
  filter {
    field = "index"
    value = 2
  }
}

data "opslevel_rubric_level" "amazing" {
  filter {
    field = "id"
    value = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvODgz"
  }
}

data "opslevel_rubric_level" "ultimate" {
  filter {
    field = "name"
    value = "Ultimate"
  }
}


output "amazing" {
  value = data.opslevel_rubric_level.amazing
}

output "second" {
  value = data.opslevel_rubric_level.second
}

output "good" {
  value = data.opslevel_rubric_level.good
}

output "ultimate" {
  value = data.opslevel_rubric_level.ultimate
}
```

Run `terraform plan`
```terraform
data.opslevel_rubric_level.ultimate: Reading...
data.opslevel_rubric_level.amazing: Reading...
data.opslevel_rubric_level.good: Reading...
data.opslevel_rubric_level.second: Reading...
data.opslevel_rubric_level.amazing: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvODgz]
data.opslevel_rubric_level.second: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMTU]
data.opslevel_rubric_level.good: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMTQ]
data.opslevel_rubric_level.ultimate: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTYy]

Changes to Outputs:
  + amazing  = {
      + alias  = "amazing_3"
      + filter = {
          + field = "id"
          + value = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvODgz"
        }
      + id     = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvODgz"
      + index  = 5
      + name   = "Amazing"
    }
  + good     = {
      + alias  = "good"
      + filter = {
          + field = "alias"
          + value = "good"
        }
      + id     = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMTQ"
      + index  = 1
      + name   = "Good"
    }
  + second   = {
      + alias  = "silver"
      + filter = {
          + field = "index"
          + value = "2"
        }
      + id     = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMTU"
      + index  = 2
      + name   = "🥈Silver"
    }
  + ultimate = {
      + alias  = "ultimate"
      + filter = {
          + field = "name"
          + value = "Ultimate"
        }
      + id     = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTYy"
      + index  = 6
      + name   = "Ultimate"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```