### PR TITLE
add lifecycle datasource

### DIFF
--- a/opslevel/datasource_opslevel_lifecycle.go
+++ b/opslevel/datasource_opslevel_lifecycle.go
@@ -26,22 +26,20 @@ type LifecycleDataSource struct {
 
 // LifecycleDataSourceModel describes the data source data model.
 type LifecycleDataSourceModel struct {
-	Alias       types.String     `tfsdk:"alias"`
-	Description types.String     `tfsdk:"description"`
-	Filter      FilterBlockModel `tfsdk:"filter"`
-	Id          types.String     `tfsdk:"id"`
-	Index       types.Int64      `tfsdk:"index"`
-	Name        types.String     `tfsdk:"name"`
+	Alias  types.String     `tfsdk:"alias"`
+	Filter FilterBlockModel `tfsdk:"filter"`
+	Id     types.String     `tfsdk:"id"`
+	Index  types.Int64      `tfsdk:"index"`
+	Name   types.String     `tfsdk:"name"`
 }
 
 func NewLifecycleDataSourceModel(ctx context.Context, lifecycle opslevel.Lifecycle, filter FilterBlockModel) LifecycleDataSourceModel {
 	return LifecycleDataSourceModel{
-		Alias:       types.StringValue(lifecycle.Alias),
-		Description: types.StringValue(lifecycle.Description),
-		Filter:      filter,
-		Id:          types.StringValue(string(lifecycle.Id)),
-		Index:       types.Int64Value(int64(lifecycle.Index)),
-		Name:        types.StringValue(lifecycle.Name),
+		Alias:  types.StringValue(lifecycle.Alias),
+		Filter: filter,
+		Id:     types.StringValue(string(lifecycle.Id)),
+		Index:  types.Int64Value(int64(lifecycle.Index)),
+		Name:   types.StringValue(lifecycle.Name),
 	}
 }
 
@@ -58,10 +56,6 @@ func (lifecycleDataSource *LifecycleDataSource) Schema(ctx context.Context, req 
 		Attributes: map[string]schema.Attribute{
 			"alias": schema.StringAttribute{
 				MarkdownDescription: "The alias attached to the Lifecycle.",
-				Computed:            true,
-			},
-			"description": schema.StringAttribute{
-				MarkdownDescription: "The description for the Lifecycle.",
 				Computed:            true,
 			},
 			"id": schema.StringAttribute{

--- a/opslevel/datasource_opslevel_lifecycle.go
+++ b/opslevel/datasource_opslevel_lifecycle.go
@@ -45,11 +45,11 @@ func NewLifecycleDataSourceModel(ctx context.Context, lifecycle opslevel.Lifecyc
 	}
 }
 
-func (sys *LifecycleDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (lifecycleDataSource *LifecycleDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_lifecycle"
 }
 
-func (sys *LifecycleDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (lifecycleDataSource *LifecycleDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	validFieldNames := []string{"alias", "id", "index", "name"}
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
@@ -83,7 +83,7 @@ func (sys *LifecycleDataSource) Schema(ctx context.Context, req datasource.Schem
 	}
 }
 
-func (sys *LifecycleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+func (lifecycleDataSource *LifecycleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data LifecycleDataSourceModel
 
 	// Read Terraform configuration data into the model
@@ -92,7 +92,7 @@ func (sys *LifecycleDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	lifecycles, err := sys.client.ListLifecycles()
+	lifecycles, err := lifecycleDataSource.client.ListLifecycles()
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to list lifecycles, got error: %s", err))
 		return
@@ -111,11 +111,11 @@ func (sys *LifecycleDataSource) Read(ctx context.Context, req datasource.ReadReq
 	resp.Diagnostics.Append(resp.State.Set(ctx, &lifecycleDataModel)...)
 }
 
-func filterLifecycles(tiers []opslevel.Lifecycle, filter FilterBlockModel) (*opslevel.Lifecycle, error) {
+func filterLifecycles(lifecycles []opslevel.Lifecycle, filter FilterBlockModel) (*opslevel.Lifecycle, error) {
 	if filter.Value.Equal(types.StringValue("")) {
 		return nil, fmt.Errorf("please provide a non-empty value for lifecycle's value")
 	}
-	for _, lifecycle := range tiers {
+	for _, lifecycle := range lifecycles {
 		switch filter.Field.ValueString() {
 		case "alias":
 			if filter.Value.Equal(types.StringValue(lifecycle.Alias)) {

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -166,6 +166,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewFilterDataSource,
 		NewIntegrationDataSource,
 		NewLevelDataSource,
+		NewLifecycleDataSource,
 		NewPropertyDefinitionDataSource,
 		NewScorecardDataSource,
 		NewServiceDataSource,

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -103,6 +103,36 @@ data "opslevel_rubric_level" "name_filter" {
   }
 }
 
+# lifecycle
+
+data "opslevel_lifecycle" "alias_filter" {
+  filter {
+    field = "alias"
+    value = "generally_available"
+  }
+}
+
+data "opslevel_lifecycle" "id_filter" {
+  filter {
+    field = "id"
+    value = "Z2lkOi8vb3BzbGV2ZWwvTGlmZWN5Y2xlLzQ"
+  }
+}
+
+data "opslevel_lifecycle" "index_filter" {
+  filter {
+    field = "index"
+    value = 123
+  }
+}
+
+data "opslevel_lifecycle" "name_filter" {
+  filter {
+    field = "name"
+    value = "Generally Available"
+  }
+}
+
 # Scorecard data sources
 
 data "opslevel_scorecard" "mock_scorecard" {

--- a/tests/datasource_lifecycle.tftest.hcl
+++ b/tests/datasource_lifecycle.tftest.hcl
@@ -9,6 +9,11 @@ run "datasource_lifecycle_filter_by_id" {
   }
 
   assert {
+    condition     = data.opslevel_lifecycle.id_filter.alias == "generally_available"
+    error_message = "id in opslevel_lifecycle mock was not set"
+  }
+
+  assert {
     condition     = data.opslevel_lifecycle.id_filter.id != ""
     error_message = "id in opslevel_lifecycle mock was not set"
   }
@@ -36,6 +41,11 @@ run "datasource_lifecycle_filter_by_name" {
   }
 
   assert {
+    condition     = data.opslevel_lifecycle.name_filter.alias == "generally_available"
+    error_message = "id in opslevel_lifecycle mock was not set"
+  }
+
+  assert {
     condition     = data.opslevel_lifecycle.name_filter.filter.field == "name"
     error_message = "filter field should be name"
   }
@@ -53,6 +63,11 @@ run "datasource_lifecycle_filter_by_index" {
   }
 
   assert {
+    condition     = data.opslevel_lifecycle.index_filter.alias == "generally_available"
+    error_message = "id in opslevel_lifecycle mock was not set"
+  }
+
+  assert {
     condition     = data.opslevel_lifecycle.index_filter.filter.field == "index"
     error_message = "filter field should be index"
   }
@@ -67,6 +82,11 @@ run "datasource_lifecycle_filter_by_index" {
 run "datasource_lifecycle_filter_by_alias" {
   providers = {
     opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.index_filter.alias == "generally_available"
+    error_message = "id in opslevel_lifecycle mock was not set"
   }
 
   assert {

--- a/tests/datasource_lifecycle.tftest.hcl
+++ b/tests/datasource_lifecycle.tftest.hcl
@@ -19,6 +19,11 @@ run "datasource_lifecycle_filter_by_id" {
   }
 
   assert {
+    condition     = data.opslevel_lifecycle.id_filter.index == 123
+    error_message = "wrong index in opslevel_lifecycle"
+  }
+
+  assert {
     condition     = data.opslevel_lifecycle.id_filter.name == "Generally Available"
     error_message = "wrong name in opslevel_lifecycle"
   }

--- a/tests/datasource_lifecycle.tftest.hcl
+++ b/tests/datasource_lifecycle.tftest.hcl
@@ -10,7 +10,7 @@ run "datasource_lifecycle_filter_by_id" {
 
   assert {
     condition     = data.opslevel_lifecycle.id_filter.alias == "generally_available"
-    error_message = "id in opslevel_lifecycle mock was not set"
+    error_message = "wrong alias in opslevel_lifecycle mock"
   }
 
   assert {
@@ -42,7 +42,7 @@ run "datasource_lifecycle_filter_by_name" {
 
   assert {
     condition     = data.opslevel_lifecycle.name_filter.alias == "generally_available"
-    error_message = "id in opslevel_lifecycle mock was not set"
+    error_message = "wrong alias in opslevel_lifecycle mock"
   }
 
   assert {
@@ -64,7 +64,7 @@ run "datasource_lifecycle_filter_by_index" {
 
   assert {
     condition     = data.opslevel_lifecycle.index_filter.alias == "generally_available"
-    error_message = "id in opslevel_lifecycle mock was not set"
+    error_message = "wrong alias in opslevel_lifecycle mock"
   }
 
   assert {
@@ -86,7 +86,7 @@ run "datasource_lifecycle_filter_by_alias" {
 
   assert {
     condition     = data.opslevel_lifecycle.index_filter.alias == "generally_available"
-    error_message = "id in opslevel_lifecycle mock was not set"
+    error_message = "wrong alias in opslevel_lifecycle mock"
   }
 
   assert {

--- a/tests/datasource_lifecycle.tftest.hcl
+++ b/tests/datasource_lifecycle.tftest.hcl
@@ -41,11 +41,6 @@ run "datasource_lifecycle_filter_by_name" {
   }
 
   assert {
-    condition     = data.opslevel_lifecycle.name_filter.alias == "generally_available"
-    error_message = "wrong alias in opslevel_lifecycle mock"
-  }
-
-  assert {
     condition     = data.opslevel_lifecycle.name_filter.filter.field == "name"
     error_message = "filter field should be name"
   }
@@ -63,11 +58,6 @@ run "datasource_lifecycle_filter_by_index" {
   }
 
   assert {
-    condition     = data.opslevel_lifecycle.index_filter.alias == "generally_available"
-    error_message = "wrong alias in opslevel_lifecycle mock"
-  }
-
-  assert {
     condition     = data.opslevel_lifecycle.index_filter.filter.field == "index"
     error_message = "filter field should be index"
   }
@@ -82,11 +72,6 @@ run "datasource_lifecycle_filter_by_index" {
 run "datasource_lifecycle_filter_by_alias" {
   providers = {
     opslevel = opslevel.fake
-  }
-
-  assert {
-    condition     = data.opslevel_lifecycle.index_filter.alias == "generally_available"
-    error_message = "wrong alias in opslevel_lifecycle mock"
   }
 
   assert {

--- a/tests/datasource_lifecycle.tftest.hcl
+++ b/tests/datasource_lifecycle.tftest.hcl
@@ -1,0 +1,82 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_datasource"
+}
+
+run "datasource_lifecycle_filter_by_id" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.id_filter.id != ""
+    error_message = "id in opslevel_lifecycle mock was not set"
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.id_filter.name == "Generally Available"
+    error_message = "wrong name in opslevel_lifecycle"
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.id_filter.filter.field == "id"
+    error_message = "filter field should be id"
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.id_filter.filter.value == "Z2lkOi8vb3BzbGV2ZWwvTGlmZWN5Y2xlLzQ"
+    error_message = "filter value for opslevel_lifecycle.id_filter should be Z2lkOi8vb3BzbGV2ZWwvTGlmZWN5Y2xlLzQ"
+  }
+
+}
+
+run "datasource_lifecycle_filter_by_name" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.name_filter.filter.field == "name"
+    error_message = "filter field should be name"
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.name_filter.filter.value == "Generally Available"
+    error_message = "filter value for opslevel_lifecycle.name_filter should be 'Generally Available'"
+  }
+
+}
+
+run "datasource_lifecycle_filter_by_index" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.index_filter.filter.field == "index"
+    error_message = "filter field should be index"
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.index_filter.filter.value == "123"
+    error_message = "filter value for opslevel_lifecycle.name_filter should be '123'"
+  }
+
+}
+
+run "datasource_lifecycle_filter_by_alias" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.alias_filter.filter.field == "alias"
+    error_message = "filter field should be alias"
+  }
+
+  assert {
+    condition     = data.opslevel_lifecycle.alias_filter.filter.value == "generally_available"
+    error_message = "filter value for opslevel_lifecycle.name_filter should be 'generally_available'"
+  }
+
+}

--- a/tests/mock_datasource/lifecycle.tfmock.hcl
+++ b/tests/mock_datasource/lifecycle.tfmock.hcl
@@ -1,7 +1,8 @@
 mock_data "opslevel_lifecycle" {
   defaults = {
+    alias = "generally_available"
     index = 123
-    name = "Generally Available"
+    name  = "Generally Available"
   }
 }
 

--- a/tests/mock_datasource/lifecycle.tfmock.hcl
+++ b/tests/mock_datasource/lifecycle.tfmock.hcl
@@ -1,0 +1,7 @@
+mock_data "opslevel_lifecycle" {
+  defaults = {
+    index = 123
+    name = "Generally Available"
+  }
+}
+


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

## Tophatting

```
data "opslevel_lifecycle" "l1" {
  filter {
    field = "alias"
    value = "generally_available"
  }
}

data "opslevel_lifecycle" "l2" {
  filter {
    field = "id"
    value = "Z2lkOi8vb3BzbGV2ZWwvTGlmZWN5Y2xlLzQ"
  }
}

output "o1" {
  value = data.opslevel_lifecycle.l1
}

output "o2" {
  value = data.opslevel_lifecycle.l2
}
```

```
Changes to Outputs:
  + o1 = {
      + alias       = "generally_available"
      + description = "Service is supporting features available to be used by all customers, and should be fully stable."
      + filter      = {
          + field = "alias"
          + value = "generally_available"
        }
      + id          = "Z2lkOi8vb3BzbGV2ZWwvTGlmZWN5Y2xlLzQ"
      + index       = 4
      + name        = "Generally Available"
    }
  + o2 = {
      + alias       = "generally_available"
      + description = "Service is supporting features available to be used by all customers, and should be fully stable."
      + filter      = {
          + field = "id"
          + value = "Z2lkOi8vb3BzbGV2ZWwvTGlmZWN5Y2xlLzQ"
        }
      + id          = "Z2lkOi8vb3BzbGV2ZWwvTGlmZWN5Y2xlLzQ"
      + index       = 4
      + name        = "Generally Available"
    }

```