### PR TITLE
replace identifier with id or alias for service datasource

### DIFF
--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -66,11 +66,11 @@ data "opslevel_property_definition" "mock_property_definition" {
 # Service data sources
 
 data "opslevel_service" "mock_service_with_alias" {
-  identifier = "mock-service-alias"
+  alias = "mock-service-alias"
 }
 
 data "opslevel_service" "mock_service_with_id" {
-  identifier = "Z2lkOi8vmock123"
+  id = "Z2lkOi8vmock123"
 }
 
 # rubric Level data sources

--- a/tests/datasource_service.tftest.hcl
+++ b/tests/datasource_service.tftest.hcl
@@ -9,7 +9,7 @@ run "datasource_service_given_alias" {
   }
 
   assert {
-    condition     = data.opslevel_service.mock_service_with_alias.identifier == "mock-service-alias"
+    condition     = data.opslevel_service.mock_service_with_alias.alias == "mock-service-alias"
     error_message = "alias in opslevel_service mock was not set"
   }
 
@@ -21,12 +21,12 @@ run "datasource_service_given_id" {
   }
 
   assert {
-    condition     = startswith(data.opslevel_service.mock_service_with_id.identifier, "Z2lkOi8v")
+    condition     = startswith(data.opslevel_service.mock_service_with_id.id, "Z2lkOi8v")
     error_message = "wrong id prefix in opslevel_service mock"
   }
 
   assert {
-    condition     = data.opslevel_service.mock_service_with_id.identifier == "Z2lkOi8vmock123"
+    condition     = data.opslevel_service.mock_service_with_id.id == "Z2lkOi8vmock123"
     error_message = "wrong id in opslevel_service mock"
   }
 


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/288

## Changelog

Changes:
- Update `service` datasource and tests. Replaced `identifier` input with `id` or `alias` to match [public docs](https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/data-sources/service)

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_service" "platform_repo_alias" {
  alias = "platform.repo"
}

data "opslevel_service" "test" {
  id = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Njg3Ng"
}

output "platform_repo_alias" {
  value = data.opslevel_service.platform_repo_alias
}

output "test" {
  value = data.opslevel_service.test
}
```

Run `terraform plan`
```terraform
data.opslevel_service.test: Reading...
data.opslevel_service.platform_repo_alias: Reading...
data.opslevel_service.platform_repo_alias: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80OTY1]
data.opslevel_service.test: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Njg3Ng]

Changes to Outputs:
  + platform_repo_alias = {
      + alias                         = "platform.repo"
      + aliases                       = [
          + "platform.repo",
          + "platform_repo",
        ]
      + api_document_path             = ""
      + description                   = "ad"
      + framework                     = ""
      + id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80OTY1"
      + language                      = ""
      + lifecycle_alias               = ""
      + name                          = "platform.repo"
      + owner                         = ""
      + owner_id                      = ""
      + preferred_api_document_source = null
      + product                       = ""
      + properties                    = [
          + {
              + definition = {
                  + aliases = [
                      + "is_beta_feature",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi85OA"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "slug",
                      + "linters",
                      + "linters_property",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8yODk"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "number",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8yODA"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "some_definition",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82OA"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "some_definition_clone",
                      + "some_definition_clooooone",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82OQ"
                }
              + value      = null
            },
        ]
      + repositories                  = [
          + "",
          + "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMjI1NDk",
        ]
      + tags                          = []
      + tier_alias                    = ""
    }
  + test                = {
      + alias                         = null
      + aliases                       = [
          + "projectname",
          + "service_for_studious-waddle_repo",
        ]
      + api_document_path             = ""
      + description                   = "{{.BootstrappingSystem.Descriptions}}"
      + framework                     = ""
      + id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Njg3Ng"
      + language                      = ""
      + lifecycle_alias               = ""
      + name                          = "{{.ProjectName}}"
      + owner                         = ""
      + owner_id                      = ""
      + preferred_api_document_source = null
      + product                       = ""
      + properties                    = [
          + {
              + definition = {
                  + aliases = [
                      + "is_beta_feature",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi85OA"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "slug",
                      + "linters",
                      + "linters_property",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8yODk"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "number",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8yODA"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "some_definition",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82OA"
                }
              + value      = null
            },
          + {
              + definition = {
                  + aliases = [
                      + "some_definition_clone",
                      + "some_definition_clooooone",
                    ]
                  + id      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi82OQ"
                }
              + value      = null
            },
        ]
      + repositories                  = [
          + "",
          + "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvMTAyOTcx",
        ]
      + tags                          = []
      + tier_alias                    = ""
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```