### PR TITLE
add rubric_level resource, with tests

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -154,6 +154,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 	return []func() resource.Resource{
 		NewDomainResource,
 		NewInfrastructureResource,
+		NewRubricLevelResource,
 		NewSecretResource,
 		NewUserResource,
 	}

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -154,7 +154,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 	return []func() resource.Resource{
 		NewDomainResource,
 		NewInfrastructureResource,
-    NewRubricCategoryResource,
+		NewRubricCategoryResource,
 		NewRubricLevelResource,
 		NewSecretResource,
 		NewUserResource,

--- a/opslevel/resource_opslevel_rubric_level.go
+++ b/opslevel/resource_opslevel_rubric_level.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -73,10 +71,8 @@ func (r *RubricLevelResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"index": schema.Int64Attribute{
 				Description: "An integer allowing this level to be inserted between others. Must be unique per rubric.",
+				Computed:    true,
 				Optional:    true,
-				Validators: []validator.Int64{
-					int64validator.AtMost(6),
-				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},

--- a/opslevel/resource_opslevel_rubric_level.go
+++ b/opslevel/resource_opslevel_rubric_level.go
@@ -1,115 +1,191 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
 
-// func resourceRubricLevel() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a rubric level",
-// 		Create:      wrap(resourceRubricLevelCreate),
-// 		Read:        wrap(resourceRubricLevelRead),
-// 		Update:      wrap(resourceRubricLevelUpdate),
-// 		Delete:      wrap(resourceRubricLevelDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: map[string]*schema.Schema{
-// 			"last_updated": {
-// 				Type:     schema.TypeString,
-// 				Optional: true,
-// 				Computed: true,
-// 			},
-// 			"name": {
-// 				Type:        schema.TypeString,
-// 				Description: "The display name of the category.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"description": {
-// 				Type:        schema.TypeString,
-// 				Description: "The description of the category.",
-// 				ForceNew:    false,
-// 				Optional:    true,
-// 			},
-// 			"index": {
-// 				Type:         schema.TypeInt,
-// 				Description:  "An integer allowing this level to be inserted between others. Must be unique per Rubric.",
-// 				ForceNew:     true,
-// 				Optional:     true,
-// 				ValidateFunc: validation.IntInSlice([]int{0, 1, 2, 3, 4, 5, 6}),
-// 			},
-// 		},
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
-// func resourceRubricLevelCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	input := opslevel.LevelCreateInput{
-// 		Name:        d.Get("name").(string),
-// 		Description: opslevel.RefOf(d.Get("description").(string)),
-// 	}
-// 	if v, ok := d.GetOk("index"); ok {
-// 		index := v.(int)
-// 		input.Index = &index
-// 	}
-// 	resource, err := client.CreateLevel(input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
-// 	return resourceRubricLevelRead(d, client)
-// }
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func resourceRubricLevelRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+var _ resource.ResourceWithConfigure = &RubricLevelResource{}
 
-// 	resource, err := client.GetLevel(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+var _ resource.ResourceWithImportState = &RubricLevelResource{}
 
-// 	if err := d.Set("name", resource.Name); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("description", resource.Description); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("index", resource.Index); err != nil {
-// 		return err
-// 	}
+func NewRubricLevelResource() resource.Resource {
+	return &RubricLevelResource{}
+}
 
-// 	return nil
-// }
+// RubricLevelResource defines the resource implementation.
+type RubricLevelResource struct {
+	CommonResourceClient
+}
 
-// func resourceRubricLevelUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	input := opslevel.LevelUpdateInput{
-// 		Id: opslevel.ID(d.Id()),
-// 	}
+// RubricLevelResourceModel describes the rubric level managed resource.
+type RubricLevelResourceModel struct {
+	Description types.String `tfsdk:"description"`
+	Id          types.String `tfsdk:"id"`
+	Index       types.Int64  `tfsdk:"index"`
+	LastUpdated types.String `tfsdk:"last_updated"`
+	Name        types.String `tfsdk:"name"`
+}
 
-// 	if d.HasChange("name") {
-// 		input.Name = opslevel.RefOf(d.Get("name").(string))
-// 	}
-// 	if d.HasChange("description") {
-// 		input.Description = opslevel.RefOf(d.Get("description").(string))
-// 	}
+func NewRubricLevelResourceModel(rubricLevel opslevel.Level) RubricLevelResourceModel {
+	return RubricLevelResourceModel{
+		Description: OptionalStringValue(rubricLevel.Description),
+		Id:          ComputedStringValue(string(rubricLevel.Id)),
+		Index:       types.Int64Value(int64(rubricLevel.Index)),
+		Name:        RequiredStringValue(rubricLevel.Name),
+	}
+}
 
-// 	_, err := client.UpdateLevel(input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceRubricLevelRead(d, client)
-// }
+func (r *RubricLevelResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_rubric_level"
+}
 
-// func resourceRubricLevelDelete(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
-// 	err := client.DeleteLevel(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId("")
-// 	return nil
-// }
+func (r *RubricLevelResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Rubric Level Resource",
+
+		Attributes: map[string]schema.Attribute{
+			"description": schema.StringAttribute{
+				Description: "The description of the rubric level.",
+				Optional:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "The ID of the rubric level.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"index": schema.Int64Attribute{
+				Description: "An integer allowing this level to be inserted between others. Must be unique per rubric.",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.AtMost(6),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplace(),
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Computed: true,
+				Optional: true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The display name of the rubric level.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (r *RubricLevelResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data RubricLevelResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	levelCreateInput := opslevel.LevelCreateInput{
+		Name:        data.Name.ValueString(),
+		Description: data.Description.ValueStringPointer(),
+	}
+	if !data.Index.IsNull() && !data.Index.IsUnknown() {
+		index := int(data.Index.ValueInt64())
+		levelCreateInput.Index = &index
+	}
+	rubricLevel, err := r.client.CreateLevel(levelCreateInput)
+	if err != nil || rubricLevel == nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create rubric level, got error: %s", err))
+		return
+	}
+
+	createdRubricLevelResourceModel := NewRubricLevelResourceModel(*rubricLevel)
+	createdRubricLevelResourceModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a rubric level resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &createdRubricLevelResourceModel)...)
+}
+
+func (r *RubricLevelResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data RubricLevelResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	rubricLevel, err := r.client.GetLevel(opslevel.ID(data.Id.ValueString()))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read rubric level, got error: %s", err))
+		return
+	}
+	readRubricLevelResourceModel := NewRubricLevelResourceModel(*rubricLevel)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &readRubricLevelResourceModel)...)
+}
+
+func (r *RubricLevelResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data RubricLevelResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatedRubricLevel, err := r.client.UpdateLevel(opslevel.LevelUpdateInput{
+		Description: data.Description.ValueStringPointer(),
+		Id:          opslevel.ID(data.Id.ValueString()),
+		Name:        data.Name.ValueStringPointer(),
+	})
+	if err != nil || updatedRubricLevel == nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update rubric level, got error: %s", err))
+		return
+	}
+	updatedRubricLevelResourceModel := NewRubricLevelResourceModel(*updatedRubricLevel)
+	updatedRubricLevelResourceModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a rubric level resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedRubricLevelResourceModel)...)
+}
+
+func (r *RubricLevelResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data RubricLevelResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteLevel(opslevel.ID(data.Id.ValueString()))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete rubric level, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a rubric level resource")
+}
+
+func (r *RubricLevelResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -47,8 +47,3 @@ func unquote(value string) string {
 	}
 	return value
 }
-
-// Returns value wrapped in a types.Int64Value
-func RequiredInt64Value(value int) basetypes.Int64Value {
-	return types.Int64Value(int64(value))
-}

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -47,3 +47,8 @@ func unquote(value string) string {
 	}
 	return value
 }
+
+// Returns value wrapped in a types.Int64Value
+func RequiredInt64Value(value int) basetypes.Int64Value {
+	return types.Int64Value(int64(value))
+}

--- a/tests/mock_resource/rubric_level.tfmock.hcl
+++ b/tests/mock_resource/rubric_level.tfmock.hcl
@@ -1,0 +1,4 @@
+mock_resource "opslevel_rubric_level" {
+  # placeholder - only computed fields here are "id" and "last_updated"
+  defaults = {}
+}

--- a/tests/mock_resource/rubric_level.tfmock.hcl
+++ b/tests/mock_resource/rubric_level.tfmock.hcl
@@ -1,4 +1,5 @@
 mock_resource "opslevel_rubric_level" {
-  # placeholder - only computed fields here are "id" and "last_updated"
-  defaults = {}
+  defaults = {
+    index = 2
+  }
 }

--- a/tests/resource_rubric_level.tftest.hcl
+++ b/tests/resource_rubric_level.tftest.hcl
@@ -1,0 +1,43 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_rubric_level_small" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_rubric_level.small.id != null && opslevel_rubric_level.small.id != ""
+    error_message = "opslevel_rubric_level.small id should not be empty"
+  }
+
+  assert {
+    condition     = opslevel_rubric_level.small.name == "small rubric level"
+    error_message = "wrong name for opslevel_rubric_level.small"
+  }
+
+}
+
+run "resource_rubric_level_big" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_rubric_level.big.description == "big rubric description"
+    error_message = "wrong description for opslevel_rubric_level.big"
+  }
+
+  assert {
+    condition     = opslevel_rubric_level.big.index == 5
+    error_message = "wrong index for opslevel_rubric_level.big"
+  }
+
+  assert {
+    condition     = opslevel_rubric_level.big.name == "big rubric level"
+    error_message = "wrong name for opslevel_rubric_level.big"
+  }
+
+}

--- a/tests/resource_rubric_level.tftest.hcl
+++ b/tests/resource_rubric_level.tftest.hcl
@@ -9,8 +9,13 @@ run "resource_rubric_level_small" {
   }
 
   assert {
-    condition     = opslevel_rubric_level.small.id != null && opslevel_rubric_level.small.id != ""
-    error_message = "opslevel_rubric_level.small id should not be empty"
+    condition     = can(opslevel_rubric_level.small.id)
+    error_message = "id attribute missing from filter in opslevel_rubric_level.small"
+  }
+
+  assert {
+    condition     = opslevel_rubric_level.small.index == 2
+    error_message = "wrong index for opslevel_rubric_level.small"
   }
 
   assert {

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -40,6 +40,18 @@ resource "opslevel_infrastructure" "big_infra" {
   schema = "Big Database"
 }
 
+# Rubric Level resources
+
+resource "opslevel_rubric_level" "big" {
+  description = "big rubric description"
+  index       = 5
+  name        = "big rubric level"
+}
+
+resource "opslevel_rubric_level" "small" {
+  name = "small rubric level"
+}
+
 # Secret resources
 
 resource "opslevel_secret" "mock_secret" {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/308

## Changelog

[public docs](https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/resources/rubric_level)

Changes:
- Add `rubric_level` resource, with tests

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

### Using this file:
```tf
# main.tf
resource "opslevel_rubric_level" "mystery" {
  name        = "mystery"
  description = "mystery level"
}

resource "opslevel_rubric_level" "five" {
  name        = "five"
  description = "five level"
  index       = 5
}
```

### Create Rubric Level, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_rubric_level.five will be created
  + resource "opslevel_rubric_level" "five" {
      + description  = "five level"
      + id           = (known after apply)
      + index        = 5
      + last_updated = (known after apply)
      + name         = "five"
    }

  # opslevel_rubric_level.mystery will be created
  + resource "opslevel_rubric_level" "mystery" {
      + description  = "mystery level"
      + id           = (known after apply)
      + index        = (known after apply)
      + last_updated = (known after apply)
      + name         = "mystery"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
opslevel_rubric_level.mystery: Creating...
opslevel_rubric_level.five: Creating...
opslevel_rubric_level.five: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNA]
opslevel_rubric_level.mystery: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyMw]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

### Update this file:
```tf
# main.tf
resource "opslevel_rubric_level" "mystery" {
  name        = "mystery"
  description = "mystery level"
  index       = 6
}

resource "opslevel_rubric_level" "five" {
  name        = "five"
  description = "five level"
  index       = 5
}
```

### Update Rubric Level, `terraform apply`
```tf
opslevel_rubric_level.five: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNA]
opslevel_rubric_level.mystery: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyMw]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # opslevel_rubric_level.mystery must be replaced
-/+ resource "opslevel_rubric_level" "mystery" {
      ~ id           = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyMw" -> (known after apply)
      ~ index        = 4 -> 6 # forces replacement
      + last_updated = (known after apply)
        name         = "mystery"
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
opslevel_rubric_level.mystery: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyMw]
opslevel_rubric_level.mystery: Destruction complete after 0s
opslevel_rubric_level.mystery: Creating...
opslevel_rubric_level.mystery: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNQ]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

### Destroy Rubric Level, `terraform apply`
```tf
opslevel_rubric_level.five: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNA]
opslevel_rubric_level.mystery: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNQ]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_rubric_level.five will be destroyed
  - resource "opslevel_rubric_level" "five" {
      - description = "five level" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNA" -> null
      - index       = 5 -> null
      - name        = "five" -> null
    }

  # opslevel_rubric_level.mystery will be destroyed
  - resource "opslevel_rubric_level" "mystery" {
      - description = "mystery level" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNQ" -> null
      - index       = 6 -> null
      - name        = "mystery" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.
opslevel_rubric_level.mystery: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNQ]
opslevel_rubric_level.five: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNDQyNA]
opslevel_rubric_level.mystery: Destruction complete after 1s
opslevel_rubric_level.five: Destruction complete after 1s

Destroy complete! Resources: 2 destroyed.
```