### PR TITLE
Add repo grep check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckRepositoryGrepResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -1,108 +1,242 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+// TODO: register resource to provider
+// TODO: write tests
 
-// func resourceCheckRepositoryGrep() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a repository file check",
-// 		Create:      wrap(resourceCheckRepositoryGrepCreate),
-// 		Read:        wrap(resourceCheckRepositoryGrepRead),
-// 		Update:      wrap(resourceCheckRepositoryGrepUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"directory_search": {
-// 				Type:        schema.TypeBool,
-// 				Description: "Whether the check looks for the existence of a directory instead of a file.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"filepaths": {
-// 				Type:        schema.TypeList,
-// 				MinItems:    1,
-// 				Description: "Restrict the search to certain file paths.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 				Elem: &schema.Schema{
-// 					Type: schema.TypeString,
-// 				},
-// 			},
-// 			"file_contents_predicate": getPredicateInputSchema(false, "A condition that should be satisfied. Defaults to `exists` condition"),
-// 		}),
-// 	}
-// }
+import (
+	"context"
+	"fmt"
+	"time"
 
-// func resourceCheckRepositoryGrepCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckRepositoryGrepCreateInput](checkCreateInput)
-// 	input.DirectorySearch = opslevel.RefOf(d.Get("directory_search").(bool))
-// 	input.FilePaths = getStringArray(d, "filepaths")
-// 	fileContentsPredicate := expandPredicate(d, "file_contents_predicate")
-// 	if fileContentsPredicate == nil {
-// 		input.FileContentsPredicate = opslevel.PredicateInput{
-// 			Type: opslevel.PredicateTypeEnumExists,
-// 		}
-// 	}
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// 	resource, err := client.CreateCheckRepositoryGrep(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+var (
+	_ resource.ResourceWithConfigure   = &CheckRepositoryGrepResource{}
+	_ resource.ResourceWithImportState = &CheckRepositoryGrepResource{}
+)
 
-// 	return resourceCheckRepositoryGrepRead(d, client)
-// }
+func NewCheckRepositoryGrepResource() resource.Resource {
+	return &CheckRepositoryGrepResource{}
+}
 
-// func resourceCheckRepositoryGrepRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+// CheckRepositoryGrepResource defines the resource implementation.
+type CheckRepositoryGrepResource struct {
+	CommonResourceClient
+}
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+type CheckRepositoryGrepResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("directory_search", resource.RepositoryGrepCheckFragment.DirectorySearch); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("filepaths", resource.RepositoryGrepCheckFragment.Filepaths); err != nil {
-// 		return err
-// 	}
-// 	if _, ok := d.GetOk("file_contents_predicate"); !ok {
-// 		if err := d.Set("file_contents_predicate", nil); err != nil {
-// 			return err
-// 		}
-// 	} else {
-// 		if err := d.Set("file_contents_predicate", flattenPredicate(resource.RepositoryGrepCheckFragment.FileContentsPredicate)); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	return nil
-// }
+	DirectorySearch       types.Bool      `tfsdk:"directory_search"`
+	Filepaths             types.List      `tfsdk:"filepaths"`
+	FileContentsPredicate *PredicateModel `tfsdk:"file_contents_predicate"`
+}
 
-// func resourceCheckRepositoryGrepUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckRepositoryGrepUpdateInput](checkUpdateInput)
-// 	input.DirectorySearch = opslevel.RefOf(d.Get("directory_search").(bool))
+func NewCheckRepositoryGrepResourceModel(ctx context.Context, check opslevel.Check) (CheckRepositoryGrepResourceModel, diag.Diagnostics) {
+	var model CheckRepositoryGrepResourceModel
 
-// 	if d.HasChange("filepaths") {
-// 		input.FilePaths = opslevel.RefOf(getStringArray(d, "filepaths"))
-// 	}
-// 	if d.HasChange("file_contents_predicate") {
-// 		input.FileContentsPredicate = expandPredicateUpdate(d, "file_contents_predicate")
-// 	}
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// 	_, err := client.UpdateCheckRepositoryGrep(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckRepositoryGrepRead(d, client)
-// }
+	model.DirectorySearch = types.BoolValue(check.RepositoryGrepCheckFragment.DirectorySearch)
+	data, diags := types.ListValueFrom(ctx, types.StringType, check.RepositoryGrepCheckFragment.Filepaths)
+	model.Filepaths = data
+	model.FileContentsPredicate = NewPredicateModel(*check.RepositoryGrepCheckFragment.FileContentsPredicate)
+
+	return model, diags
+}
+
+func (r *CheckRepositoryGrepResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_repository_grep"
+}
+
+func (r *CheckRepositoryGrepResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Repository Grep Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"directory_search": schema.BoolAttribute{
+				Description: "Whether the check looks for the existence of a directory instead of a file.",
+				Required:    true,
+			},
+			"filepaths": schema.ListAttribute{
+				Description: "Restrict the search to certain file paths.",
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"file_contents_predicate": PredicateSchema(),
+		}),
+	}
+}
+
+func (r *CheckRepositoryGrepResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckRepositoryGrepResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckRepositoryGrepCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.DirectorySearch = planModel.DirectorySearch.ValueBoolPointer()
+	resp.Diagnostics.Append(planModel.Filepaths.ElementsAs(ctx, &input.FilePaths, false)...)
+	if planModel.FileContentsPredicate != nil {
+		input.FileContentsPredicate = opslevel.PredicateInput{
+			Type:  opslevel.PredicateTypeEnum(planModel.FileContentsPredicate.Type.String()),
+			Value: opslevel.RefOf(planModel.FileContentsPredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.CreateCheckRepositoryGrep(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_repository_grep, got error: %s", err))
+		return
+	}
+
+	stateModel, diags := NewCheckRepositoryGrepResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	// Custom Prop Overrides Here
+	stateModel.LastUpdated = timeLastUpdated()
+	resp.Diagnostics.Append(diags...)
+
+	tflog.Trace(ctx, "created a check repositorygrep resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositoryGrepResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckRepositoryGrepResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check repositorygrep, got error: %s", err))
+		return
+	}
+	stateModel, diags := NewCheckRepositoryGrepResourceModel(ctx, *data)
+	resp.Diagnostics.Append(diags...)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositoryGrepResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckRepositoryGrepResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckRepositoryGrepUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.DirectorySearch = planModel.DirectorySearch.ValueBoolPointer()
+	resp.Diagnostics.Append(planModel.Filepaths.ElementsAs(ctx, &input.FilePaths, false)...)
+	if planModel.FileContentsPredicate != nil {
+		input.FileContentsPredicate = &opslevel.PredicateUpdateInput{
+			Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.FileContentsPredicate.Type.String())),
+			Value: opslevel.RefOf(planModel.FileContentsPredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.UpdateCheckRepositoryGrep(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_repository_grep, got error: %s", err))
+		return
+	}
+
+	stateModel, diags := NewCheckRepositoryGrepResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+	resp.Diagnostics.Append(diags...)
+
+	tflog.Trace(ctx, "updated a check repositorygrep resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckRepositoryGrepResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckRepositoryGrepResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check repositorygrep, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check repositorygrep resource")
+}
+
+func (r *CheckRepositoryGrepResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/resource_check_repository_grep.tftest.hcl
+++ b/tests/resource_check_repository_grep.tftest.hcl
@@ -1,0 +1,27 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_repository_grep" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+  assert {
+    condition     = opslevel_check_repository_grep.example.directory_search == false
+    error_message = "wrong value for directory_search in opslevel_check_repository_grep.example"
+  }
+
+  assert {
+    condition = opslevel_check_repository_grep.example.file_contents_predicate == {
+      type  = "contains"
+      value = "**/hello.go"
+    }
+    error_message = "wrong value for file_contents_predicate in opslevel_check_repository_grep.example"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_grep.example.filepaths == tolist(["/src", "/tests"])
+    error_message = "wrong value for filepaths in opslevel_check_repository_grep.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,20 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Repo Grep
+
+resource "opslevel_check_repository_grep" "example" {
+  name             = "foo"
+  enabled          = true
+  category         = var.test_id
+  level            = var.test_id
+  owner            = var.test_id
+  filter           = var.test_id
+  directory_search = false
+  filepaths        = ["/src", "/tests"]
+  file_contents_predicate = {
+    type  = "contains"
+    value = "**/hello.go"
+  }
+}


### PR DESCRIPTION
## Issues

Add repo grep check

## Tophatting

Create
```
  # opslevel_check_repository_grep.example will be created
  + resource "opslevel_check_repository_grep" "example" {
      + category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description             = (known after apply)
      + directory_search        = false
      + enabled                 = true
      + file_contents_predicate = {
          + type  = "contains"
          + value = "**/hello.go"
        }
      + filepaths               = [
          + "/src",
          + "/tests",
        ]
      + id                      = (known after apply)
      + last_updated            = (known after apply)
      + level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name                    = "foo"
    }

```

Create - no predicate FAILS because of a bug in opslevel-go
```bash
│ Unable to create check_repository_grep, got error: Message: Variable $input of type CheckRepositoryGrepCreateInput! was provided invalid value for fileContentsPredicate.type (Expected "" to be one of: contains,
│ does_not_contain, does_not_equal, does_not_exist, ends_with, equals, exists, greater_than_or_equal_to, less_than_or_equal_to, starts_with, satisfies_version_constraint, matches_regex, does_not_match_regex, belongs_to,
│ matches, does_not_match, satisfies_jq_expression), Locations: [{Line:1 Column:36}], Extensions: map[problems:[map[explanation:Expected "" to be one of: contains, does_not_contain, does_not_equal, does_not_exist, ends_with,
│ equals, exists, greater_than_or_equal_to, less_than_or_equal_to, starts_with, satisfies_version_constraint, matches_regex, does_not_match_regex, belongs_to, matches, does_not_match, satisfies_jq_expression
│ path:[fileContentsPredicate type]]] value:map[categoryId:Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1 directorySearch:false enabled:true fileContentsPredicate:map[type:] filePaths:[/src /tests] filterId:<nil>
│ levelId:Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw name:foo ownerId:<nil>]], Path: []

```

Update - predicate
```
  # opslevel_check_repository_grep.example will be updated in-place
  ~ resource "opslevel_check_repository_grep" "example" {
      ~ file_contents_predicate = {
          ~ type  = "exists" -> "contains"
          + value = "world"
        }
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNDE3Ng"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (6 unchanged attributes hidden)
    }

```

update - filepaths
```bash
  # opslevel_check_repository_grep.example will be updated in-place
  ~ resource "opslevel_check_repository_grep" "example" {
      ~ filepaths               = [
          - "/src",
          + "/dst",
            "/tests",
        ]
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNDE3Ng"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (6 unchanged attributes hidden)
    }

```
and
```
  # opslevel_check_repository_grep.example will be updated in-place
  ~ resource "opslevel_check_repository_grep" "example" {
      ~ filepaths               = [
            # (1 unchanged element hidden)
            "/tests",
          + "/docs",
        ]
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNDE3Ng"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (6 unchanged attributes hidden)
    }

```

update - directory search
```
  # opslevel_check_repository_grep.example will be updated in-place
  ~ resource "opslevel_check_repository_grep" "example" {
      ~ directory_search        = false -> true
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNDE3Ng"
      + last_updated            = (known after apply)
        name                    = "foo"
        # (6 unchanged attributes hidden)
    }

```

Delete
```bash
  # opslevel_check_repository_grep.example will be destroyed
  # (because opslevel_check_repository_grep.example is not in configuration)
  - resource "opslevel_check_repository_grep" "example" {
      - category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - description             = "Verifies the existence and/or contents of files in a service's attached Git repositories." -> null
      - directory_search        = false -> null
      - enabled                 = true -> null
      - file_contents_predicate = {
          - type  = "contains" -> null
          - value = "**/hello.go" -> null
        } -> null
      - filepaths               = [
          - "/src",
          - "/tests",
        ] -> null
      - id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNDE3NA" -> null
      - level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name                    = "foo" -> null
    }

```
