### PR TITLE
add team datasource

### DIFF
--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -1,85 +1,121 @@
 package opslevel
 
-// import (
-// 	"github.com/opslevel/opslevel-go/v2024"
+import (
+	"context"
+	"fmt"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// )
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func datasourceTeam() *schema.Resource {
-// 	return &schema.Resource{
-// 		Read: wrap(datasourceTeamRead),
-// 		Schema: map[string]*schema.Schema{
-// 			"alias": {
-// 				Type:        schema.TypeString,
-// 				Description: "An alias of the team to find by.",
-// 				ForceNew:    true,
-// 				Optional:    true,
-// 			},
-// 			"id": {
-// 				Type:        schema.TypeString,
-// 				Description: "The id of the team to find.",
-// 				ForceNew:    true,
-// 				Optional:    true,
-// 			},
-// 			"name": {
-// 				Type:        schema.TypeString,
-// 				Description: "The name of the team.",
-// 				Computed:    true,
-// 			},
-// 			"members": {
-// 				Type:        schema.TypeList,
-// 				Description: "List of members in the team with email address and role.",
-// 				Computed:    true,
-// 				Elem: &schema.Resource{
-// 					Schema: map[string]*schema.Schema{
-// 						"email": {
-// 							Type:        schema.TypeString,
-// 							Description: "The email address of the team member.",
-// 							Computed:    true,
-// 						},
-// 						"role": {
-// 							Type:        schema.TypeString,
-// 							Description: "The role of the team member.",
-// 							Computed:    true,
-// 						},
-// 					},
-// 				},
-// 			},
-// 			"parent_alias": {
-// 				Type:        schema.TypeString,
-// 				Description: "The alias of the parent team.",
-// 				Computed:    true,
-// 			},
-// 			"parent_id": {
-// 				Type:        schema.TypeString,
-// 				Description: "The id of the parent team.",
-// 				Computed:    true,
-// 			},
-// 		},
-// 	}
-// }
+// Ensure TeamDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &TeamDataSource{}
 
-// func datasourceTeamRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	resource, err := findTeam("alias", "id", d, client)
-// 	if err != nil {
-// 		return err
-// 	}
+func NewTeamDataSource() datasource.DataSource {
+	return &TeamDataSource{}
+}
 
-// 	d.SetId(string(resource.Id))
-// 	d.Set("alias", resource.Alias)
-// 	d.Set("name", resource.Name)
+// TeamDataSource manages a Team data source.
+type TeamDataSource struct {
+	CommonDataSourceClient
+}
 
-// 	if err := d.Set("members", mapMembershipsArray(resource.Memberships)); err != nil {
-// 		return err
-// 	}
+// TeamDataSourceModel describes the data source data model.
+type TeamDataSourceModel struct {
+	Alias       types.String   `tfsdk:"alias"`
+	Id          types.String   `tfsdk:"id"`
+	Identifier  types.String   `tfsdk:"identifier"`
+	Members     types.ListType `tfsdk:"members"`
+	Name        types.String   `tfsdk:"name"`
+	ParentAlias types.String   `tfsdk:"parent_alias"`
+	ParentId    types.String   `tfsdk:"parent_id"`
+}
 
-// 	if err := d.Set("parent_alias", resource.ParentTeam.Alias); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("parent_id", resource.ParentTeam.Id); err != nil {
-// 		return err
-// 	}
+func NewTeamDataSourceModel(ctx context.Context, team opslevel.Team, identifier types.String) TeamDataSourceModel {
+	return TeamDataSourceModel{
+		Alias:      types.StringValue(team.Alias),
+		Id:         types.StringValue(string(team.Id)),
+		Identifier: identifier,
+		// TODO: members
+		Name:        types.StringValue(team.Name),
+		ParentAlias: types.StringValue(team.ParentTeam.Alias),
+		ParentId:    types.StringValue(string(team.ParentTeam.Id)),
+	}
+}
 
-// 	return nil
-// }
+func (teamDataSource *TeamDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_team"
+}
+
+func (teamDataSource *TeamDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Team data source",
+
+		Attributes: map[string]schema.Attribute{
+			"aliases": schema.ListAttribute{
+				ElementType:         types.StringType,
+				MarkdownDescription: "All of the aliases attached to the Team.",
+				Computed:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "The description of the Team.",
+				Computed:            true,
+			},
+			"domain": schema.StringAttribute{
+				MarkdownDescription: "ID of the parent domain of the Team.",
+				Computed:            true,
+			},
+			"id": schema.StringAttribute{
+				Description: "The ID of this Team.",
+				Computed:    true,
+			},
+			"identifier": schema.StringAttribute{
+				Description: "The id or alias of the Team.",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of the Team.",
+				Computed:    true,
+			},
+			"owner": schema.StringAttribute{
+				Description: "The id of the team that owns the Team.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (teamDataSource *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data TeamDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var err error
+	var team *opslevel.Team
+	if opslevel.IsID(data.Identifier.ValueString()) {
+		team, err = teamDataSource.client.GetTeam(opslevel.ID(data.Identifier.ValueString()))
+	} else {
+		team, err = teamDataSource.client.GetTeamWithAlias(data.Identifier.ValueString())
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to read team, got error: %s", err))
+		return
+	}
+
+	// TODO: members
+
+	teamDataModel := NewTeamDataSourceModel(ctx, *team, data.Identifier)
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "read an OpsLevel Team data source")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &teamDataModel)...)
+}

--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -94,7 +94,7 @@ func (teamDataSource *TeamDataSource) Schema(ctx context.Context, req datasource
 				Computed:    true,
 			},
 			"members": schema.ListAttribute{
-				Description: "List of team members on the team.",
+				Description: "List of team members on the team with email address and role.",
 				ElementType: memberObjectType,
 				Computed:    true,
 			},

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -172,6 +172,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewScorecardDataSource,
 		NewServiceDataSource,
 		NewSystemDataSource,
+		NewTeamDataSource,
 		NewTierDataSource,
 		NewUserDataSource,
 		NewWebhookActionDataSource,

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -154,6 +154,16 @@ data "opslevel_system" "mock_system" {
   identifier = "my_system"
 }
 
+# team
+
+data "opslevel_team" "mock_team_with_id" {
+  id = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNjc4"
+}
+
+data "opslevel_team" "mock_team_with_alias" {
+  alias = "platform"
+}
+
 # Tier data sources
 
 data "opslevel_tier" "mock_tier" {

--- a/tests/datasource_team.tftest.hcl
+++ b/tests/datasource_team.tftest.hcl
@@ -32,6 +32,16 @@ run "datasource_team_with_alias" {
     condition     = data.opslevel_team.mock_team_with_alias.parent_id == "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg"
     error_message = "wrong parent_id on opslevel_team"
   }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_alias.members[0].email == "person1@opslevel.com" && data.opslevel_team.mock_team_with_alias.members[0].role == "manager" && data.opslevel_team.mock_team_with_alias.members[1].email == "person2@opslevel.com" && data.opslevel_team.mock_team_with_alias.members[1].role == "contributor"
+    error_message = "wrong members data on opslevel_team"
+  }
+
+  assert {
+    condition     = length(data.opslevel_team.mock_team_with_alias.members) == 2
+    error_message = "wrong members length on opslevel_team"
+  }
 }
 
 run "datasource_team_with_id" {

--- a/tests/datasource_team.tftest.hcl
+++ b/tests/datasource_team.tftest.hcl
@@ -1,0 +1,51 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_datasource"
+}
+
+run "datasource_team_with_alias" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_alias.alias == "platform"
+    error_message = "wrong alias on opslevel_team"
+  }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_alias.id != null && data.opslevel_team.mock_team_with_alias.id != ""
+    error_message = "empty id on opslevel_team"
+  }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_alias.name == "Platform"
+    error_message = "wrong name on opslevel_team"
+  }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_alias.parent_alias == "engineering"
+    error_message = "wrong parent_alias on opslevel_team"
+  }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_alias.parent_id == "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg"
+    error_message = "wrong parent_id on opslevel_team"
+  }
+}
+
+run "datasource_team_with_id" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_id.alias == "platform"
+    error_message = "wrong alias on opslevel_team"
+  }
+
+  assert {
+    condition     = data.opslevel_team.mock_team_with_id.id != null && data.opslevel_team.mock_team_with_id.id != ""
+    error_message = "empty id on opslevel_team"
+  }
+}

--- a/tests/mock_datasource/team.tfmock.hcl
+++ b/tests/mock_datasource/team.tfmock.hcl
@@ -1,0 +1,9 @@
+mock_data "opslevel_team" {
+  defaults = {
+    alias = "platform"
+    parent_id = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg"
+    parent_alias = "engineering"
+    name  = "Platform"
+  }
+}
+

--- a/tests/mock_datasource/team.tfmock.hcl
+++ b/tests/mock_datasource/team.tfmock.hcl
@@ -1,9 +1,10 @@
 mock_data "opslevel_team" {
   defaults = {
-    alias = "platform"
-    parent_id = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg"
+    alias        = "platform"
+    parent_id    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg"
     parent_alias = "engineering"
-    name  = "Platform"
+    members      = [{ "email" : "person1@opslevel.com", "role" : "manager" }, { "email" : "person2@opslevel.com", "role" : "contributor" }]
+    name         = "Platform"
   }
 }
 


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

Current docs for team: https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/data-sources/team

## Tophatting

```
data "opslevel_team" "engineering" {
  alias = "engineering"
}

data "opslevel_team" "platform" {
  id = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNjc4"
}

output "o1" {
  value = data.opslevel_team.engineering
}

output "o2" {
  value = data.opslevel_team.platform
}
```

```
Changes to Outputs:
  + o1 = {
      + alias        = "engineering"
      + id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg"
      + members      = [
          + {
              + email = "x@opslevel.com"
              + role  = "manager"
            },
        ]
      + name         = "Engineering"
      + parent_alias = "product"
      + parent_id    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mw"
    }
  + o2 = {
      + alias        = "platform"
      + id           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNjc4"
      + members      = [
          + {
              + email = "x@opslevel.com"
              + role  = "manager"
            },
          + {
              + email = "x@opslevel.com"
              + role  = "contributor"
            },
          + {
              + email = "x@opslevel.com"
              + role  = "contributor"
            },
        ]
      + name         = "Platform"
      + parent_alias = "engineering"
      + parent_id    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg"
    }

```
