### PR TITLE
add infra resource, with tests

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewDomainResource,
+		NewInfrastructureResource,
 		NewSecretResource,
 		NewUserResource,
 	}

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -230,6 +230,12 @@ func (r *InfrastructureResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 	updatedInfrastructureResourceModel, diags := NewInfrastructureResourceModel(ctx, *updatedInfrastructure)
+
+	if data.ProviderData == nil && updatedInfrastructureResourceModel.ProviderData != nil {
+		resp.Diagnostics.AddError("Known error", "Unable to unset 'provider_data' field for now. We have a planned fix for this.")
+		return
+	}
+
 	resp.Diagnostics.Append(diags...)
 	updatedInfrastructureResourceModel.Aliases = data.Aliases
 	updatedInfrastructureResourceModel.LastUpdated = timeLastUpdated()

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -1,5 +1,408 @@
 package opslevel
 
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	// "github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
+
+var _ resource.ResourceWithConfigure = &InfrastructureResource{}
+
+var _ resource.ResourceWithImportState = &InfrastructureResource{}
+
+func NewInfrastructureResource() resource.Resource {
+	return &InfrastructureResource{}
+}
+
+// InfrastructureResource defines the resource implementation.
+type InfrastructureResource struct {
+	CommonResourceClient
+}
+
+// WIP: pick up here
+var infraProviderAttrTypes = map[string]attr.Type{
+	"account": types.StringType,
+	"name":    types.StringType,
+	"type":    types.StringType,
+	"url":     types.StringType,
+}
+
+// NOTE: old approach, might drop
+var infraProviderDataObjectType = types.ObjectType{
+	AttrTypes: infraProviderAttrTypes,
+}
+
+func newInfraProviderData(infrastructure opslevel.InfrastructureResource) (basetypes.ObjectValue, diag.Diagnostics) {
+	infraAttrs := make(map[string]attr.Value)
+	infraAttrs["account"] = RequiredStringValue(infrastructure.ProviderData.AccountName)
+	infraAttrs["name"] = OptionalStringValue(infrastructure.ProviderData.ProviderName)
+	infraAttrs["type"] = OptionalStringValue(infrastructure.ProviderType)
+	infraAttrs["url"] = OptionalStringValue(infrastructure.ProviderData.ExternalURL)
+	return types.ObjectValue(identifierObjectType.AttrTypes, infraAttrs)
+}
+
+// InfrastructureResourceModel describes the Infrastructure managed resource.
+type InfrastructureResourceModel struct {
+	Aliases      types.List   `tfsdk:"aliases"`
+	Data         types.String `tfsdk:"data"`
+	Id           types.String `tfsdk:"id"`
+	LastUpdated  types.String `tfsdk:"last_updated"`
+	ProviderData types.Object `tfsdk:"provider_data"`
+	Owner        types.String `tfsdk:"owner"`
+	Schema       types.String `tfsdk:"schema"`
+}
+
+func NewInfrastructureResourceModel(ctx context.Context, infrastructure opslevel.InfrastructureResource) (InfrastructureResourceModel, diag.Diagnostics) {
+	providerData, diags := newInfraProviderData(infrastructure)
+
+	aliases, diags := OptionalStringListValue(ctx, infrastructure.Aliases)
+	return InfrastructureResourceModel{
+		Aliases:      aliases,
+		Data:         OptionalStringValue(infrastructure.Data.ToJSON()),
+		Id:           ComputedStringValue(infrastructure.Id),
+		ProviderData: providerData,
+		Owner:        OptionalStringValue(string(infrastructure.Owner.Id())),
+		Schema:       RequiredStringValue(infrastructure.Schema),
+	}, diags
+}
+
+func (r *InfrastructureResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_infrastructure"
+}
+
+func (r *InfrastructureResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Infrastructure Resource",
+
+		Attributes: map[string]schema.Attribute{
+			"aliases": schema.ListAttribute{
+				ElementType: types.StringType,
+				Description: "The aliases for the infrastructure resource.",
+				Optional:    true,
+			},
+			"data": schema.StringAttribute{
+				Description: "The data of the infrastructure resource in JSON format.",
+				Optional:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "The ID of the infrastructure.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Computed: true,
+			},
+			"owner": schema.StringAttribute{
+				Description: "The id of the team that owns the infrastructure resource. Does not support aliases!",
+				Optional:    true,
+				Validators:  []validator.String{IdStringValidator()},
+			},
+			"provider_data": schema.SingleNestedAttribute{
+				Description: "The provider specific data for the infrastructure resource.",
+				Optional:    true,
+				Default:     objectdefault.StaticValue(types.ObjectNull(infraProviderAttrTypes)),
+				Attributes: map[string]schema.Attribute{
+					"account": schema.StringAttribute{
+						Description: "The canonical account name for the provider of the infrastructure resource.",
+						Required:    true,
+					},
+					"name": schema.StringAttribute{
+						Description: "The name of the provider of the infrastructure resource. (eg. AWS, GCP, Azure)",
+						Optional:    true,
+					},
+					"type": schema.StringAttribute{
+						Description: "The type of the infrastructure resource as defined by its provider.",
+						Optional:    true,
+					},
+					"url": schema.StringAttribute{
+						Description: "The url for the provider of the infrastructure resource.",
+						Optional:    true,
+					},
+				},
+			},
+			"schema": schema.StringAttribute{
+				Description: "The schema of the infrastructure resource that determines its data specification.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (r *InfrastructureResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data InfrastructureResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newJSON, err := opslevel.NewJSON(data.Data.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to parse infrastructure resource 'data' into JSON, got error: %s", err))
+		return
+	}
+
+	infrastructure, err := r.client.CreateInfrastructure(opslevel.InfraInput{
+		Schema: data.Schema.ValueString(),
+		Owner:  opslevel.NewID(data.Owner.ValueString()),
+		Data:   newJSON,
+		// Provider: expandInfraProviderData(data.ProviderData), // TODO: fix this
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create infrastructure, got error: %s", err))
+		return
+	}
+
+	createdInfrastructureResourceModel, diags := NewInfrastructureResourceModel(ctx, *infrastructure)
+	resp.Diagnostics.Append(diags...)
+	if data.Aliases.IsNull() {
+		createdInfrastructureResourceModel.Aliases = data.Aliases
+	}
+	createdInfrastructureResourceModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a infrastructure resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &createdInfrastructureResourceModel)...)
+}
+
+func (r *InfrastructureResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data InfrastructureResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	infrastructure, err := r.client.GetInfrastructure(data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read infrastructure, got error: %s", err))
+		return
+	}
+	readInfrastructureResourceModel, diags := NewInfrastructureResourceModel(ctx, *infrastructure)
+	resp.Diagnostics.Append(diags...)
+	if data.Aliases.IsNull() {
+		readInfrastructureResourceModel.Aliases = data.Aliases
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &readInfrastructureResourceModel)...)
+}
+
+func (r *InfrastructureResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data InfrastructureResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newJSON, err := opslevel.NewJSON(data.Data.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to parse infrastructure resource 'data' into JSON, got error: %s", err))
+		return
+	}
+	updatedInfrastructure, err := r.client.UpdateInfrastructure(data.Id.ValueString(), opslevel.InfraInput{
+		Schema: data.Schema.ValueString(),
+		Owner:  opslevel.NewID(data.Owner.ValueString()),
+		Data:   newJSON,
+		// Provider: expandInfraProviderData(data.ProviderData), // TODO: fix this
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update infrastructure, got error: %s", err))
+		return
+	}
+	updatedInfrastructureResourceModel, diags := NewInfrastructureResourceModel(ctx, *updatedInfrastructure)
+	resp.Diagnostics.Append(diags...)
+	if data.Aliases.IsNull() {
+		updatedInfrastructureResourceModel.Aliases = data.Aliases
+	}
+	updatedInfrastructureResourceModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a infrastructure resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedInfrastructureResourceModel)...)
+}
+
+func (r *InfrastructureResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data InfrastructureResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteInfrastructure(data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete infrastructure, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a infrastructure resource")
+}
+
+func (r *InfrastructureResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// TODO: fix this
+// func expandInfraProviderData(providerData map[string]attr.Type) *opslevel.InfraProviderInput {
+// 	var blank infraProviderData
+// 	if providerData == blank {
+// 		return &opslevel.InfraProviderInput{}
+// 	}
+// 	return &opslevel.InfraProviderInput{
+// 		Account: providerData.Account.ValueString(),
+// 		Name:    providerData.Name.ValueString(),
+// 		Type:    providerData.Type.ValueString(),
+// 		URL:     providerData.Url.ValueString(),
+// 	}
+// }
+
+// import (
+// 	"time"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+// 	"github.com/opslevel/opslevel-go/v2024"
+// )
+
+// func resourceInfrastructure() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Manages a infrastructure",
+// 		Create:      wrap(resourceInfrastructureCreate),
+// 		Read:        wrap(resourceInfrastructureRead),
+// 		Update:      wrap(resourceInfrastructureUpdate),
+// 		Delete:      wrap(resourceInfrastructureDelete),
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"last_updated": {
+// 				Type:     schema.TypeString,
+// 				Optional: true,
+// 				Computed: true,
+// 			},
+// 			"alias": {
+// 				Type:        schema.TypeString,
+// 				Description: "The alias for this infrastructure.",
+// 				ForceNew:    true,
+// 				Required:    true,
+// 			},
+// 			"owner": {
+// 				Type:        schema.TypeString,
+// 				Description: "The owner of this infrastructure.",
+// 				ForceNew:    false,
+// 				Required:    true,
+// 			},
+// 			"value": {
+// 				Type:        schema.TypeString,
+// 				Description: "A sensitive value.",
+// 				Sensitive:   true,
+// 				ForceNew:    false,
+// 				Required:    true,
+// 			},
+// 			"created_at": {
+// 				Type:        schema.TypeString,
+// 				Description: "Timestamp of time created at.",
+// 				Computed:    true,
+// 			},
+// 			"updated_at": {
+// 				Type:        schema.TypeString,
+// 				Description: "Timestamp of last update.",
+// 				Computed:    true,
+// 			},
+// 		},
+// 	}
+// }
+
+// func resourceInfrastructureCreate(d *schema.ResourceData, client *opslevel.Client) error {
+// 	input := opslevel.InfrastructureInput{
+// 		Owner: opslevel.NewIdentifier(d.Get("owner").(string)),
+// 		Value: opslevel.RefOf(d.Get("value").(string)),
+// 	}
+// 	alias := d.Get("alias").(string)
+// 	resource, err := client.CreateInfrastructure(alias, input)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	d.SetId(string(resource.ID))
+// 	return resourceInfrastructureRead(d, client)
+// }
+
+// func resourceInfrastructureRead(d *schema.ResourceData, client *opslevel.Client) error {
+// 	id := d.Id()
+
+// 	resource, err := client.GetInfrastructure(id)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	if opslevel.IsID(d.Get("owner").(string)) {
+// 		if err := d.Set("owner", resource.Owner.Id); err != nil {
+// 			return err
+// 		}
+// 	} else {
+// 		if err := d.Set("owner", resource.Owner.Alias); err != nil {
+// 			return err
+// 		}
+// 	}
+// 	created_at := resource.Timestamps.CreatedAt.Local().Format(time.RFC850)
+// 	if err := d.Set("created_at", created_at); err != nil {
+// 		return err
+// 	}
+// 	updated_at := resource.Timestamps.UpdatedAt.Local().Format(time.RFC850)
+// 	if err := d.Set("updated_at", updated_at); err != nil {
+// 		return err
+// 	}
+
+// 	return nil
+// }
+
+// func resourceInfrastructureUpdate(d *schema.ResourceData, client *opslevel.Client) error {
+// 	input := opslevel.InfrastructureInput{
+// 		Owner: opslevel.NewIdentifier(d.Get("owner").(string)),
+// 		Value: opslevel.RefOf(d.Get("value").(string)),
+// 	}
+
+// 	_, err := client.UpdateInfrastructure(d.Id(), input)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	d.Set("last_updated", timeLastUpdated())
+// 	return resourceInfrastructureRead(d, client)
+// }
+
+// func resourceInfrastructureDelete(d *schema.ResourceData, client *opslevel.Client) error {
+// 	id := d.Id()
+// 	err := client.DeleteInfrastructure(id)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	d.SetId("")
+// 	return nil
+// }
+
 // import (
 // 	"slices"
 

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -1,6 +1,9 @@
 package opslevel
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -9,7 +12,7 @@ import (
 
 // Returns value wrapped in a types.StringValue, even if blank string given
 func RequiredStringValue(value string) basetypes.StringValue {
-	return types.StringValue(value)
+	return types.StringValue(unquote(value))
 }
 
 // Returns value wrapped in a types.StringValue, or types.StringNull if blank
@@ -17,7 +20,7 @@ func OptionalStringValue(value string) basetypes.StringValue {
 	if value == "" {
 		return types.StringNull()
 	}
-	return types.StringValue(value)
+	return types.StringValue(unquote(value))
 }
 
 // Syntactic sugar for OptionalStringValue
@@ -33,4 +36,14 @@ func OptionalStringListValue(ctx context.Context, value []string) (basetypes.Lis
 		return types.ListNull(types.StringType), diag.Diagnostics{}
 	}
 	return types.ListValueFrom(ctx, types.StringType, value)
+}
+
+// unquotes unwanted quotes from strings in maps, returns original value in most cases
+func unquote(value string) string {
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		if unquotedValue, err := strconv.Unquote(value); err == nil {
+			return unquotedValue
+		}
+	}
+	return value
 }

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -1,0 +1,36 @@
+package opslevel
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"golang.org/x/net/context"
+)
+
+// Returns value wrapped in a types.StringValue, even if blank string given
+func RequiredStringValue(value string) basetypes.StringValue {
+	return types.StringValue(value)
+}
+
+// Returns value wrapped in a types.StringValue, or types.StringNull if blank
+func OptionalStringValue(value string) basetypes.StringValue {
+	if value == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(value)
+}
+
+// Syntactic sugar for OptionalStringValue
+func ComputedStringValue(value string) basetypes.StringValue {
+	return OptionalStringValue(value)
+}
+
+// Returns value wrapped in a types.StringValue, or types.ListNull if blank
+//
+// NOTE: an empty list is not the same as 'null'
+func OptionalStringListValue(ctx context.Context, value []string) (basetypes.ListValue, diag.Diagnostics) {
+	if value == nil {
+		return types.ListNull(types.StringType), diag.Diagnostics{}
+	}
+	return types.ListValueFrom(ctx, types.StringType, value)
+}

--- a/opslevel/validators.go
+++ b/opslevel/validators.go
@@ -2,6 +2,7 @@ package opslevel
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -28,12 +29,76 @@ func (v idStringValidator) ValidateString(ctx context.Context, request validator
 	}
 
 	value := request.ConfigValue.ValueString()
-
 	if !opslevel.IsID(value) {
-		response.Diagnostics.AddError("expected a valid id", fmt.Sprintf("a valid id should start with Z2lkOi8v. %s was set to `%s`", request.Path, value))
+		response.Diagnostics.AddError("Config error", fmt.Sprintf("expected a valid id. id should start with Z2lkOi8v. '%s' was set to `%s`", request.Path, value))
 	}
 }
 
 func IdStringValidator() validator.String {
 	return idStringValidator{}
+}
+
+// OpsLevel ID String Validator
+type jsonStringValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (v jsonStringValidator) Description(_ context.Context) string {
+	return "field expected to be valid JSON"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v jsonStringValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v jsonStringValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	if !json.Valid([]byte(value)) {
+		response.Diagnostics.AddError("Config error", fmt.Sprintf("expected valid JSON. %s was set to `%s`", request.Path, value))
+	}
+}
+
+func JsonStringValidator() validator.String {
+	return jsonStringValidator{}
+}
+
+// OpsLevel ID String Validator
+type jsonHasNameKeyValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (v jsonHasNameKeyValidator) Description(_ context.Context) string {
+	return "field expected to be valid JSON with a 'name' key to some value"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v jsonHasNameKeyValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v jsonHasNameKeyValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	result := make(map[string]any)
+	if err := json.Unmarshal([]byte(value), &result); err != nil {
+		response.Diagnostics.AddError("Config error", fmt.Sprintf("expected valid JSON. '%s' was set to `%s`", request.Path, value))
+		return
+	}
+	if _, ok := result["name"]; !ok {
+		response.Diagnostics.AddError("Config error", fmt.Sprintf("expected JSON with 'name' key mapped to some value.\n'%s' was set to `%s`", request.Path, value))
+	}
+}
+
+func JsonHasNameKeyValidator() validator.String {
+	return jsonHasNameKeyValidator{}
 }

--- a/opslevel/validators.go
+++ b/opslevel/validators.go
@@ -8,7 +8,7 @@ import (
 	"github.com/opslevel/opslevel-go/v2024"
 )
 
-// Non Empty String Validator
+// OpsLevel ID String Validator
 type idStringValidator struct{}
 
 // Description describes the validation in plain text formatting.

--- a/tests/data_sources.tf
+++ b/tests/data_sources.tf
@@ -18,7 +18,7 @@ data "opslevel_filter" "name_filter" {
 data "opslevel_filter" "id_filter" {
   filter {
     field = "id"
-    value = "Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+    value = var.test_id
   }
 }
 

--- a/tests/mock_resource/infra.tfmock.hcl
+++ b/tests/mock_resource/infra.tfmock.hcl
@@ -1,0 +1,4 @@
+mock_resource "opslevel_infrastructure" {
+  # placeholder - only computed fields here are "id" and "last_updated"
+  defaults = {}
+}

--- a/tests/resource_infra.tftest.hcl
+++ b/tests/resource_infra.tftest.hcl
@@ -10,12 +10,24 @@ run "resource_infra_small" {
 
   assert {
     condition     = !contains([null, ""], opslevel_infrastructure.small_infra.id)
-    error_message = "opslevel_infrastructure id should not be empty"
+    error_message = "opslevel_infrastructure.small_infra id should not be empty"
   }
 
   assert {
     condition     = !contains([null, ""], opslevel_infrastructure.small_infra.last_updated)
-    error_message = "opslevel_infrastructure last_updated should not be empty"
+    error_message = "opslevel_infrastructure.small_infra last_updated should not be empty"
+  }
+
+  assert {
+    condition = opslevel_infrastructure.small_infra.data == jsonencode({
+      name = "big-query"
+    })
+    error_message = "wrong data in opslevel_infrastructure.small_infra"
+  }
+
+  assert {
+    condition     = opslevel_infrastructure.small_infra.owner == var.test_id
+    error_message = "wrong owner for opslevel_infrastructure.small_infra"
   }
 
   assert {
@@ -46,7 +58,7 @@ run "resource_infra_big" {
         value = 700
       }
     })
-    error_message = "wrong data in opslevel_infrastructure.data"
+    error_message = "wrong data in opslevel_infrastructure.big_infra"
   }
 
   assert {
@@ -61,7 +73,7 @@ run "resource_infra_big" {
       type    = "BigQuery"
       url     = "https://console.cloud.google.com/"
     }
-    error_message = "wrong provider_data in opslevel_infrastructure.data"
+    error_message = "wrong provider_data in opslevel_infrastructure.big_infra"
   }
 
   assert {

--- a/tests/resource_infra.tftest.hcl
+++ b/tests/resource_infra.tftest.hcl
@@ -1,0 +1,72 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_infra_small" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = !contains([null, ""], opslevel_infrastructure.small_infra.id)
+    error_message = "opslevel_infrastructure id should not be empty"
+  }
+
+  assert {
+    condition     = !contains([null, ""], opslevel_infrastructure.small_infra.last_updated)
+    error_message = "opslevel_infrastructure last_updated should not be empty"
+  }
+
+  assert {
+    condition     = opslevel_infrastructure.small_infra.schema == "Small Database"
+    error_message = "wrong schema for opslevel_infrastructure.small_infra"
+  }
+
+}
+
+run "resource_infra_big" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_infrastructure.big_infra.aliases == tolist(["big-infra"])
+    error_message = "wrong aliases in opslevel_infrastructure.big_infra"
+  }
+
+  assert {
+    condition = opslevel_infrastructure.big_infra.data == jsonencode({
+      name                = "big-query"
+      external_id         = 1234
+      replica             = true
+      publicly_accessible = false
+      storage_size = {
+        unit  = "GB"
+        value = 700
+      }
+    })
+    error_message = "wrong data in opslevel_infrastructure.data"
+  }
+
+  assert {
+    condition     = startswith(opslevel_infrastructure.big_infra.owner, "Z2lkOi8v")
+    error_message = "wrong owner in opslevel_infrastructure.big_infra"
+  }
+
+  assert {
+    condition = opslevel_infrastructure.big_infra.provider_data == {
+      account = "dev"
+      name    = "google cloud"
+      type    = "BigQuery"
+      url     = "https://console.cloud.google.com/"
+    }
+    error_message = "wrong provider_data in opslevel_infrastructure.data"
+  }
+
+  assert {
+    condition     = opslevel_infrastructure.big_infra.schema == "Big Database"
+    error_message = "wrong schema for opslevel_infrastructure.big_infra"
+  }
+
+}

--- a/tests/resource_infra.tftest.hcl
+++ b/tests/resource_infra.tftest.hcl
@@ -20,7 +20,7 @@ run "resource_infra_small" {
 
   assert {
     condition = opslevel_infrastructure.small_infra.data == jsonencode({
-      name = "big-query"
+      name = "small-query"
     })
     error_message = "wrong data in opslevel_infrastructure.small_infra"
   }

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -7,6 +7,35 @@ resource "opslevel_domain" "fancy" {
   note        = "This is an example"
 }
 
+# Infrastructure resources
+
+resource "opslevel_infrastructure" "small_infra" {
+  schema = "Small Database"
+}
+
+
+resource "opslevel_infrastructure" "big_infra" {
+  aliases = ["big-infra"]
+  data = jsonencode({
+    name                = "big-query"
+    external_id         = 1234
+    replica             = true
+    publicly_accessible = false
+    storage_size = {
+      unit  = "GB"
+      value = 700
+    }
+  })
+  owner = "Z2lkOi8vukla122kljf"
+  provider_data = {
+    account = "dev"
+    name    = "google cloud"
+    type    = "BigQuery"
+    url     = "https://console.cloud.google.com/"
+  }
+  schema = "Big Database"
+}
+
 # Secret resources
 
 resource "opslevel_secret" "mock_secret" {

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -10,6 +10,10 @@ resource "opslevel_domain" "fancy" {
 # Infrastructure resources
 
 resource "opslevel_infrastructure" "small_infra" {
+  data = jsonencode({
+    name = "small-query"
+  })
+  owner  = var.test_id
   schema = "Small Database"
 }
 

--- a/tests/variables.tf
+++ b/tests/variables.tf
@@ -1,0 +1,11 @@
+variable "test_id" {
+  type        = string
+  description = "id for testing"
+  default     = "Z2lkOi8vb3BzbGV2ZWwvVGllci8yMTAw"
+
+  validation {
+    condition     = startswith(var.test_id, "Z2lkOi8v")
+    error_message = "expected test_id to start with Z2lkOi8v"
+  }
+}
+


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/308

## Changelog

[public docs](https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/resources/infrastructure)

Changes:
- Add `infrastructure` resource, with tests

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
resource "opslevel_infrastructure" "big" {
  aliases = ["one", "two"]
  data = jsonencode({
    name                = "big-query-123"
    external_id         = "example_2_1234"
    zone                = "us-east-1"
    engine              = "bigquery"
    engine_version      = "1.28.0"
    endpoint            = "https://console.cloud.google.com/..."
    replica             = false
    publicly_accessible = false
    storage_size = {
      unit  = "GB"
      value = 700
    }
    storage_type = "gp3"
    storage_iops = {
      unit  = "per second"
      value = 12000
    }
  })
  owner = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  provider_data = {
    account = "dev"
    name    = "google cloud"
    type    = "BigQuery"
    url     = "https://console.cloud.google.com/..."
  }
  schema = "Database"
}
```

Create infrastructure resource. Run `terraform apply`
```terraform
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_infrastructure.big will be created
  + resource "opslevel_infrastructure" "big" {
      + aliases       = [
          + "one",
          + "two",
        ]
      + data          = jsonencode(
            {
              + endpoint            = "https://console.cloud.google.com/..."
              + engine              = "bigquery"
              + engine_version      = "1.28.0"
              + external_id         = "example_2_1234"
              + name                = "big-query-123"
              + publicly_accessible = false
              + replica             = false
              + storage_iops        = {
                  + unit  = "per second"
                  + value = 12000
                }
              + storage_size        = {
                  + unit  = "GB"
                  + value = 700
                }
              + storage_type        = "gp3"
              + zone                = "us-east-1"
            }
        )
      + id            = (known after apply)
      + last_updated  = (known after apply)
      + owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
      + provider_data = {
          + account = "dev"
          + name    = "google cloud"
          + type    = "BigQuery"
          + url     = "https://console.cloud.google.com/..."
        }
      + schema        = "Database"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_infrastructure.big: Creating...
opslevel_infrastructure.big: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Update terraform config file
```tf
resource "opslevel_infrastructure" "big" {
  aliases = null
  data = jsonencode({
    name                = "big-query-123"
    external_id         = "example_2_1234"
    zone                = "us-east-1"
    engine              = "bigquery"
    engine_version      = "1.29.0"
    endpoint            = "https://console.cloud.google.com/..."
    replica             = false
    publicly_accessible = false
    storage_size = {
      unit  = "GB"
      value = 789
    }
    storage_type = "gp3"
    storage_iops = {
      unit  = "per second"
      value = 12345
    }
  })
  owner = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  provider_data = {
    account = "dev"
    # name    = "google cloud"
    # type    = "BigQuery"
    # url     = "https://console.cloud.google.com/..."
  }
  schema = "Database"
}
```

Update infrastructure resource. Run `terraform apply`
```tf
opslevel_infrastructure.big: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.big will be updated in-place
  ~ resource "opslevel_infrastructure" "big" {
      - aliases       = [
          - "one",
          - "two",
        ] -> null
      ~ data          = jsonencode(
          ~ {
              ~ engine_version      = "1.28.0" -> "1.29.0"
                name                = "big-query-123"
              ~ storage_iops        = {
                  ~ value = 12000 -> 12345
                    # (1 unchanged attribute hidden)
                }
              ~ storage_size        = {
                  ~ value = 700 -> 789
                    # (1 unchanged attribute hidden)
                }
                # (7 unchanged attributes hidden)
            }
        )
        id            = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg"
      + last_updated  = (known after apply)
      ~ provider_data = {
          - name    = "google cloud" -> null
          - type    = "BigQuery" -> null
          - url     = "https://console.cloud.google.com/..." -> null
            # (1 unchanged attribute hidden)
        }
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_infrastructure.big: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]
opslevel_infrastructure.big: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

## Test known error
Ticket to fix this [here](https://github.com/OpsLevel/team-platform/issues/324)

Set `provider_data = null`. This currently fails but should work after the linked ticket is finished. For now we are telling customers that we know about the issue with a custom error message.
```tf
resource "opslevel_infrastructure" "big" {
  aliases = null
  data = jsonencode({
    name                = "big-query-123"
    external_id         = "example_2_1234"
    zone                = "us-east-1"
    engine              = "bigquery"
    engine_version      = "1.29.0"
    endpoint            = "https://console.cloud.google.com/..."
    replica             = false
    publicly_accessible = false
    storage_size = {
      unit  = "GB"
      value = 789
    }
    storage_type = "gp3"
    storage_iops = {
      unit  = "per second"
      value = 12345
    }
  })
  owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  provider_data = null
  schema        = "Database"
}
```

Run `terraform apply`, see expected error message
```tf
opslevel_infrastructure.big: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.big will be updated in-place
  ~ resource "opslevel_infrastructure" "big" {
        id            = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg"
      + last_updated  = (known after apply)
      - provider_data = {
          - account = "dev" -> null
        } -> null
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_infrastructure.big: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]
╷
│ Error: Known error
│ 
│   with opslevel_infrastructure.big,
│   on main.tf line 1, in resource "opslevel_infrastructure" "big":
│    1: resource "opslevel_infrastructure" "big" {
│ 
│ Unable to unset 'provider_data' field for now. We have a planned fix for this.
```

Run `terraform destroy`,
```tf
opslevel_infrastructure.big: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_infrastructure.big will be destroyed
  - resource "opslevel_infrastructure" "big" {
      - data          = jsonencode(
            {
              - endpoint            = "https://console.cloud.google.com/..."
              - engine              = "bigquery"
              - engine_version      = "1.29.0"
              - external_id         = "example_2_1234"
              - name                = "big-query-123"
              - publicly_accessible = false
              - replica             = false
              - storage_iops        = {
                  - unit  = "per second"
                  - value = 12345
                }
              - storage_size        = {
                  - unit  = "GB"
                  - value = 789
                }
              - storage_type        = "gp3"
              - zone                = "us-east-1"
            }
        ) -> null
      - id            = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg" -> null
      - owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
      - provider_data = {
          - account = "dev" -> null
        } -> null
      - schema        = "Database" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_infrastructure.big: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzE5NjkxMDg]
opslevel_infrastructure.big: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```