### PR TITLE
add service ownership check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckServiceOwnershipResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -1,127 +1,239 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
+	"time"
 
-// func resourceCheckServiceOwnership() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a service ownership check.",
-// 		Create:      wrap(resourceCheckServiceOwnershipCreate),
-// 		Read:        wrap(resourceCheckServiceOwnershipRead),
-// 		Update:      wrap(resourceCheckServiceOwnershipUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"require_contact_method": {
-// 				Type:        schema.TypeBool,
-// 				Description: "True if a service's owner must have a contact method, False otherwise.",
-// 				ForceNew:    false,
-// 				Optional:    true,
-// 			},
-// 			"contact_method": {
-// 				Type:         schema.TypeString,
-// 				Description:  "The type of contact method that is required.",
-// 				ForceNew:     false,
-// 				Optional:     true,
-// 				ValidateFunc: validation.StringInSlice(append(opslevel.AllContactType, "ANY"), true),
-// 			},
-// 			"tag_key": {
-// 				Type:        schema.TypeString,
-// 				Description: "The tag key where the tag predicate should be applied.",
-// 				ForceNew:    false,
-// 				Optional:    true,
-// 			},
-// 			"tag_predicate": getPredicateInputSchema(false, DefaultPredicateDescription),
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckServiceOwnershipCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckServiceOwnershipCreateInput](checkCreateInput)
+var (
+	_ resource.ResourceWithConfigure   = &CheckServiceOwnershipResource{}
+	_ resource.ResourceWithImportState = &CheckServiceOwnershipResource{}
+)
 
-// 	input.RequireContactMethod = opslevel.Bool(d.Get("require_contact_method").(bool))
-// 	if value, ok := d.GetOk("contact_method"); ok {
-// 		contactMethod := opslevel.ContactType(value.(string))
-// 		input.ContactMethod = opslevel.RefOf(string(contactMethod))
-// 	}
-// 	if tagKey, ok := d.GetOk("tag_key"); ok {
-// 		input.TagKey = opslevel.RefOf(tagKey.(string))
-// 	}
-// 	input.TagPredicate = expandPredicate(d, "tag_predicate")
+func NewCheckServiceOwnershipResource() resource.Resource {
+	return &CheckServiceOwnershipResource{}
+}
 
-// 	resource, err := client.CreateCheckServiceOwnership(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+// CheckServiceOwnershipResource defines the resource implementation.
+type CheckServiceOwnershipResource struct {
+	CommonResourceClient
+}
 
-// 	return resourceCheckServiceOwnershipRead(d, client)
-// }
+type CheckServiceOwnershipResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// func resourceCheckServiceOwnershipRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+	RequireContactMethod types.Bool      `tfsdk:"require_contact_method"`
+	ContactMethod        types.String    `tfsdk:"contact_method"`
+	TagKey               types.String    `tfsdk:"tag_key"`
+	TagPredicate         *PredicateModel `tfsdk:"tag_predicate"`
+}
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+func NewCheckServiceOwnershipResourceModel(ctx context.Context, check opslevel.Check) CheckServiceOwnershipResourceModel {
+	var model CheckServiceOwnershipResourceModel
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// 	if err := d.Set("require_contact_method", resource.RequireContactMethod); err != nil {
-// 		return err
-// 	}
+	model.RequireContactMethod = types.BoolPointerValue(check.ServiceOwnershipCheckFragment.RequireContactMethod)
+	model.ContactMethod = types.StringValue(string(*check.ServiceOwnershipCheckFragment.ContactMethod))
+	model.TagKey = types.StringValue(check.ServiceOwnershipCheckFragment.TeamTagKey)
+	model.TagPredicate = NewPredicateModel(*check.ServiceOwnershipCheckFragment.TeamTagPredicate)
 
-// 	if _, ok := d.GetOk("contact_method"); ok {
-// 		if err := d.Set("contact_method", resource.ContactMethod); err != nil {
-// 			return err
-// 		}
-// 	}
+	return model
+}
 
-// 	if _, ok := d.GetOk("tag_key"); ok {
-// 		if err := d.Set("tag_key", resource.TeamTagKey); err != nil {
-// 			return err
-// 		}
-// 	}
+func (r *CheckServiceOwnershipResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_service_ownership"
+}
 
-// 	if _, ok := d.GetOk("tag_predicate"); ok {
-// 		if err := d.Set("tag_predicate", flattenPredicate(resource.TeamTagPredicate)); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	return nil
-// }
+func (r *CheckServiceOwnershipResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Service Ownership Resource",
 
-// func resourceCheckServiceOwnershipUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckServiceOwnershipUpdateInput](checkUpdateInput)
-// 	input.RequireContactMethod = opslevel.Bool(d.Get("require_contact_method").(bool))
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"require_contact_method": schema.BoolAttribute{
+				Description: "True if a service's owner must have a contact method, False otherwise.",
+				Optional:    true,
+			},
+			"contact_method": schema.StringAttribute{
+				Description: "The type of contact method that is required.",
+				Optional:    true,
+				Validators:  []validator.String{stringvalidator.OneOf(append(opslevel.AllContactType, "ANY")...)},
+			},
+			"tag_key": schema.StringAttribute{
+				Description: "The tag key where the tag predicate should be applied.",
+				Optional:    true,
+			},
+			"tag_predicate": PredicateSchema(),
+		}),
+	}
+}
 
-// 	if d.HasChange("contact_method") {
-// 		contactMethod := opslevel.ContactType(d.Get("contact_method").(string))
-// 		input.ContactMethod = opslevel.RefOf(string(contactMethod))
-// 	}
+func (r *CheckServiceOwnershipResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckServiceOwnershipResourceModel
 
-// 	if d.HasChange("tag_key") {
-// 		input.TagKey = opslevel.RefOf(d.Get("tag_key").(string))
-// 	}
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
 
-// 	if d.HasChange("tag_predicate") {
-// 		input.TagPredicate = expandPredicateUpdate(d, "tag_predicate")
-// 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-// 	_, err := client.UpdateCheckServiceOwnership(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckServiceOwnershipRead(d, client)
-// }
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckServiceOwnershipCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.RequireContactMethod = planModel.RequireContactMethod.ValueBoolPointer()
+	input.ContactMethod = opslevel.RefOf(planModel.ContactMethod.ValueString())
+	input.TagKey = planModel.TagKey.ValueStringPointer()
+	input.TagPredicate = &opslevel.PredicateInput{
+		Type:  opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String()),
+		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	}
+
+	data, err := r.client.CreateCheckServiceOwnership(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_service_ownership, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a check service ownership resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckServiceOwnershipResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckServiceOwnershipResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check service ownership, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckServiceOwnershipResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckServiceOwnershipResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckServiceOwnershipUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.RequireContactMethod = planModel.RequireContactMethod.ValueBoolPointer()
+	input.ContactMethod = opslevel.RefOf(planModel.ContactMethod.ValueString())
+	input.TagKey = planModel.TagKey.ValueStringPointer()
+	input.TagPredicate = &opslevel.PredicateUpdateInput{
+		Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String())),
+		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	}
+
+	data, err := r.client.UpdateCheckServiceOwnership(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_service_ownership, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a check service ownership resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckServiceOwnershipResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckServiceOwnershipResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check service ownership, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check service ownership resource")
+}
+
+func (r *CheckServiceOwnershipResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -3,7 +3,6 @@ package opslevel
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -49,26 +48,39 @@ type CheckServiceOwnershipResourceModel struct {
 	TagPredicate         *PredicateModel `tfsdk:"tag_predicate"`
 }
 
-func NewCheckServiceOwnershipResourceModel(ctx context.Context, check opslevel.Check) CheckServiceOwnershipResourceModel {
-	var model CheckServiceOwnershipResourceModel
+func NewCheckServiceOwnershipResourceModel(ctx context.Context, check opslevel.Check, planModel CheckServiceOwnershipResourceModel) CheckServiceOwnershipResourceModel {
+	var stateModel CheckServiceOwnershipResourceModel
 
-	model.Category = types.StringValue(string(check.Category.Id))
-	model.Enabled = types.BoolValue(check.Enabled)
-	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
-	model.Filter = types.StringValue(string(check.Filter.Id))
-	model.Id = types.StringValue(string(check.Id))
-	model.Level = types.StringValue(string(check.Level.Id))
-	model.Name = types.StringValue(check.Name)
-	model.Notes = types.StringValue(check.Notes)
-	model.Owner = types.StringValue(string(check.Owner.Team.Id))
-	model.LastUpdated = timeLastUpdated()
+	stateModel.Category = RequiredStringValue(string(check.Category.Id))
+	stateModel.Description = ComputedStringValue(check.Description)
+	if planModel.Enabled.IsNull() {
+		stateModel.Enabled = types.BoolValue(false)
+	} else {
+		stateModel.Enabled = OptionalBoolValue(&check.Enabled)
+	}
+	if planModel.EnableOn.IsNull() {
+		stateModel.EnableOn = types.StringNull()
+	} else {
+		// We pass through the plan value because of time formatting issue to ensure the state gets the exact value the customer specified
+		stateModel.EnableOn = planModel.EnableOn
+	}
+	stateModel.Filter = OptionalStringValue(string(check.Filter.Id))
+	stateModel.Id = ComputedStringValue(string(check.Id))
+	stateModel.Level = RequiredStringValue(string(check.Level.Id))
+	stateModel.Name = RequiredStringValue(check.Name)
+	stateModel.Notes = OptionalStringValue(check.Notes)
+	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
 
-	model.RequireContactMethod = types.BoolPointerValue(check.ServiceOwnershipCheckFragment.RequireContactMethod)
-	model.ContactMethod = types.StringValue(string(*check.ServiceOwnershipCheckFragment.ContactMethod))
-	model.TagKey = types.StringValue(check.ServiceOwnershipCheckFragment.TeamTagKey)
-	model.TagPredicate = NewPredicateModel(*check.ServiceOwnershipCheckFragment.TeamTagPredicate)
+	stateModel.RequireContactMethod = OptionalBoolValue(check.ServiceOwnershipCheckFragment.RequireContactMethod)
+	if check.ServiceOwnershipCheckFragment.ContactMethod != nil {
+		stateModel.ContactMethod = OptionalStringValue(string(*check.ServiceOwnershipCheckFragment.ContactMethod))
+	}
+	stateModel.TagKey = OptionalStringValue(check.ServiceOwnershipCheckFragment.TeamTagKey)
+	if check.ServiceOwnershipCheckFragment.TeamTagPredicate != nil {
+		stateModel.TagPredicate = NewPredicateModel(*check.ServiceOwnershipCheckFragment.TeamTagPredicate)
+	}
 
-	return model
+	return stateModel
 }
 
 func (r *CheckServiceOwnershipResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -109,27 +121,28 @@ func (r *CheckServiceOwnershipResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("error", err.Error())
-	}
 	input := opslevel.CheckServiceOwnershipCreateInput{
 		CategoryId: asID(planModel.Category),
 		Enabled:    planModel.Enabled.ValueBoolPointer(),
-		EnableOn:   &iso8601.Time{Time: enabledOn},
 		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
 		LevelId:    asID(planModel.Level),
 		Name:       planModel.Name.ValueString(),
 		Notes:      planModel.Notes.ValueStringPointer(),
 		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
 	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
 
 	input.RequireContactMethod = planModel.RequireContactMethod.ValueBoolPointer()
 	input.ContactMethod = opslevel.RefOf(planModel.ContactMethod.ValueString())
 	input.TagKey = planModel.TagKey.ValueStringPointer()
-	input.TagPredicate = &opslevel.PredicateInput{
-		Type:  opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String()),
-		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	if planModel.TagPredicate != nil {
+		input.TagPredicate = planModel.TagPredicate.ToCreateInput()
 	}
 
 	data, err := r.client.CreateCheckServiceOwnership(input)
@@ -138,8 +151,7 @@ func (r *CheckServiceOwnershipResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data)
-	stateModel.EnableOn = planModel.EnableOn
+	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data, planModel)
 	stateModel.LastUpdated = timeLastUpdated()
 
 	tflog.Trace(ctx, "created a check service ownership resource")
@@ -161,7 +173,7 @@ func (r *CheckServiceOwnershipResource) Read(ctx context.Context, req resource.R
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check service ownership, got error: %s", err))
 		return
 	}
-	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data)
+	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data, planModel)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
@@ -177,29 +189,31 @@ func (r *CheckServiceOwnershipResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("error", err.Error())
-		return
-	}
 	input := opslevel.CheckServiceOwnershipUpdateInput{
 		CategoryId: opslevel.RefOf(asID(planModel.Category)),
 		Enabled:    planModel.Enabled.ValueBoolPointer(),
-		EnableOn:   &iso8601.Time{Time: enabledOn},
 		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
-		LevelId:    opslevel.RefOf(asID(planModel.Level)),
 		Id:         asID(planModel.Id),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
 		Name:       opslevel.RefOf(planModel.Name.ValueString()),
-		Notes:      planModel.Notes.ValueStringPointer(),
+		Notes:      opslevel.RefOf(planModel.Notes.ValueString()),
 		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
 	}
 
 	input.RequireContactMethod = planModel.RequireContactMethod.ValueBoolPointer()
 	input.ContactMethod = opslevel.RefOf(planModel.ContactMethod.ValueString())
 	input.TagKey = planModel.TagKey.ValueStringPointer()
-	input.TagPredicate = &opslevel.PredicateUpdateInput{
-		Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String())),
-		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	if planModel.TagPredicate != nil {
+		input.TagPredicate = planModel.TagPredicate.ToUpdateInput()
+	} else {
+		input.TagPredicate = &opslevel.PredicateUpdateInput{}
 	}
 
 	data, err := r.client.UpdateCheckServiceOwnership(input)
@@ -208,8 +222,7 @@ func (r *CheckServiceOwnershipResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data)
-	stateModel.EnableOn = planModel.EnableOn
+	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data, planModel)
 	stateModel.LastUpdated = timeLastUpdated()
 
 	tflog.Trace(ctx, "updated a check service ownership resource")

--- a/tests/resource_check_service_ownership.tftest.hcl
+++ b/tests/resource_check_service_ownership.tftest.hcl
@@ -1,0 +1,38 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_service_ownership" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_service_ownership.example.name == "foo"
+    error_message = "wrong value name for opslevel_check_service_ownership.example"
+  }
+
+  assert {
+    condition     = opslevel_check_service_ownership.example.require_contact_method == true
+    error_message = "wrong value for require_contact_method in opslevel_check_service_ownership.example"
+  }
+
+  assert {
+    condition     = opslevel_check_service_ownership.example.contact_method == "ANY"
+    error_message = "wrong value for contact_method in opslevel_check_service_ownership.example"
+  }
+
+  assert {
+    condition     = opslevel_check_service_ownership.example.tag_key == "team"
+    error_message = "wrong value for tag_key in opslevel_check_service_ownership.example"
+  }
+
+  assert {
+    condition = opslevel_check_service_ownership.example.tag_predicate == {
+      type  = "equals"
+      value = "frontend"
+    }
+    error_message = "wrong tag_predicate in opslevel_check_service_ownership.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,22 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Check Service Ownership
+
+resource "opslevel_check_service_ownership" "example" {
+  name                   = "foo"
+  enabled                = true
+  category               = var.test_id
+  level                  = var.test_id
+  owner                  = var.test_id
+  filter                 = var.test_id
+  notes                  = "Optional additional info on why this check is run or how to fix it"
+  require_contact_method = true
+  contact_method         = "ANY"
+  tag_key                = "team"
+  tag_predicate = {
+    type  = "equals"
+    value = "frontend"
+  }
+}


### PR DESCRIPTION
## Issues

Add service ownership check

There is one bug with this and its due to a bug in the API not in our tools

## Tophatting

Create
```bash
  # opslevel_check_service_ownership.example will be created
  + resource "opslevel_check_service_ownership" "example" {
      + category               = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + contact_method         = "ANY"
      + description            = (known after apply)
      + enabled                = true
      + id                     = (known after apply)
      + last_updated           = (known after apply)
      + level                  = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name                   = "foo"
      + notes                  = "Optional additional info on why this check is run or how to fix it"
      + require_contact_method = true
      + tag_key                = "team"
      + tag_predicate          = {
          + type  = "equals"
          + value = "frontend"
        }
    }

```

Update tag predicate
```bash
  # opslevel_check_service_ownership.example will be updated in-place
  ~ resource "opslevel_check_service_ownership" "example" {
        id                     = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE2Ng"
      + last_updated           = (known after apply)
        name                   = "foo"
      ~ tag_predicate          = {
          ~ type  = "equals" -> "contains"
            # (1 unchanged attribute hidden)
        }
        # (8 unchanged attributes hidden)
    }

```

Update remove tag predicate
```bash
  # opslevel_check_service_ownership.example will be updated in-place
  ~ resource "opslevel_check_service_ownership" "example" {
        id                     = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE2Ng"
      + last_updated           = (known after apply)
        name                   = "foo"
      - tag_predicate          = {
          - type  = "contains" -> null
          - value = "frontend" -> null
        } -> null
        # (8 unchanged attributes hidden)
    }

```

Update tag key

```bash
  # opslevel_check_service_ownership.example will be updated in-place
  ~ resource "opslevel_check_service_ownership" "example" {
        id                     = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE2Ng"
      + last_updated           = (known after apply)
        name                   = "foo"
      ~ tag_key                = "team" -> "owner"
        # (7 unchanged attributes hidden)
    }

```

Delete
```bash
  # opslevel_check_service_ownership.example will be destroyed
  # (because opslevel_check_service_ownership.example is not in configuration)
  - resource "opslevel_check_service_ownership" "example" {
      - category               = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - contact_method         = "ANY" -> null
      - description            = "Verifies that the service has an owner defined and with an optional requirement for a contact method and/or tag to be associated with that owner." -> null
      - enabled                = true -> null
      - id                     = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNDE2Ng" -> null
      - level                  = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name                   = "foo" -> null
      - notes                  = "Optional additional info on why this check is run or how to fix it" -> null
      - require_contact_method = false -> null
      - tag_key                = "owner" -> null
    }

```