### PR TITLE
add secret resource, with tests, update timeLastUpdated

### DIFF
--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -3,6 +3,7 @@ package opslevel
 import (
 	"context"
 	"fmt"
+
 	// "sort"
 	"strconv"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	// "github.com/mitchellh/mapstructure"
 	// "github.com/rs/zerolog/log"
@@ -97,8 +99,8 @@ func timeID() string {
 	return strconv.FormatInt(time.Now().Unix(), 10)
 }
 
-func timeLastUpdated() string {
-	return time.Now().Format(time.RFC850)
+func timeLastUpdated() basetypes.StringValue {
+	return types.StringValue(time.Now().Format(time.RFC850))
 }
 
 // func wrap(handler func(data *schema.ResourceData, client *opslevel.Client) error) func(d *schema.ResourceData, meta interface{}) error {

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewDomainResource,
+		NewSecretResource,
 		NewUserResource,
 	}
 }

--- a/opslevel/resource_opslevel_domain.go
+++ b/opslevel/resource_opslevel_domain.go
@@ -122,7 +122,7 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 	createdDomainResourceModel, diags := NewDomainResourceModel(ctx, *resource)
 	resp.Diagnostics.Append(diags...)
-	createdDomainResourceModel.LastUpdated = types.StringValue(timeLastUpdated())
+	createdDomainResourceModel.LastUpdated = timeLastUpdated()
 
 	tflog.Trace(ctx, "created a domain resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &createdDomainResourceModel)...)
@@ -172,7 +172,7 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 	updatedDomainResourceModel, diags := NewDomainResourceModel(ctx, *resource)
 	resp.Diagnostics.Append(diags...)
-	updatedDomainResourceModel.LastUpdated = types.StringValue(timeLastUpdated())
+	updatedDomainResourceModel.LastUpdated = timeLastUpdated()
 
 	tflog.Trace(ctx, "updated a domain resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedDomainResourceModel)...)

--- a/opslevel/resource_opslevel_secrets.go
+++ b/opslevel/resource_opslevel_secrets.go
@@ -1,5 +1,192 @@
 package opslevel
 
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
+
+var _ resource.ResourceWithConfigure = &SecretResource{}
+
+var _ resource.ResourceWithImportState = &SecretResource{}
+
+func NewSecretResource() resource.Resource {
+	return &SecretResource{}
+}
+
+// SecretResource defines the resource implementation.
+type SecretResource struct {
+	CommonResourceClient
+}
+
+// SecretResourceModel describes the Secret managed resource.
+type SecretResourceModel struct {
+	Alias       types.String `tfsdk:"alias"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+	Id          types.String `tfsdk:"id"`
+	LastUpdated types.String `tfsdk:"last_updated"`
+	Owner       types.String `tfsdk:"owner"`
+	UpdatedAt   types.String `tfsdk:"updated_at"`
+	Value       types.String `tfsdk:"value"`
+}
+
+func NewSecretResourceModel(secret opslevel.Secret, ownerIdentifier, sensitiveValue string) SecretResourceModel {
+	return SecretResourceModel{
+		Alias:     types.StringValue(secret.Alias),
+		CreatedAt: types.StringValue(secret.Timestamps.CreatedAt.Local().Format(time.RFC850)),
+		Id:        types.StringValue(string(secret.ID)),
+		Owner:     types.StringValue(ownerIdentifier),
+		UpdatedAt: types.StringValue(secret.Timestamps.UpdatedAt.Local().Format(time.RFC850)),
+		Value:     types.StringValue(sensitiveValue),
+	}
+}
+
+func (r *SecretResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_secret"
+}
+
+func (r *SecretResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Secret Resource",
+
+		Attributes: map[string]schema.Attribute{
+			"alias": schema.StringAttribute{
+				Description: "The alias for this secret.",
+				Required:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Timestamp of time created at.",
+				Computed:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "The ID of the secret.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Computed: true,
+			},
+			"owner": schema.StringAttribute{
+				Description: "The owner of this secret.",
+				Required:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Timestamp of last update.",
+				Computed:    true,
+			},
+			"value": schema.StringAttribute{
+				Description: "A sensitive value",
+				Sensitive:   true,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (r *SecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data SecretResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	secret, err := r.client.CreateSecret(data.Alias.ValueString(), opslevel.SecretInput{
+		Owner: opslevel.NewIdentifier(data.Owner.ValueString()),
+		Value: opslevel.RefOf(data.Value.ValueString()),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create secret, got error: %s", err))
+		return
+	}
+	createdSecretResourceModel := NewSecretResourceModel(*secret, data.Owner.ValueString(), data.Value.ValueString())
+	createdSecretResourceModel.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+
+	tflog.Trace(ctx, "created a secret resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &createdSecretResourceModel)...)
+}
+
+func (r *SecretResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data SecretResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	secret, err := r.client.GetSecret(data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read secret, got error: %s", err))
+		return
+	}
+	readSecretResourceModel := NewSecretResourceModel(*secret, data.Owner.ValueString(), data.Value.ValueString())
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &readSecretResourceModel)...)
+}
+
+func (r *SecretResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data SecretResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatedSecret, err := r.client.UpdateSecret(data.Id.ValueString(), opslevel.SecretInput{
+		Owner: opslevel.NewIdentifier(data.Owner.ValueString()),
+		Value: opslevel.RefOf(data.Value.ValueString()),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update secret, got error: %s", err))
+		return
+	}
+	updatedSecretResourceModel := NewSecretResourceModel(*updatedSecret, data.Owner.ValueString(), data.Value.ValueString())
+	updatedSecretResourceModel.LastUpdated = types.StringValue(time.Now().Format(time.RFC850))
+
+	tflog.Trace(ctx, "updated a secret resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedSecretResourceModel)...)
+}
+
+func (r *SecretResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data SecretResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteSecret(data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete secret, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a secret resource")
+}
+
+func (r *SecretResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
 // import (
 // 	"time"
 

--- a/opslevel/resource_opslevel_secrets.go
+++ b/opslevel/resource_opslevel_secrets.go
@@ -62,7 +62,7 @@ func (r *SecretResource) Schema(ctx context.Context, req resource.SchemaRequest,
 
 		Attributes: map[string]schema.Attribute{
 			"alias": schema.StringAttribute{
-				Description: "The alias for this secret.",
+				Description: "The alias for this secret. Can only be set at create time.",
 				Required:    true,
 			},
 			"created_at": schema.StringAttribute{

--- a/opslevel/resource_opslevel_user.go
+++ b/opslevel/resource_opslevel_user.go
@@ -43,7 +43,7 @@ func NewUserResourceModel(user opslevel.User) UserResourceModel {
 	return UserResourceModel{
 		Email:            types.StringValue(user.Email),
 		Id:               types.StringValue(string(user.Id)),
-		LastUpdated:      types.StringValue(timeLastUpdated()),
+		LastUpdated:      timeLastUpdated(),
 		Name:             types.StringValue(user.Name),
 		Role:             types.StringValue(string(user.Role)),
 		SkipWelcomeEmail: types.BoolNull(),

--- a/tests/mock_resource/secret.tfmock.hcl
+++ b/tests/mock_resource/secret.tfmock.hcl
@@ -1,0 +1,7 @@
+mock_resource "opslevel_secret" {
+  defaults = {
+    # id intentionally omitted - will be assigned a random string
+    created_at = "2022-02-24T13:50:07Z"
+    updated_at = "2022-03-24T13:50:07Z"
+  }
+}

--- a/tests/resource_secret.tftest.hcl
+++ b/tests/resource_secret.tftest.hcl
@@ -19,7 +19,7 @@ run "resource_secret" {
   }
 
   assert {
-    condition = contains([-1, 0], timecmp(opslevel_secret.mock_secret.created_at, opslevel_secret.mock_secret.updated_at))
+    condition     = contains([-1, 0], timecmp(opslevel_secret.mock_secret.created_at, opslevel_secret.mock_secret.updated_at))
     error_message = "created_at timestamp should not be after updated_at timestamp in opslevel_secret"
   }
 

--- a/tests/resource_secret.tftest.hcl
+++ b/tests/resource_secret.tftest.hcl
@@ -1,0 +1,42 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_secret" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_secret.mock_secret.alias == "secret-alias"
+    error_message = "wrong alias in opslevel_secret"
+  }
+
+  assert {
+    condition     = opslevel_secret.mock_secret.created_at == "2022-02-24T13:50:07Z"
+    error_message = "wrong created_at timestamp in opslevel_secret"
+  }
+
+  assert {
+    condition = contains([-1, 0], timecmp(opslevel_secret.mock_secret.created_at, opslevel_secret.mock_secret.updated_at))
+    error_message = "created_at timestamp should not be after updated_at timestamp in opslevel_secret"
+  }
+
+  assert {
+    condition     = opslevel_secret.mock_secret.id != null && opslevel_secret.mock_secret.id != ""
+    error_message = "opslevel_secret id should not be empty"
+  }
+
+  assert {
+    condition     = opslevel_secret.mock_secret.owner == "Developers"
+    error_message = "wrong owner of opslevel_secret"
+  }
+
+  assert {
+    condition     = opslevel_secret.mock_secret.value == "too_many_passwords"
+    error_message = "wrong value of opslevel_secret"
+  }
+
+}
+

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -1,9 +1,21 @@
+# Domain resources
+
 resource "opslevel_domain" "fancy" {
   name        = "Example"
   description = "The whole app in one monolith"
   owner       = "Developers"
   note        = "This is an example"
 }
+
+# Secret resources
+
+resource "opslevel_secret" "mock_secret" {
+  alias = "secret-alias"
+  value = "too_many_passwords"
+  owner = "Developers"
+}
+
+# User resources
 
 resource "opslevel_user" "mock_user" {
   name  = "Mock User"


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/308

## Changelog

Changes:
- Add `secret` resource, with tests
- Update `timeLastUpdated()` to return new type

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
resource "opslevel_secret" "my_secret" {
  alias = "secret-alias-123456"
  owner = "platform"
  value = "too_many_passwords_123"
}
```

Create secret. Run `terraform apply`
```terraform
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_secret.my_secret will be created
  + resource "opslevel_secret" "my_secret" {
      + alias        = "secret-alias-123456"
      + created_at   = (known after apply)
      + id           = (known after apply)
      + last_updated = (known after apply)
      + owner        = "platform"
      + updated_at   = (known after apply)
      + value        = (sensitive value)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_secret.my_secret: Creating...
opslevel_secret.my_secret: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNA]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Update `main.tf`
```tf
Using this file:
```terraform
# main.tf
resource "opslevel_secret" "my_secret" {
  alias = "secret-alias-123456"
  owner = "test_team"
  value = "TOO_MANY_PASSWORDS_123"
}
```

Update secret's value and team. Run `terraform apply`
```tf
opslevel_secret.my_secret: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNQ]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_secret.my_secret will be updated in-place
  ~ resource "opslevel_secret" "my_secret" {
      ~ created_at   = "Monday, 25-Mar-24 15:06:02 CDT" -> (known after apply)
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNQ"
      + last_updated = (known after apply)
      ~ owner        = "platform" -> "test_team"
      ~ updated_at   = "Monday, 25-Mar-24 15:06:02 CDT" -> (known after apply)
      ~ value        = (sensitive value)
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opslevel_secret.my_secret: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNQ]
opslevel_secret.my_secret: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNQ]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

```

Remove user. Run `terraform destroy`
```tf
opslevel_secret.my_secret: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNQ]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_secret.my_secret will be destroyed
  - resource "opslevel_secret" "my_secret" {
      - alias      = "secret-alias-123456" -> null
      - created_at = "Monday, 25-Mar-24 15:06:02 CDT" -> null
      - id         = "Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNQ" -> null
      - owner      = "test_team" -> null
      - updated_at = "Monday, 25-Mar-24 15:06:57 CDT" -> null
      - value      = (sensitive value) -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

opslevel_secret.my_secret: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VjcmV0c1ZhdWx0czo6U2VjcmV0LzExNQ]
opslevel_secret.my_secret: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```