### PR TITLE
handle id or alias case outside of NewServiceResourceModel

### DIFF
--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -286,11 +286,6 @@ func (r *ServiceResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	// Set Owner.Id to empty if service Owner is not ID. Needed in NewServiceResourceModel
-	if planModel.Owner.ValueString() != "" && !opslevel.IsID(planModel.Owner.ValueString()) {
-		service.Owner.Id = opslevel.ID("")
-	}
-
 	stateModel, diags := NewServiceResourceModel(ctx, *service)
 	resp.Diagnostics.Append(diags...)
 	switch planModel.Owner.ValueString() {
@@ -388,11 +383,6 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get service after update, got error: %s", err))
 		return
-	}
-
-	// Set Owner.Id to empty if service Owner is not ID. Needed in NewServiceResourceModel
-	if planModel.Owner.ValueString() != "" && !opslevel.IsID(planModel.Owner.ValueString()) {
-		service.Owner.Id = opslevel.ID("")
 	}
 
 	stateModel, diags := NewServiceResourceModel(ctx, *service)


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Rename `data` to `planModel`
Rename returned models from `NewServiceResourceModel` to be `stateModel`

- [ ] List your changes here
- [ ] Make a `changie` entry

# Tophatting

### Using this file, create a service:
```terraform
# main.tf
resource "opslevel_service" "test" {
  aliases                       = ["one-test-one", "TWO-TEST-TW2O", "two-test-two"]
  api_document_path             = "my/path/doc.yaml"
  description                   = "fancy things"
  framework                     = "da-best"
  language                      = "go"
  lifecycle_alias               = "alpha"
  name                          = "tophatting-service"
  owner                         = "platform"
  preferred_api_document_source = "PUSH"
  product                       = "tophat"
  tags                          = ["key:value"]
  tier_alias                    = "tier_2"
}
```

### Create Service, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_service.test will be created
  + resource "opslevel_service" "test" {
      + aliases                       = [
          + "one-test-one",
          + "TWO-TEST-TW2O",
          + "two-test-two",
        ]
      + api_document_path             = "my/path/doc.yaml"
      + description                   = "fancy things"
      + framework                     = "da-best"
      + id                            = (known after apply)
      + language                      = "go"
      + last_updated                  = (known after apply)
      + lifecycle_alias               = "alpha"
      + name                          = "tophatting-service"
      + owner                         = "platform"
      + preferred_api_document_source = "PUSH"
      + product                       = "tophat"
      + tags                          = [
          + "key:value",
        ]
      + tier_alias                    = "tier_2"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_service.test: Creating...
opslevel_service.test: Still creating... [10s elapsed]
opslevel_service.test: Creation complete after 13s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Update `owner` in file
```tf
resource "opslevel_service" "test" {
  aliases                       = ["one-test-one", "TWO-TEST-TW2O", "two-test-two"]
  api_document_path             = "my/path/doc.yaml"
  description                   = "fancy things"
  framework                     = "da-best"
  language                      = "go"
  lifecycle_alias               = "alpha"
  name                          = "tophatting-service"
  owner                         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  preferred_api_document_source = "PUSH"
  product                       = "tophat"
  tags                          = ["key:value"]
  tier_alias                    = "tier_2"
}
```

### Update Service, `terraform apply`
```tf
opslevel_service.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.test will be updated in-place
  ~ resource "opslevel_service" "test" {
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE"
      + last_updated                  = (known after apply)
        name                          = "tophatting-service"
      ~ owner                         = "platform" -> "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
        tags                          = [
            "key:value",
        ]
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE]
opslevel_service.test: Modifications complete after 3s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Destroy Service, `terraform destroy`
```tf
opslevel_service.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_service.test will be destroyed
  - resource "opslevel_service" "test" {
      - aliases                       = [
          - "one-test-one",
          - "TWO-TEST-TW2O",
          - "two-test-two",
        ] -> null
      - api_document_path             = "my/path/doc.yaml" -> null
      - description                   = "fancy things" -> null
      - framework                     = "da-best" -> null
      - id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE" -> null
      - language                      = "go" -> null
      - lifecycle_alias               = "alpha" -> null
      - name                          = "tophatting-service" -> null
      - owner                         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
      - preferred_api_document_source = "PUSH" -> null
      - product                       = "tophat" -> null
      - tags                          = [
          - "key:value",
        ] -> null
      - tier_alias                    = "tier_2" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_service.test: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTkxOTE]
opslevel_service.test: Destruction complete after 2s

Destroy complete! Resources: 1 destroyed.
```
