### PR TITLE
add webhook_action datasource, with tests

### DIFF
--- a/opslevel/datasource_opslevel_webhook_action.go
+++ b/opslevel/datasource_opslevel_webhook_action.go
@@ -1,72 +1,125 @@
 package opslevel
 
-// import (
-// 	"github.com/opslevel/opslevel-go/v2024"
+import (
+	"context"
+	"fmt"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// )
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func datasourceWebhookAction() *schema.Resource {
-// 	return &schema.Resource{
-// 		Read: wrap(datasourceWebhookActionRead),
-// 		Schema: map[string]*schema.Schema{
-// 			"identifier": {
-// 				Type:        schema.TypeString,
-// 				Description: "The id or alias of the webhook action to find.",
-// 				ForceNew:    true,
-// 				Optional:    true,
-// 			},
-// 			"name": {
-// 				Type:        schema.TypeString,
-// 				Description: "The name of the Webhook Action.",
-// 				Computed:    true,
-// 			},
-// 			"description": {
-// 				Type:        schema.TypeString,
-// 				Description: "The description of the Webhook Action.",
-// 				Computed:    true,
-// 			},
-// 			"payload": {
-// 				Type:        schema.TypeString,
-// 				Description: "Template that can be used to generate a webhook payload.",
-// 				Computed:    true,
-// 			},
-// 			"url": {
-// 				Type:        schema.TypeString,
-// 				Description: "The URL of the Webhook Action.",
-// 				Computed:    true,
-// 			},
-// 			"method": {
-// 				Type:        schema.TypeString,
-// 				Description: "The http method used to call the Webhook Action.",
-// 				Computed:    true,
-// 			},
-// 			"headers": {
-// 				Type:        schema.TypeMap,
-// 				Description: "HTTP headers to be passed along with your webhook when triggered.",
-// 				Computed:    true,
-// 				Elem: &schema.Schema{
-// 					Type: schema.TypeString,
-// 				},
-// 			},
-// 		},
-// 	}
-// }
+// Ensure WebhookActionDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &WebhookActionDataSource{}
 
-// func datasourceWebhookActionRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	identifier := d.Get("identifier").(string)
-// 	resource, err := client.GetCustomAction(identifier)
-// 	if err != nil {
-// 		return err
-// 	}
+func NewWebhookActionDataSource() datasource.DataSource {
+	return &WebhookActionDataSource{}
+}
 
-// 	d.SetId(string(resource.Id))
-// 	d.Set("name", resource.Name)
-// 	d.Set("description", resource.Description)
-// 	d.Set("payload", resource.LiquidTemplate)
-// 	d.Set("url", resource.WebhookURL)
-// 	d.Set("method", resource.HTTPMethod)
-// 	d.Set("headers", resource.Headers)
+// WebhookActionDataSource manages a WebhookAction data source.
+type WebhookActionDataSource struct {
+	CommonDataSourceClient
+}
 
-// 	return nil
-// }
+// WebhookActionDataSourceModel describes the data source data model.
+type WebhookActionDataSourceModel struct {
+	Description types.String `tfsdk:"description"`
+	Headers     types.Map    `tfsdk:"headers"`
+	Identifier  types.String `tfsdk:"identifier"`
+	Method      types.String `tfsdk:"method"`
+	Name        types.String `tfsdk:"name"`
+	Payload     types.String `tfsdk:"payload"`
+	Url         types.String `tfsdk:"url"`
+}
+
+func jsonToMap(json map[string]any) map[string]attr.Value {
+	jsonAttrs := make(map[string]attr.Value)
+	for k, v := range json {
+		jsonAttrs[k] = types.StringValue(v.(string))
+		if v == nil {
+			jsonAttrs[k] = types.StringNull()
+		}
+	}
+	return jsonAttrs
+}
+
+func NewWebhookActionDataSourceModel(ctx context.Context, webhookAction opslevel.CustomActionsExternalAction, identifier string) WebhookActionDataSourceModel {
+	jsonAttrs := jsonToMap(webhookAction.Headers)
+	webhookActionDataSourceModel := WebhookActionDataSourceModel{
+		Description: types.StringValue(webhookAction.Description),
+		Headers:     types.MapValueMust(types.StringType, jsonAttrs),
+		Identifier:  types.StringValue(identifier),
+		Method:      types.StringValue(string(webhookAction.CustomActionsWebhookAction.HTTPMethod)),
+		Name:        types.StringValue(webhookAction.Name),
+		Payload:     types.StringValue(webhookAction.LiquidTemplate),
+		Url:         types.StringValue(webhookAction.CustomActionsWebhookAction.WebhookURL),
+	}
+
+	return webhookActionDataSourceModel
+}
+
+func (d *WebhookActionDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_webhook_action"
+}
+
+func (d *WebhookActionDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "WebhookAction data source",
+
+		Attributes: map[string]schema.Attribute{
+			"description": schema.StringAttribute{
+				Description: "The description of the Webhook Action.",
+				Computed:    true,
+			},
+			"headers": schema.MapAttribute{
+				ElementType: types.StringType,
+				Description: "HTTP headers to be passed along with your webhook when triggered.",
+				Computed:    true,
+			},
+			"identifier": schema.StringAttribute{
+				Description: "The id or alias of the Webhook Action to find.",
+				Required:    true,
+			},
+			"method": schema.StringAttribute{
+				Description: "The http method used to call the Webhook Action.",
+				Computed:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the Webhook Action.",
+				Computed:    true,
+			},
+			"payload": schema.StringAttribute{
+				Description: "Template that can be used to generate a webhook payload.",
+				Computed:    true,
+			},
+			"url": schema.StringAttribute{
+				Description: "The URL of the Webhook Action.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *WebhookActionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data WebhookActionDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	webhookAction, err := d.client.GetCustomAction(data.Identifier.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read webhookAction datasource, got error: %s", err))
+		return
+	}
+	webhookActionDataModel := NewWebhookActionDataSourceModel(ctx, *webhookAction, data.Identifier.ValueString())
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "read an OpsLevel WebhookAction data source")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &webhookActionDataModel)...)
+}

--- a/opslevel/datasource_opslevel_webhook_action.go
+++ b/opslevel/datasource_opslevel_webhook_action.go
@@ -38,8 +38,9 @@ type WebhookActionDataSourceModel struct {
 func jsonToMap(json map[string]any) map[string]attr.Value {
 	jsonAttrs := make(map[string]attr.Value)
 	for k, v := range json {
-		jsonAttrs[k] = types.StringValue(v.(string))
-		if v == nil {
+		if value, ok := v.(string); ok {
+			jsonAttrs[k] = types.StringValue(value)
+		} else {
 			jsonAttrs[k] = types.StringNull()
 		}
 	}

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -165,6 +165,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewLevelDataSource,
 		NewPropertyDefinitionDataSource,
 		NewTierDataSource,
+		NewWebhookActionDataSource,
 	}
 }
 

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -115,3 +115,9 @@ data "opslevel_tier" "name_filter" {
     value = "name-value"
   }
 }
+
+# Webhook Action data sources
+
+data "opslevel_webhook_action" "mock_webhook_action" {
+  identifier = "mock-webhook-action-alias"
+}

--- a/tests/datasource_webhook_action.tftest.hcl
+++ b/tests/datasource_webhook_action.tftest.hcl
@@ -1,0 +1,51 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_datasource"
+}
+
+run "datasource_webhook_action_mocked_fields" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_webhook_action.mock_webhook_action.description == "mock-webhook-action-description"
+    error_message = "wrong description in opslevel_webhook_action mock"
+  }
+
+  assert {
+    condition     = data.opslevel_webhook_action.mock_webhook_action.identifier == "mock-webhook-action-alias"
+    error_message = "wrong identifier in opslevel_webhook_action mock"
+  }
+
+  assert {
+    condition     = data.opslevel_webhook_action.mock_webhook_action.headers["Accept"] == "application/json"
+    error_message = "wrong 'Accept' header in opslevel_webhook_action mock"
+  }
+
+  assert {
+    condition     = data.opslevel_webhook_action.mock_webhook_action.headers["Content-Type"] == "application/json"
+    error_message = "wrong 'Content-Type' header in opslevel_webhook_action mock"
+  }
+
+  assert {
+    condition     = data.opslevel_webhook_action.mock_webhook_action.headers["Authorization"] == "Basic cXTlcjpeYPNzd29fZA=="
+    error_message = "wrong 'Authorization' header in opslevel_webhook_action mock"
+  }
+
+  assert {
+    condition     = contains(["GET", "PATCH", "POST", "PUT", "DELETE"], data.opslevel_webhook_action.mock_webhook_action.method)
+    error_message = "wrong method in opslevel_webhook_action mock"
+  }
+
+  assert {
+    condition     = data.opslevel_webhook_action.mock_webhook_action.name == "mock-domain-name"
+    error_message = "wrong name in opslevel_webhook_action mock"
+  }
+
+  assert {
+    condition     = data.opslevel_webhook_action.mock_webhook_action.url == "https://www.opslevel.com/"
+    error_message = "wrong url in opslevel_webhook_action mock"
+  }
+
+}

--- a/tests/mock_datasource/webhook_action.tfmock.hcl
+++ b/tests/mock_datasource/webhook_action.tfmock.hcl
@@ -2,14 +2,14 @@ mock_data "opslevel_webhook_action" {
   defaults = {
     description = "mock-webhook-action-description"
     headers = {
-      "Accept" = "application/json"
-      "Content-Type" = "application/json"
+      "Accept"        = "application/json"
+      "Content-Type"  = "application/json"
       "Authorization" = "Basic cXTlcjpeYPNzd29fZA=="
     }
-    method = "GET"
-    name        = "mock-domain-name"
+    method  = "GET"
+    name    = "mock-domain-name"
     payload = "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}"
-    url = "https://www.opslevel.com/"
+    url     = "https://www.opslevel.com/"
   }
 }
 

--- a/tests/mock_datasource/webhook_action.tfmock.hcl
+++ b/tests/mock_datasource/webhook_action.tfmock.hcl
@@ -1,0 +1,15 @@
+mock_data "opslevel_webhook_action" {
+  defaults = {
+    description = "mock-webhook-action-description"
+    headers = {
+      "Accept" = "application/json"
+      "Content-Type" = "application/json"
+      "Authorization" = "Basic cXTlcjpeYPNzd29fZA=="
+    }
+    method = "GET"
+    name        = "mock-domain-name"
+    payload = "{\"token\": \"XXX\", \"ref\":\"main\", \"action\": \"rollback\"}"
+    url = "https://www.opslevel.com/"
+  }
+}
+


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

## Changelog

Changes:
- Add `webhook_action` datasource with tests.

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_webhook_action" "example" {
  identifier = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8zNjk"
}

output "webhook_action" {
  value = data.opslevel_webhook_action.example
}
```

Run `terraform plan`
```terraform
data.opslevel_webhook_action.example: Reading...
data.opslevel_webhook_action.example: Read complete after 0s [name=Page The On Call]

Changes to Outputs:
  + webhook_action = {
      + description = "Pages the On Call"
      + headers     = {
          + accept        = "application/vnd.pagerduty+json;version=2"
          + authorization = "Token token=XXXXXXXXXXXXXX"
          + content-type  = "application/json"
          + from          = "john@opslevel.com"
        }
      + identifier  = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi8zNjk"
      + method      = "POST"
      + name        = "Page The On Call"
      + payload     = jsonencode(
            {
              + incident = {
                  + body    = {
                      + details = "Incident triggered from OpsLevel by {{user.name}} with the email {{user.email}}. {{manualInputs.IncidentDescription}}"
                      + type    = "incident_body"
                    }
                  + service = {
                      + id   = "{{ service | tag_value: 'pd_id' }}"
                      + type = "service_reference"
                    }
                  + title   = "{{manualInputs.IncidentTitle}}"
                  + type    = "incident"
                }
            }
        )
      + url         = "https://api.pagerduty.com/incidents"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```