### PR TITLE
update opslevel domain aliases field, fix read function

### DIFF
--- a/opslevel/resource_opslevel_domain.go
+++ b/opslevel/resource_opslevel_domain.go
@@ -43,14 +43,13 @@ type DomainResourceModel struct {
 func NewDomainResourceModel(ctx context.Context, domain opslevel.Domain) (DomainResourceModel, diag.Diagnostics) {
 	var domainResourceModel DomainResourceModel
 
-	domainAliases, diags := types.ListValueFrom(ctx, types.StringType, domain.Aliases)
+	domainAliases, diags := types.ListValueFrom(ctx, types.StringType, domain.ManagedAliases)
 	domainResourceModel.Aliases = domainAliases
 	domainResourceModel.Description = types.StringValue(string(domain.Description))
 	domainResourceModel.Id = types.StringValue(string(domain.Id))
 	domainResourceModel.Name = types.StringValue(string(domain.Name))
 	domainResourceModel.Note = types.StringValue(string(domain.Note))
 	domainResourceModel.Owner = types.StringValue(string(domain.Owner.Id()))
-	domainResourceModel.LastUpdated = types.StringValue(timeLastUpdated())
 
 	return domainResourceModel, diags
 }
@@ -123,6 +122,7 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 	createdDomainResourceModel, diags := NewDomainResourceModel(ctx, *resource)
 	resp.Diagnostics.Append(diags...)
+	createdDomainResourceModel.LastUpdated = types.StringValue(timeLastUpdated())
 
 	tflog.Trace(ctx, "created a domain resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &createdDomainResourceModel)...)
@@ -143,17 +143,11 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read domain, got error: %s", err))
 		return
 	}
-	domainAliases, d := types.ListValueFrom(ctx, types.StringType, resource.ManagedAliases)
-	resp.Diagnostics.Append(d...)
-
-	data.Aliases = domainAliases
-	data.Description = types.StringValue(resource.Description)
-	data.Name = types.StringValue(string(resource.Name))
-	data.Note = types.StringValue(resource.Note)
-	data.Owner = types.StringValue(string(resource.Owner.Id()))
+	readDomainResourceModel, diags := NewDomainResourceModel(ctx, *resource)
+	resp.Diagnostics.Append(diags...)
 
 	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &readDomainResourceModel)...)
 }
 
 func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -178,6 +172,7 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 	updatedDomainResourceModel, diags := NewDomainResourceModel(ctx, *resource)
 	resp.Diagnostics.Append(diags...)
+	updatedDomainResourceModel.LastUpdated = types.StringValue(timeLastUpdated())
 
 	tflog.Trace(ctx, "updated a domain resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedDomainResourceModel)...)

--- a/opslevel/resource_opslevel_domain.go
+++ b/opslevel/resource_opslevel_domain.go
@@ -43,7 +43,7 @@ type DomainResourceModel struct {
 func NewDomainResourceModel(ctx context.Context, domain opslevel.Domain) (DomainResourceModel, diag.Diagnostics) {
 	var domainResourceModel DomainResourceModel
 
-	domainAliases, diags := types.ListValueFrom(ctx, types.StringType, domain.ManagedAliases)
+	domainAliases, diags := types.ListValueFrom(ctx, types.StringType, domain.Aliases)
 	domainResourceModel.Aliases = domainAliases
 	domainResourceModel.Description = types.StringValue(string(domain.Description))
 	domainResourceModel.Id = types.StringValue(string(domain.Id))


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/308

## Changelog

- Domain field in `opslevel-go` updated from `Aliases` to `ManagedAliases`
- `Read` operation uses `NewDomainResourceModel(ctx, *resource)` just like `Create` and `Update`.
- Setting `LastUpdated` field done outside of `NewDomainResourceModel()`. 

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this config:
```tf
# main.tf
resource "opslevel_domain" "example" {
  name        = "FANCY FEAST"
  description = "CATS FEAST ON FANCY TABLES"
  owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  note        = "CATS LOVE FANCY TABLES"
}
```

Create domain, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_domain.example will be created
  + resource "opslevel_domain" "example" {
      + aliases      = (known after apply)
      + description  = "CATS FEAST ON FANCY TABLES"
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "FANCY FEAST"
      + note         = "CATS LOVE FANCY TABLES"
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_domain.example: Creating...
opslevel_domain.example: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE]
```

Update config:
```tf
# main.tf
resource "opslevel_domain" "example" {
  name        = "Fancy Feast"
  description = "Cats feast on fancy tables"
  owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  note        = "Cats love fancy tables"
}
```

Update domain, `terraform apply`
```tf
opslevel_domain.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_domain.example will be updated in-place
  ~ resource "opslevel_domain" "example" {
      ~ aliases      = [] -> (known after apply)
      ~ description  = "CATS FEAST ON FANCY TABLES" -> "Cats feast on fancy tables"
        id           = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE"
      + last_updated = (known after apply)
      ~ name         = "FANCY FEAST" -> "Fancy Feast"
      ~ note         = "CATS LOVE FANCY TABLES" -> "Cats love fancy tables"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_domain.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE]
opslevel_domain.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Destroy domain, `terraform destroy`
```tf
opslevel_domain.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_domain.example will be destroyed
  - resource "opslevel_domain" "example" {
      - aliases     = [] -> null
      - description = "Cats feast on fancy tables" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE" -> null
      - name        = "Fancy Feast" -> null
      - note        = "Cats love fancy tables" -> null
      - owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

opslevel_domain.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE4ODg2NzE]
opslevel_domain.example: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```