### PR TITLE
add missing plan modifiers to secret and user resources

### DIFF
--- a/opslevel/resource_opslevel_domain.go
+++ b/opslevel/resource_opslevel_domain.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	_ "github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/opslevel/resource_opslevel_secrets.go
+++ b/opslevel/resource_opslevel_secrets.go
@@ -63,7 +63,10 @@ func (r *SecretResource) Schema(ctx context.Context, req resource.SchemaRequest,
 		Attributes: map[string]schema.Attribute{
 			"alias": schema.StringAttribute{
 				Description: "The alias for this secret. Can only be set at create time.",
-				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Required: true,
 			},
 			"created_at": schema.StringAttribute{
 				Description: "Timestamp of time created at.",
@@ -186,127 +189,3 @@ func (r *SecretResource) Delete(ctx context.Context, req resource.DeleteRequest,
 func (r *SecretResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
-
-// import (
-// 	"time"
-
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
-
-// func resourceSecret() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a secret",
-// 		Create:      wrap(resourceSecretCreate),
-// 		Read:        wrap(resourceSecretRead),
-// 		Update:      wrap(resourceSecretUpdate),
-// 		Delete:      wrap(resourceSecretDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: map[string]*schema.Schema{
-// 			"last_updated": {
-// 				Type:     schema.TypeString,
-// 				Optional: true,
-// 				Computed: true,
-// 			},
-// 			"alias": {
-// 				Type:        schema.TypeString,
-// 				Description: "The alias for this secret.",
-// 				ForceNew:    true,
-// 				Required:    true,
-// 			},
-// 			"owner": {
-// 				Type:        schema.TypeString,
-// 				Description: "The owner of this secret.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"value": {
-// 				Type:        schema.TypeString,
-// 				Description: "A sensitive value.",
-// 				Sensitive:   true,
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"created_at": {
-// 				Type:        schema.TypeString,
-// 				Description: "Timestamp of time created at.",
-// 				Computed:    true,
-// 			},
-// 			"updated_at": {
-// 				Type:        schema.TypeString,
-// 				Description: "Timestamp of last update.",
-// 				Computed:    true,
-// 			},
-// 		},
-// 	}
-// }
-
-// func resourceSecretCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	input := opslevel.SecretInput{
-// 		Owner: opslevel.NewIdentifier(d.Get("owner").(string)),
-// 		Value: opslevel.RefOf(d.Get("value").(string)),
-// 	}
-// 	alias := d.Get("alias").(string)
-// 	resource, err := client.CreateSecret(alias, input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.ID))
-// 	return resourceSecretRead(d, client)
-// }
-
-// func resourceSecretRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
-
-// 	resource, err := client.GetSecret(id)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	if opslevel.IsID(d.Get("owner").(string)) {
-// 		if err := d.Set("owner", resource.Owner.Id); err != nil {
-// 			return err
-// 		}
-// 	} else {
-// 		if err := d.Set("owner", resource.Owner.Alias); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	created_at := resource.Timestamps.CreatedAt.Local().Format(time.RFC850)
-// 	if err := d.Set("created_at", created_at); err != nil {
-// 		return err
-// 	}
-// 	updated_at := resource.Timestamps.UpdatedAt.Local().Format(time.RFC850)
-// 	if err := d.Set("updated_at", updated_at); err != nil {
-// 		return err
-// 	}
-
-// 	return nil
-// }
-
-// func resourceSecretUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	input := opslevel.SecretInput{
-// 		Owner: opslevel.NewIdentifier(d.Get("owner").(string)),
-// 		Value: opslevel.RefOf(d.Get("value").(string)),
-// 	}
-
-// 	_, err := client.UpdateSecret(d.Id(), input)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceSecretRead(d, client)
-// }
-
-// func resourceSecretDelete(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
-// 	err := client.DeleteSecret(id)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId("")
-// 	return nil
-// }

--- a/opslevel/resource_opslevel_user.go
+++ b/opslevel/resource_opslevel_user.go
@@ -62,7 +62,10 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 		Attributes: map[string]schema.Attribute{
 			"email": schema.StringAttribute{
 				Description: "The email address of the user.",
-				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Required: true,
 			},
 			"id": schema.StringAttribute{
 				Description: "The ID of the user.",


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add missing `stringplanmodifier.RequiresReplace()` to `secret` and `user` resources. I missed this during my first pass at these resource upgrade.

The old `ForceNew: true,` from SDKv2 needs to be replaced by a `RequiresReplace` PlanModifier [see upgrade docs](https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/force-new) and [RequiresReplace doc](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#requiresreplace)
- [link to secret's email field](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/opslevel/resource_opslevel_user.go#L34) with `ForceNew: true,`
- [link to user's alias field](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/opslevel/resource_opslevel_secrets.go#L29) with `ForceNew:true,`

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
