### PR TITLE
add repo search check

### DIFF
--- a/examples/resources/opslevel_check_repository_search/resource.tf
+++ b/examples/resources/opslevel_check_repository_search/resource.tf
@@ -33,7 +33,7 @@ resource "opslevel_check_repository_search" "example" {
   owner           = data.opslevel_team.devs.id
   filter          = data.opslevel_filter.tier1.id
   file_extensions = ["sbt", "py"]
-  file_contents_predicate {
+  file_contents_predicate = {
     type  = "contains"
     value = "postgres"
   }

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckRepositorySearchResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -1,94 +1,231 @@
 package opslevel
 
-// import (
-// 	"fmt"
+import (
+	"context"
+	"fmt"
+	"time"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckRepositorySearch() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a repository search check.",
-// 		Create:      wrap(resourceCheckRepositorySearchCreate),
-// 		Read:        wrap(resourceCheckRepositorySearchRead),
-// 		Update:      wrap(resourceCheckRepositorySearchUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"file_extensions": {
-// 				Type:        schema.TypeList,
-// 				MinItems:    1,
-// 				Description: "Restrict the search to files of given extensions. Extensions should contain only letters and numbers. For example: [\"py\", \"rb\"].",
-// 				ForceNew:    false,
-// 				Optional:    true,
-// 				Elem: &schema.Schema{
-// 					Type: schema.TypeString,
-// 				},
-// 			},
-// 			"file_contents_predicate": getPredicateInputSchema(true, DefaultPredicateDescription),
-// 		}),
-// 	}
-// }
+var (
+	_ resource.ResourceWithConfigure   = &CheckRepositorySearchResource{}
+	_ resource.ResourceWithImportState = &CheckRepositorySearchResource{}
+)
 
-// func resourceCheckRepositorySearchCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckRepositorySearchCreateInput](checkCreateInput)
-// 	input.FileExtensions = opslevel.RefOf(getStringArray(d, "file_extensions"))
-// 	predicate := expandPredicate(d, "file_contents_predicate")
-// 	if predicate == nil {
-// 		return fmt.Errorf("error reading 'file_contents_predicate' in config - a valid type and value are required")
-// 	}
-// 	input.FileContentsPredicate = *predicate
+func NewCheckRepositorySearchResource() resource.Resource {
+	return &CheckRepositorySearchResource{}
+}
 
-// 	resource, err := client.CreateCheckRepositorySearch(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+// CheckRepositorySearchResource defines the resource implementation.
+type CheckRepositorySearchResource struct {
+	CommonResourceClient
+}
 
-// 	return resourceCheckRepositorySearchRead(d, client)
-// }
+type CheckRepositorySearchResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// func resourceCheckRepositorySearchRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+	FileExtensions        types.List      `tfsdk:"file_extensions"`
+	FileContentsPredicate *PredicateModel `tfsdk:"file_contents_predicate"`
+}
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+func NewCheckRepositorySearchResourceModel(ctx context.Context, check opslevel.Check) (CheckRepositorySearchResourceModel, diag.Diagnostics) {
+	var model CheckRepositorySearchResourceModel
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("file_extensions", resource.FileExtensions); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("file_contents_predicate", flattenPredicate(&resource.RepositorySearchCheckFragment.FileContentsPredicate)); err != nil {
-// 		return err
-// 	}
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// 	return nil
-// }
+	data, diags := types.ListValueFrom(ctx, types.StringType, check.RepositorySearchCheckFragment.FileExtensions)
+	model.FileExtensions = data
+	model.FileContentsPredicate = NewPredicateModel(check.RepositorySearchCheckFragment.FileContentsPredicate)
 
-// func resourceCheckRepositorySearchUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckRepositorySearchUpdateInput](checkUpdateInput)
+	return model, diags
+}
 
-// 	if d.HasChange("file_extensions") {
-// 		input.FileExtensions = opslevel.RefOf(getStringArray(d, "file_extensions"))
-// 	}
+func (r *CheckRepositorySearchResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_repository_search"
+}
 
-// 	if d.HasChange("file_contents_predicate") {
-// 		input.FileContentsPredicate = expandPredicateUpdate(d, "file_contents_predicate")
-// 	}
+func (r *CheckRepositorySearchResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Repository Search Resource",
 
-// 	_, err := client.UpdateCheckRepositorySearch(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckRepositorySearchRead(d, client)
-// }
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"file_extensions": schema.ListAttribute{
+				Description: "Restrict the search to files of given extensions. Extensions should contain only letters and numbers. For example: [\"py\", \"rb\"].",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"file_contents_predicate": PredicateSchema(),
+		}),
+	}
+}
+
+func (r *CheckRepositorySearchResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckRepositorySearchResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckRepositorySearchCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	resp.Diagnostics.Append(planModel.FileExtensions.ElementsAs(ctx, &input.FileExtensions, false)...)
+	if planModel.FileContentsPredicate != nil {
+		input.FileContentsPredicate = opslevel.PredicateInput{
+			Type:  opslevel.PredicateTypeEnum(planModel.FileContentsPredicate.Type.String()),
+			Value: opslevel.RefOf(planModel.FileContentsPredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.CreateCheckRepositorySearch(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_repository_search, got error: %s", err))
+		return
+	}
+
+	stateModel, diags := NewCheckRepositorySearchResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+	resp.Diagnostics.Append(diags...)
+
+	tflog.Trace(ctx, "created a check repository search resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositorySearchResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckRepositorySearchResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check repository search, got error: %s", err))
+		return
+	}
+	stateModel, diags := NewCheckRepositorySearchResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	resp.Diagnostics.Append(diags...)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositorySearchResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckRepositorySearchResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckRepositorySearchUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	resp.Diagnostics.Append(planModel.FileExtensions.ElementsAs(ctx, &input.FileExtensions, false)...)
+	if planModel.FileContentsPredicate != nil {
+		input.FileContentsPredicate = &opslevel.PredicateUpdateInput{
+			Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.FileContentsPredicate.Type.String())),
+			Value: opslevel.RefOf(planModel.FileContentsPredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.UpdateCheckRepositorySearch(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_repository_search, got error: %s", err))
+		return
+	}
+
+	stateModel, diags := NewCheckRepositorySearchResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+	resp.Diagnostics.Append(diags...)
+
+	tflog.Trace(ctx, "updated a check repository search resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositorySearchResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckRepositorySearchResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check repository search, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check repository search resource")
+}
+
+func (r *CheckRepositorySearchResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/resource_repository_search.tftest.hcl
+++ b/tests/resource_repository_search.tftest.hcl
@@ -1,0 +1,28 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_repository_search" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_repository_search.example.name == "foo"
+    error_message = "wrong value name for opslevel_check_repository_search.example"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_search.example.file_extensions == tolist(["sbt", "py"])
+    error_message = "wrong value for file_extensions in opslevel_check_repository_search.example"
+  }
+
+  assert {
+    condition = opslevel_check_repository_search.example.file_contents_predicate == {
+      type  = "contains"
+      value = "postgres"
+    }
+    error_message = "wrong value for file_contents_predicate in opslevel_check_repository_search.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,19 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Repo Search
+
+resource "opslevel_check_repository_search" "example" {
+  name            = "foo"
+  enabled         = true
+  category        = var.test_id
+  level           = var.test_id
+  owner           = var.test_id
+  filter          = var.test_id
+  file_extensions = ["sbt", "py"]
+  file_contents_predicate = {
+    type  = "contains"
+    value = "postgres"
+  }
+}


### PR DESCRIPTION
## Issues

Add repo search check

## Tophatting

Create
```bash
  # opslevel_check_repository_search.example will be created
  + resource "opslevel_check_repository_search" "example" {
      + category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description             = (known after apply)
      + enabled                 = true
      + file_contents_predicate = {
          + type  = "contains"
          + value = "postgres"
        }
      + file_extensions         = [
          + "sbt",
          + "py",
        ]
      + id                      = (known after apply)
      + last_updated            = (known after apply)
      + level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name                    = "foo"
    }

```

Update file_extensions
```bash
  # opslevel_check_repository_search.example will be updated in-place
  ~ resource "opslevel_check_repository_search" "example" {
      ~ description             = "Repo contains search term 'postgres' in at least one .sbt, .py, or .go file." -> (known after apply)
      ~ file_extensions         = [
            # (2 unchanged elements hidden)
          + "go",
          + "sh",
        ]
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI0MTYz"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (4 unchanged attributes hidden)
    }

```

Update file_contents_predicate
```bash
  # opslevel_check_repository_search.example will be updated in-place
  ~ resource "opslevel_check_repository_search" "example" {
      ~ description             = "Repo contains search term 'postgres' in at least one .sbt, .py, .go, or .sh file." -> (known after apply)
      ~ file_contents_predicate = {
          ~ type  = "contains" -> "does_not_contain"
            # (1 unchanged attribute hidden)
        }
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI0MTYz"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (4 unchanged attributes hidden)
    }

```

Delete
```bash
  # opslevel_check_repository_search.example will be destroyed
  # (because opslevel_check_repository_search.example is not in configuration)
  - resource "opslevel_check_repository_search" "example" {
      - category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - description             = "Repo does not contain search term 'postgres' in any .sbt, .py, .go, or .sh files." -> null
      - enabled                 = true -> null
      - file_contents_predicate = {
          - type  = "does_not_contain" -> null
          - value = "postgres" -> null
        } -> null
      - file_extensions         = [
          - "sbt",
          - "py",
          - "go",
          - "sh",
        ] -> null
      - id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI0MTYz" -> null
      - level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name                    = "foo" -> null
    }

```