### PR TITLE
fix infra resource alias create,update

### DIFF
--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -330,7 +330,6 @@ func expandInfraProviderData(providerData InfraProviderData) *opslevel.InfraProv
 	}
 }
 
-// func reconcileInfraAliases(d *schema.ResourceData, resource *opslevel.InfrastructureResource, client *opslevel.Client) error {
 func reconcileInfraAliases(client opslevel.Client, aliasesFromConfig []string, infra *opslevel.InfrastructureResource) error {
 	// delete aliases found in infrastructure resource but not listed in Terraform config
 	for _, alias := range infra.Aliases {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

```tf
# main.tf
resource "opslevel_infrastructure" "big" {
  aliases = ["one", "two"]
  data = jsonencode({
    name                = "big-query-123"
    external_id         = "example_2_1234"
    zone                = "us-east-1"
    engine              = "bigquery"
    engine_version      = "1.28.0"
    endpoint            = "https://console.cloud.google.com/..."
    replica             = false
    publicly_accessible = false
    storage_size = {
      unit  = "GB"
      value = 700
    }
    storage_type = "gp3"
    storage_iops = {
      unit  = "per second"
      value = 12000
    }
  })
  owner = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  provider_data = {
    account = "dev"
    name    = "google cloud"
    type    = "BigQuery"
    url     = "https://console.cloud.google.com/..."
  }
  schema = "Database"
}
```

### `terraform apply`

```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_infrastructure.big will be created
  + resource "opslevel_infrastructure" "big" {
      + aliases       = [
          + "one",
          + "two",
        ]
      + data          = jsonencode(
            {
              + endpoint            = "https://console.cloud.google.com/..."
              + engine              = "bigquery"
              + engine_version      = "1.28.0"
              + external_id         = "example_2_1234"
              + name                = "big-query-123"
              + publicly_accessible = false
              + replica             = false
              + storage_iops        = {
                  + unit  = "per second"
                  + value = 12000
                }
              + storage_size        = {
                  + unit  = "GB"
                  + value = 700
                }
              + storage_type        = "gp3"
              + zone                = "us-east-1"
            }
        )
      + id            = (known after apply)
      + last_updated  = (known after apply)
      + owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
      + provider_data = {
          + account = "dev"
          + name    = "google cloud"
          + type    = "BigQuery"
          + url     = "https://console.cloud.google.com/..."
        }
      + schema        = "Database"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_infrastructure.big: Creating...
opslevel_infrastructure.big: Creation complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Update terraform config

```tf
# main.tf
resource "opslevel_infrastructure" "big" {
  aliases = ["one", "two", "three"]
  data = jsonencode({
    name                = "big-query-123"
    external_id         = "example_2_1234"
    zone                = "us-east-1"
    engine              = "bigquery"
    engine_version      = "1.28.0"
    endpoint            = "https://console.cloud.google.com/..."
    replica             = false
    publicly_accessible = false
    storage_size = {
      unit  = "GB"
      value = 700
    }
    storage_type = "gp3"
    storage_iops = {
      unit  = "per second"
      value = 12000
    }
  })
  owner = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  provider_data = {
    account = "dev"
    name    = "google cloud"
    type    = "BigQuery"
    url     = "https://console.cloud.google.com/..."
  }
  schema = "Database"
}
```

### Update `terraform apply`

```tf
opslevel_infrastructure.big: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.big will be updated in-place
  ~ resource "opslevel_infrastructure" "big" {
      ~ aliases       = [
            # (1 unchanged element hidden)
            "two",
          + "three",
        ]
        id            = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM"
      + last_updated  = (known after apply)
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_infrastructure.big: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM]
opslevel_infrastructure.big: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Verify with cli
```bash
opslevel get infra Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM
```
```json
{
  "id": "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM",
  "aliases": [
    "one",
    "three",
    "two"
  ],
  "name": "big-query-123",
  "type": "Database",
  "providerResourceType": "BigQuery",
  "providerData": {
    "accountName": "dev",
    "externalUrl": "https://console.cloud.google.com/...",
    "providerName": "google cloud"
  },
  "owner": {
    "OnTeam": {
      "alias": "platform",
      "id": "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
    }
  },
  "ownerLocked": false,
  "data": "{\"endpoint\":\"https://console.cloud.google.com/...\",\"engine\":\"bigquery\",\"engine_version\":\"1.28.0\",\"external_id\":\"example_2_1234\",\"name\":\"big-query-123\",\"publicly_accessible\":false,\"replica\":false,\"storage_iops\":{\"unit\":\"per second\",\"valu
e\":12000},\"storage_size\":{\"unit\":\"GB\",\"value\":700},\"storage_type\":\"gp3\",\"zone\":\"us-east-1\"}",
  "rawData": "{\"endpoint\":\"https://console.cloud.google.com/...\",\"engine\":\"bigquery\",\"engine_version\":\"1.28.0\",\"external_id\":\"example_2_1234\",\"name\":\"big-query-123\",\"publicly_accessible\":false,\"replica\":false,\"storage_iops\":{\"unit\":\"per second\",\"v
alue\":12000},\"storage_size\":{\"unit\":\"GB\",\"value\":700},\"storage_type\":\"gp3\",\"zone\":\"us-east-1\"}"
}
```

### `terraform destroy`

```tf
opslevel_infrastructure.big: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_infrastructure.big will be destroyed
  - resource "opslevel_infrastructure" "big" {
      - aliases       = [
          - "one",
          - "two",
          - "three",
        ] -> null
      - data          = jsonencode(
            {
              - endpoint            = "https://console.cloud.google.com/..."
              - engine              = "bigquery"
              - engine_version      = "1.28.0"
              - external_id         = "example_2_1234"
              - name                = "big-query-123"
              - publicly_accessible = false
              - replica             = false
              - storage_iops        = {
                  - unit  = "per second"
                  - value = 12000
                }
              - storage_size        = {
                  - unit  = "GB"
                  - value = 700
                }
              - storage_type        = "gp3"
              - zone                = "us-east-1"
            }
        ) -> null
      - id            = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM" -> null
      - owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
      - provider_data = {
          - account = "dev" -> null
          - name    = "google cloud" -> null
          - type    = "BigQuery" -> null
          - url     = "https://console.cloud.google.com/..." -> null
        } -> null
      - schema        = "Database" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_infrastructure.big: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIwMzEyNDM]
opslevel_infrastructure.big: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```