### PR TITLE
add user datasource, with tests

### DIFF
--- a/.changes/unreleased/Feature-20240322-131940.yaml
+++ b/.changes/unreleased/Feature-20240322-131940.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add user datasource
+time: 2024-03-22T13:19:40.014451-05:00

--- a/opslevel/datasource_opslevel_user.go
+++ b/opslevel/datasource_opslevel_user.go
@@ -1,0 +1,98 @@
+package opslevel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
+
+// Ensure UserDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &UserDataSource{}
+
+func NewUserDataSource() datasource.DataSource {
+	return &UserDataSource{}
+}
+
+// UserDataSource manages a User data source.
+type UserDataSource struct {
+	CommonDataSourceClient
+}
+
+// UserDataSourceModel describes the data source data model.
+type UserDataSourceModel struct {
+	Email      types.String `tfsdk:"email"`
+	Id         types.String `tfsdk:"id"`
+	Identifier types.String `tfsdk:"identifier"`
+	Name       types.String `tfsdk:"name"`
+	Role       types.String `tfsdk:"role"`
+}
+
+func NewUserDataSourceModel(ctx context.Context, user opslevel.User, identifier string) UserDataSourceModel {
+	return UserDataSourceModel{
+		Email:      types.StringValue(user.Email),
+		Id:         types.StringValue(string(user.Id)),
+		Identifier: types.StringValue(identifier),
+		Name:       types.StringValue(user.Name),
+		Role:       types.StringValue(string(user.Role)),
+	}
+}
+
+func (d *UserDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user"
+}
+
+func (d *UserDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "User data source",
+
+		Attributes: map[string]schema.Attribute{
+			"email": schema.StringAttribute{
+				Description: "The email of the user.",
+				Computed:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "The unique identifier for the user.",
+				Computed:    true,
+			},
+			"identifier": schema.StringAttribute{
+				Description: "The id or email of the user to find.",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the user.",
+				Computed:    true,
+			},
+			"role": schema.StringAttribute{
+				Description: "The user's assigned role.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data UserDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	user, err := d.client.GetUser(data.Identifier.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, got error: %s", err))
+		return
+	}
+	userDataModel := NewUserDataSourceModel(ctx, *user, data.Identifier.ValueString())
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "read an OpsLevel User data source")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &userDataModel)...)
+}

--- a/opslevel/datasource_opslevel_user.go
+++ b/opslevel/datasource_opslevel_user.go
@@ -87,7 +87,7 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	user, err := d.client.GetUser(data.Identifier.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 		return
 	}
 	userDataModel := NewUserDataSourceModel(ctx, *user, data.Identifier.ValueString())

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -168,6 +168,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewServiceDataSource,
 		NewSystemDataSource,
 		NewTierDataSource,
+		NewUserDataSource,
 	}
 }
 

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -137,3 +137,9 @@ data "opslevel_tier" "name_filter" {
     value = "name-value"
   }
 }
+
+# User data sources
+
+data "opslevel_user" "mock_user" {
+  identifier = "mock-user-name@example.com"
+}

--- a/tests/datasource_user.tftest.hcl
+++ b/tests/datasource_user.tftest.hcl
@@ -1,0 +1,36 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_datasource"
+}
+
+run "datasource_user" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_user.mock_user.email == "mock-user-name@example.com"
+    error_message = "wrong email address of opslevel_user"
+  }
+
+  assert {
+    condition     = data.opslevel_user.mock_user.id != null && data.opslevel_user.mock_user.id != ""
+    error_message = "opslevel_user id should not be empty"
+  }
+
+  assert {
+    condition     = contains([data.opslevel_user.mock_user.email, data.opslevel_user.mock_user.id], data.opslevel_user.mock_user.identifier)
+    error_message = "wrong identifier of opslevel_user, should match id or email"
+  }
+
+  assert {
+    condition     = data.opslevel_user.mock_user.name == "mock-user-name"
+    error_message = "wrong name of opslevel_user"
+  }
+
+  assert {
+    condition     = data.opslevel_user.mock_user.role == "mock-user-role"
+    error_message = "wrong role of opslevel_user"
+  }
+}
+

--- a/tests/mock_datasource/user.tfmock.hcl
+++ b/tests/mock_datasource/user.tfmock.hcl
@@ -1,0 +1,8 @@
+mock_data "opslevel_user" {
+  defaults = {
+    email = "mock-user-name@example.com"
+    name  = "mock-user-name"
+    role  = "mock-user-role"
+  }
+}
+


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

## Changelog

Changes:
- Add `user` datasource with tests.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_user" "user" {
  identifier = "david+orange@opslevel.com"
}

output "user" {
  value = data.opslevel_user.user
}
```

Run `terraform plan`
```terraform
data.opslevel_user.user: Reading...
data.opslevel_user.user: Read complete after 0s [id=Z2lk...]

Changes to Outputs:
  + user = {
      + email      = "david+orange@opslevel.com"
      + id         = "Z2lk...."
      + identifier = "david+orange@opslevel.com"
      + name       = "David"
      + role       = "admin"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```