### PR TITLE
Add has documentation check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckHasDocumentationResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_has_documentation.go
+++ b/opslevel/resource_opslevel_check_has_documentation.go
@@ -1,92 +1,219 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
+	"time"
 
-// func resourceCheckHasDocumentation() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a has documentation check",
-// 		Create:      wrap(resourceCheckHasDocumentationCreate),
-// 		Read:        wrap(resourceCheckHasDocumentationRead),
-// 		Update:      wrap(resourceCheckHasDocumentationUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"document_type": {
-// 				Type:         schema.TypeString,
-// 				Description:  "The type of the document.",
-// 				ForceNew:     false,
-// 				Required:     true,
-// 				ValidateFunc: validation.StringInSlice(opslevel.AllHasDocumentationTypeEnum, false),
-// 			},
-// 			"document_subtype": {
-// 				Type:         schema.TypeString,
-// 				Description:  "The subtype of the document.",
-// 				ForceNew:     false,
-// 				Required:     true,
-// 				ValidateFunc: validation.StringInSlice(opslevel.AllHasDocumentationSubtypeEnum, false),
-// 			},
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckHasDocumentationCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckHasDocumentationCreateInput](checkCreateInput)
+var (
+	_ resource.ResourceWithConfigure   = &CheckHasDocumentationResource{}
+	_ resource.ResourceWithImportState = &CheckHasDocumentationResource{}
+)
 
-// 	input.DocumentType = opslevel.HasDocumentationTypeEnum(d.Get("document_type").(string))
-// 	input.DocumentSubtype = opslevel.HasDocumentationSubtypeEnum(d.Get("document_subtype").(string))
+func NewCheckHasDocumentationResource() resource.Resource {
+	return &CheckHasDocumentationResource{}
+}
 
-// 	resource, err := client.CreateCheckHasDocumentation(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+// CheckHasDocumentationResource defines the resource implementation.
+type CheckHasDocumentationResource struct {
+	CommonResourceClient
+}
 
-// 	return resourceCheckHasDocumentationRead(d, client)
-// }
+type CheckHasDocumentationResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// func resourceCheckHasDocumentationRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+	DocumentType    types.String `tfsdk:"document_type"`
+	DocumentSubtype types.String `tfsdk:"document_subtype"`
+}
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+func NewCheckHasDocumentationResourceModel(ctx context.Context, check opslevel.Check) CheckHasDocumentationResourceModel {
+	var model CheckHasDocumentationResourceModel
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("document_type", string(resource.DocumentType)); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("document_subtype", string(resource.DocumentSubtype)); err != nil {
-// 		return err
-// 	}
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// 	return nil
-// }
+	model.DocumentType = types.StringValue(string(check.DocumentType))
+	model.DocumentSubtype = types.StringValue(string(check.DocumentSubtype))
 
-// func resourceCheckHasDocumentationUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckHasDocumentationUpdateInput](checkUpdateInput)
+	return model
+}
 
-// 	if d.HasChange("document_type") {
-// 		input.DocumentType = opslevel.RefOf(opslevel.HasDocumentationTypeEnum(d.Get("document_type").(string)))
-// 	}
-// 	if d.HasChange("document_subtype") {
-// 		input.DocumentSubtype = opslevel.RefOf(opslevel.HasDocumentationSubtypeEnum(d.Get("document_subtype").(string)))
-// 	}
+func (r *CheckHasDocumentationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_has_documentation"
+}
 
-// 	_, err := client.UpdateCheckHasDocumentation(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckHasDocumentationRead(d, client)
-// }
+func (r *CheckHasDocumentationResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Has Documentation Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"document_type": schema.StringAttribute{
+				Description: "The type of the document.",
+				Required:    true,
+				Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllHasDocumentationTypeEnum...)},
+			},
+			"document_subtype": schema.StringAttribute{
+				Description: "The subtype of the document.",
+				Required:    true,
+				Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllHasDocumentationSubtypeEnum...)},
+			},
+		}),
+	}
+}
+
+func (r *CheckHasDocumentationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckHasDocumentationResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckHasDocumentationCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.DocumentType = opslevel.HasDocumentationTypeEnum(planModel.DocumentType.ValueString())
+	input.DocumentSubtype = opslevel.HasDocumentationSubtypeEnum(planModel.DocumentSubtype.ValueString())
+
+	data, err := r.client.CreateCheckHasDocumentation(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_has_documentation, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckHasDocumentationResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a check has documentation resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckHasDocumentationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckHasDocumentationResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check has documentation, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckHasDocumentationResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckHasDocumentationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckHasDocumentationResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckHasDocumentationUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	input.DocumentType = opslevel.RefOf(opslevel.HasDocumentationTypeEnum(planModel.DocumentType.ValueString()))
+	input.DocumentSubtype = opslevel.RefOf(opslevel.HasDocumentationSubtypeEnum(planModel.DocumentSubtype.ValueString()))
+
+	data, err := r.client.UpdateCheckHasDocumentation(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_has_documentation, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckHasDocumentationResourceModel(ctx, *data)
+
+	tflog.Trace(ctx, "updated a check has documentation resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckHasDocumentationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckHasDocumentationResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check has documentation, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check has documentation resource")
+}
+
+func (r *CheckHasDocumentationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/opslevel/resource_opslevel_check_has_documentation.go
+++ b/opslevel/resource_opslevel_check_has_documentation.go
@@ -50,6 +50,7 @@ func NewCheckHasDocumentationResourceModel(ctx context.Context, check opslevel.C
 	var stateModel CheckHasDocumentationResourceModel
 
 	stateModel.Category = RequiredStringValue(string(check.Category.Id))
+	stateModel.Description = ComputedStringValue(check.Description)
 	if planModel.Enabled.IsNull() {
 		stateModel.Enabled = types.BoolValue(false)
 	} else {

--- a/tests/resource_check_has_documentation.tftest.hcl
+++ b/tests/resource_check_has_documentation.tftest.hcl
@@ -1,0 +1,60 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_has_documentation" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_has_documentation.example.name == "foo"
+    error_message = "wrong value name for opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = opslevel_check_has_documentation.example.enabled == true
+    error_message = "wrong value enabled on opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = can(opslevel_check_has_documentation.example.id)
+    error_message = "id attribute missing from in opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = can(opslevel_check_has_documentation.example.owner)
+    error_message = "owner attribute missing from in opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = can(opslevel_check_has_documentation.example.filter)
+    error_message = "filter attribute missing from in opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = can(opslevel_check_has_documentation.example.category)
+    error_message = "category attribute missing from in opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = can(opslevel_check_has_documentation.example.level)
+    error_message = "level attribute missing from in opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = opslevel_check_has_documentation.example.notes == null
+    error_message = "wrong value for notes in opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = opslevel_check_has_documentation.example.document_type == "api"
+    error_message = "wrong document_type in opslevel_check_has_documentation.example"
+  }
+
+  assert {
+    condition     = opslevel_check_has_documentation.example.document_subtype == "openapi"
+    error_message = "wrong value for document_subtype in opslevel_check_has_documentation.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,17 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Has Documentation
+
+resource "opslevel_check_has_documentation" "example" {
+  name     = "foo"
+  enabled  = true
+  category = var.test_id
+  level    = var.test_id
+  owner    = var.test_id
+  filter   = var.test_id
+
+  document_type    = "api"
+  document_subtype = "openapi"
+}


### PR DESCRIPTION
## Issues

Add has documentation check

## Tophatting

Create
```tf
resource "opslevel_check_has_documentation" "example" {
  name       = "foo"
  category   = data.opslevel_rubric_category.security.id
  level      = data.opslevel_rubric_level.bronze.id
  document_subtype = "openapi"
  document_type = "api"
}
```

```bash
  # opslevel_check_has_documentation.example will be created
  + resource "opslevel_check_has_documentation" "example" {
      + category         = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description      = (known after apply)
      + document_subtype = "openapi"
      + document_type    = "api"
      + enabled          = false
      + id               = (known after apply)
      + last_updated     = (known after apply)
      + level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name             = "foo"
    }
```


Update
```tf
resource "opslevel_check_has_documentation" "example" {
  name       = "foo"
  category   = data.opslevel_rubric_category.security.id
  level      = data.opslevel_rubric_level.bronze.id
  document_subtype = "openapi"
  document_type = "tech"
}
```

```bash
  # opslevel_check_has_documentation.example will be updated in-place
  ~ resource "opslevel_check_has_documentation" "example" {
      + description      = (known after apply)
      ~ document_type    = "api" -> "tech"
        id               = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNEb2N1bWVudGF0aW9uLzI0MTQ1"
      + last_updated     = (known after apply)
        name             = "foo"
        # (4 unchanged attributes hidden)
    }

```

Delete
```bash
  # opslevel_check_has_documentation.example will be destroyed
  # (because opslevel_check_has_documentation.example is not in configuration)
  - resource "opslevel_check_has_documentation" "example" {
      - category         = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - document_subtype = "openapi" -> null
      - document_type    = "api" -> null
      - enabled          = false -> null
      - id               = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNEb2N1bWVudGF0aW9uLzI0MTQ1" -> null
      - level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name             = "foo" -> null
    }

```
