### PR TITLE
add check repo file

### DIFF
--- a/examples/resources/opslevel_check_repository_file/resource.tf
+++ b/examples/resources/opslevel_check_repository_file/resource.tf
@@ -34,7 +34,7 @@ resource "opslevel_check_repository_file" "example" {
   filter           = data.opslevel_filter.tier1.id
   directory_search = false
   filepaths        = ["/src", "/tests"]
-  file_contents_predicate {
+  file_contents_predicate = {
     type  = "equals"
     value = "import shim"
   }

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckRepositoryFileResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -1,110 +1,246 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
+	"time"
 
-// func resourceCheckRepositoryFile() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a repository file check",
-// 		Create:      wrap(resourceCheckRepositoryFileCreate),
-// 		Read:        wrap(resourceCheckRepositoryFileRead),
-// 		Update:      wrap(resourceCheckRepositoryFileUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"directory_search": {
-// 				Type:        schema.TypeBool,
-// 				Description: "Whether the check looks for the existence of a directory instead of a file.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"filepaths": {
-// 				Type:        schema.TypeList,
-// 				MinItems:    1,
-// 				Description: "Restrict the search to certain file paths.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 				Elem: &schema.Schema{
-// 					Type: schema.TypeString,
-// 				},
-// 			},
-// 			"file_contents_predicate": getPredicateInputSchema(false, DefaultPredicateDescription),
-// 			"use_absolute_root": {
-// 				Type:        schema.TypeBool,
-// 				Description: "Whether the checks looks at the absolute root of a repo or the relative root (the directory specified when attached a repo to a service).",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckRepositoryFileCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckRepositoryFileCreateInput](checkCreateInput)
+var (
+	_ resource.ResourceWithConfigure   = &CheckRepositoryFileResource{}
+	_ resource.ResourceWithImportState = &CheckRepositoryFileResource{}
+)
 
-// 	input.DirectorySearch = opslevel.RefOf(d.Get("directory_search").(bool))
-// 	input.FilePaths = getStringArray(d, "filepaths")
-// 	input.FileContentsPredicate = expandPredicate(d, "file_contents_predicate")
-// 	input.UseAbsoluteRoot = opslevel.RefOf(d.Get("use_absolute_root").(bool))
+func NewCheckRepositoryFileResource() resource.Resource {
+	return &CheckRepositoryFileResource{}
+}
 
-// 	resource, err := client.CreateCheckRepositoryFile(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+// CheckRepositoryFileResource defines the resource implementation.
+type CheckRepositoryFileResource struct {
+	CommonResourceClient
+}
 
-// 	return resourceCheckRepositoryFileRead(d, client)
-// }
+type CheckRepositoryFileResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// func resourceCheckRepositoryFileRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+	DirectorySearch       types.Bool      `tfsdk:"directory_search"`
+	Filepaths             types.List      `tfsdk:"filepaths"`
+	FileContentsPredicate *PredicateModel `tfsdk:"file_contents_predicate"`
+	UseAbsoluteRoot       types.Bool      `tfsdk:"use_absolute_root"`
+}
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+func NewCheckRepositoryFileResourceModel(ctx context.Context, check opslevel.Check) (CheckRepositoryFileResourceModel, diag.Diagnostics) {
+	var model CheckRepositoryFileResourceModel
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("directory_search", resource.RepositoryFileCheckFragment.DirectorySearch); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("filepaths", resource.RepositoryFileCheckFragment.Filepaths); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("file_contents_predicate", flattenPredicate(resource.RepositoryFileCheckFragment.FileContentsPredicate)); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("use_absolute_root", resource.UseAbsoluteRoot); err != nil {
-// 		return err
-// 	}
-// 	return nil
-// }
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// func resourceCheckRepositoryFileUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckRepositoryFileUpdateInput](checkUpdateInput)
-// 	input.DirectorySearch = opslevel.RefOf(d.Get("directory_search").(bool))
-// 	input.UseAbsoluteRoot = opslevel.RefOf(d.Get("use_absolute_root").(bool))
+	model.DirectorySearch = types.BoolValue(check.RepositoryFileCheckFragment.DirectorySearch)
+	data, diags := types.ListValueFrom(ctx, types.StringType, check.RepositoryFileCheckFragment.Filepaths)
+	model.Filepaths = data
+	model.FileContentsPredicate = NewPredicateModel(*check.RepositoryFileCheckFragment.FileContentsPredicate)
+	model.UseAbsoluteRoot = types.BoolValue(check.RepositoryFileCheckFragment.UseAbsoluteRoot)
 
-// 	if d.HasChange("filepaths") {
-// 		input.FilePaths = opslevel.RefOf(getStringArray(d, "filepaths"))
-// 	}
+	return model, diags
+}
 
-// 	if d.HasChange("file_contents_predicate") {
-// 		input.FileContentsPredicate = expandPredicateUpdate(d, "file_contents_predicate")
-// 	}
+func (r *CheckRepositoryFileResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_repository_file"
+}
 
-// 	_, err := client.UpdateCheckRepositoryFile(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckRepositoryFileRead(d, client)
-// }
+func (r *CheckRepositoryFileResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Repository File Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"directory_search": schema.BoolAttribute{
+				Description: "Whether the check looks for the existence of a directory instead of a file.",
+				Required:    true,
+			},
+			"filepaths": schema.ListAttribute{
+				Description: "Restrict the search to certain file paths.",
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"file_contents_predicate": PredicateSchema(),
+			"use_absolute_root": schema.BoolAttribute{
+				Description: "Whether the checks looks at the absolute root of a repo or the relative root (the directory specified when attached a repo to a service).",
+				Required:    true,
+			},
+		}),
+	}
+}
+
+func (r *CheckRepositoryFileResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckRepositoryFileResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckRepositoryFileCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	input.DirectorySearch = planModel.DirectorySearch.ValueBoolPointer()
+	resp.Diagnostics.Append(planModel.Filepaths.ElementsAs(ctx, &input.FilePaths, false)...)
+	if planModel.FileContentsPredicate != nil {
+		input.FileContentsPredicate = &opslevel.PredicateInput{
+			Type:  opslevel.PredicateTypeEnum(planModel.FileContentsPredicate.Type.String()),
+			Value: opslevel.RefOf(planModel.FileContentsPredicate.Value.String()),
+		}
+	}
+	input.UseAbsoluteRoot = planModel.UseAbsoluteRoot.ValueBoolPointer()
+
+	data, err := r.client.CreateCheckRepositoryFile(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_repository_file, got error: %s", err))
+		return
+	}
+
+	stateModel, diags := NewCheckRepositoryFileResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+	resp.Diagnostics.Append(diags...)
+
+	tflog.Trace(ctx, "created a check repository file resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositoryFileResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckRepositoryFileResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check repository file, got error: %s", err))
+		return
+	}
+	stateModel, diags := NewCheckRepositoryFileResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	resp.Diagnostics.Append(diags...)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositoryFileResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckRepositoryFileResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckRepositoryFileUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.DirectorySearch = planModel.DirectorySearch.ValueBoolPointer()
+	resp.Diagnostics.Append(planModel.Filepaths.ElementsAs(ctx, &input.FilePaths, false)...)
+	if planModel.FileContentsPredicate != nil {
+		input.FileContentsPredicate = &opslevel.PredicateUpdateInput{
+			Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.FileContentsPredicate.Type.String())),
+			Value: opslevel.RefOf(planModel.FileContentsPredicate.Value.String()),
+		}
+	}
+	input.UseAbsoluteRoot = planModel.UseAbsoluteRoot.ValueBoolPointer()
+
+	data, err := r.client.UpdateCheckRepositoryFile(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_repository_file, got error: %s", err))
+		return
+	}
+
+	stateModel, diags := NewCheckRepositoryFileResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+	resp.Diagnostics.Append(diags...)
+
+	tflog.Trace(ctx, "updated a check repository file resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositoryFileResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckRepositoryFileResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check repository file, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check repository file resource")
+}
+
+func (r *CheckRepositoryFileResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -73,7 +73,9 @@ func NewCheckRepositoryFileResourceModel(ctx context.Context, check opslevel.Che
 	stateModel.DirectorySearch = RequiredBoolValue(check.RepositoryFileCheckFragment.DirectorySearch)
 	data, diags := types.ListValueFrom(ctx, types.StringType, check.RepositoryFileCheckFragment.Filepaths)
 	stateModel.Filepaths = data
-	stateModel.FileContentsPredicate = NewPredicateModel(*check.RepositoryFileCheckFragment.FileContentsPredicate)
+	if check.RepositoryFileCheckFragment.FileContentsPredicate != nil {
+		stateModel.FileContentsPredicate = NewPredicateModel(*check.RepositoryFileCheckFragment.FileContentsPredicate)
+	}
 	stateModel.UseAbsoluteRoot = RequiredBoolValue(check.RepositoryFileCheckFragment.UseAbsoluteRoot)
 
 	return stateModel, diags

--- a/tests/resource_check_repository_file.tftest.hcl
+++ b/tests/resource_check_repository_file.tftest.hcl
@@ -1,0 +1,33 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_repository_file" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_repository_file.example.directory_search == false
+    error_message = "wrong value for directory_search in opslevel_check_repository_file.example"
+  }
+
+  assert {
+    condition = opslevel_check_repository_file.example.file_contents_predicate == {
+      type  = "equals"
+      value = "import shim"
+    }
+    error_message = "wrong value for file_contents_predicate in opslevel_check_repository_file.example"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_file.example.filepaths == tolist(["/src", "/tests"])
+    error_message = "wrong value for filepaths in opslevel_check_repository_file.example"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_file.example.use_absolute_root == false
+    error_message = "wrong value for use_absolute_root in opslevel_check_repository_file.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,21 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Repo File
+
+resource "opslevel_check_repository_file" "example" {
+  name             = "foo"
+  enabled          = true
+  category         = var.test_id
+  level            = var.test_id
+  owner            = var.test_id
+  filter           = var.test_id
+  directory_search = false
+  filepaths        = ["/src", "/tests"]
+  file_contents_predicate = {
+    type  = "equals"
+    value = "import shim"
+  }
+  use_absolute_root = false
+}


### PR DESCRIPTION
## Issues

Add repo file check

## Tophatting

Create
```bash
  # opslevel_check_repository_file.example will be created
  + resource "opslevel_check_repository_file" "example" {
      + category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description       = (known after apply)
      + directory_search  = false
      + enabled           = false
      + filepaths         = [
          + "main.go",
        ]
      + id                = (known after apply)
      + last_updated      = (known after apply)
      + level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name              = "foo"
      + use_absolute_root = true
    }

```

Update Add Predicate
```bash
  # opslevel_check_repository_file.example will be updated in-place
  ~ resource "opslevel_check_repository_file" "example" {
      + file_contents_predicate = {
          + type  = "contains"
          + value = "foo"
        }
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNDE2Mg"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (7 unchanged attributes hidden)
    }

```

Update Modify Predicate
``` bash
  ~ resource "opslevel_check_repository_file" "example" {
      ~ description             = "Repo file 'main.go' contains 'foo'." -> (known after apply)
      ~ file_contents_predicate = {
          ~ type  = "contains" -> "equals"
            # (1 unchanged attribute hidden)
        }
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNDE2Mg"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (6 unchanged attributes hidden)
    }

```

Update directory_search
```bash
  # opslevel_check_repository_file.example will be updated in-place
  ~ resource "opslevel_check_repository_file" "example" {
      ~ description             = "Repo file 'main.go' equals 'foo'." -> (known after apply)
      ~ directory_search        = false -> true
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNDE2Mg"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (6 unchanged attributes hidden)
    }

```

Delete
```bash
  # opslevel_check_repository_file.example will be destroyed
  # (because opslevel_check_repository_file.example is not in configuration)
  - resource "opslevel_check_repository_file" "example" {
      - category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - description             = "Repo directory 'main.go' equals 'foo'." -> null
      - directory_search        = true -> null
      - enabled                 = false -> null
      - file_contents_predicate = {
          - type  = "equals" -> null
          - value = "foo" -> null
        } -> null
      - filepaths               = [
          - "main.go",
        ] -> null
      - id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNDE2Mg" -> null
      - level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name                    = "foo" -> null
      - use_absolute_root       = true -> null
    }

```