### PR TITLE
add tag defined check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckTagDefinedResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -3,7 +3,6 @@ package opslevel
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -41,28 +40,39 @@ type CheckTagDefinedResourceModel struct {
 	Owner       types.String `tfsdk:"owner"`
 	LastUpdated types.String `tfsdk:"last_updated"`
 
-	TagKey       types.String   `tfsdk:"tag_key"`
-	TagPredicate PredicateModel `tfsdk:"tag_predicate"`
+	TagKey       types.String    `tfsdk:"tag_key"`
+	TagPredicate *PredicateModel `tfsdk:"tag_predicate"`
 }
 
-func NewCheckTagDefinedResourceModel(ctx context.Context, check opslevel.Check) CheckTagDefinedResourceModel {
-	var model CheckTagDefinedResourceModel
+func NewCheckTagDefinedResourceModel(ctx context.Context, check opslevel.Check, planModel CheckTagDefinedResourceModel) CheckTagDefinedResourceModel {
+	var stateModel CheckTagDefinedResourceModel
 
-	model.Category = types.StringValue(string(check.Category.Id))
-	model.Enabled = types.BoolValue(check.Enabled)
-	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
-	model.Filter = types.StringValue(string(check.Filter.Id))
-	model.Id = types.StringValue(string(check.Id))
-	model.Level = types.StringValue(string(check.Level.Id))
-	model.Name = types.StringValue(check.Name)
-	model.Notes = types.StringValue(check.Notes)
-	model.Owner = types.StringValue(string(check.Owner.Team.Id))
-	model.LastUpdated = timeLastUpdated()
+	stateModel.Category = RequiredStringValue(string(check.Category.Id))
+	stateModel.Description = ComputedStringValue(check.Description)
+	if planModel.Enabled.IsNull() {
+		stateModel.Enabled = types.BoolValue(false)
+	} else {
+		stateModel.Enabled = OptionalBoolValue(&check.Enabled)
+	}
+	if planModel.EnableOn.IsNull() {
+		stateModel.EnableOn = types.StringNull()
+	} else {
+		// We pass through the plan value because of time formatting issue to ensure the state gets the exact value the customer specified
+		stateModel.EnableOn = planModel.EnableOn
+	}
+	stateModel.Filter = OptionalStringValue(string(check.Filter.Id))
+	stateModel.Id = ComputedStringValue(string(check.Id))
+	stateModel.Level = RequiredStringValue(string(check.Level.Id))
+	stateModel.Name = RequiredStringValue(check.Name)
+	stateModel.Notes = OptionalStringValue(check.Notes)
+	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
 
-	model.TagKey = types.StringValue(check.TagKey)
-	model.TagPredicate = *NewPredicateModel(*check.TagPredicate)
+	stateModel.TagKey = RequiredStringValue(check.TagKey)
+	if check.TagPredicate != nil {
+		stateModel.TagPredicate = NewPredicateModel(*check.TagPredicate)
+	}
 
-	return model
+	return stateModel
 }
 
 func (r *CheckTagDefinedResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -94,25 +104,26 @@ func (r *CheckTagDefinedResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("error", err.Error())
-	}
 	input := opslevel.CheckTagDefinedCreateInput{
 		CategoryId: asID(planModel.Category),
 		Enabled:    planModel.Enabled.ValueBoolPointer(),
-		EnableOn:   &iso8601.Time{Time: enabledOn},
 		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
 		LevelId:    asID(planModel.Level),
 		Name:       planModel.Name.ValueString(),
 		Notes:      planModel.Notes.ValueStringPointer(),
 		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
 	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
 
 	input.TagKey = planModel.TagKey.ValueString()
-	input.TagPredicate = &opslevel.PredicateInput{
-		Type:  opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String()),
-		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	if planModel.TagPredicate != nil {
+		input.TagPredicate = planModel.TagPredicate.ToCreateInput()
 	}
 
 	data, err := r.client.CreateCheckTagDefined(input)
@@ -121,8 +132,7 @@ func (r *CheckTagDefinedResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	stateModel := NewCheckTagDefinedResourceModel(ctx, *data)
-	stateModel.EnableOn = planModel.EnableOn
+	stateModel := NewCheckTagDefinedResourceModel(ctx, *data, planModel)
 	stateModel.LastUpdated = timeLastUpdated()
 
 	tflog.Trace(ctx, "created a check tag defined resource")
@@ -144,7 +154,7 @@ func (r *CheckTagDefinedResource) Read(ctx context.Context, req resource.ReadReq
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check tag defined, got error: %s", err))
 		return
 	}
-	stateModel := NewCheckTagDefinedResourceModel(ctx, *data)
+	stateModel := NewCheckTagDefinedResourceModel(ctx, *data, planModel)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
@@ -160,27 +170,29 @@ func (r *CheckTagDefinedResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("error", err.Error())
-		return
-	}
 	input := opslevel.CheckTagDefinedUpdateInput{
 		CategoryId: opslevel.RefOf(asID(planModel.Category)),
 		Enabled:    planModel.Enabled.ValueBoolPointer(),
-		EnableOn:   &iso8601.Time{Time: enabledOn},
 		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
-		LevelId:    opslevel.RefOf(asID(planModel.Level)),
 		Id:         asID(planModel.Id),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
 		Name:       opslevel.RefOf(planModel.Name.ValueString()),
-		Notes:      planModel.Notes.ValueStringPointer(),
+		Notes:      opslevel.RefOf(planModel.Notes.ValueString()),
 		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
 	}
 
 	input.TagKey = planModel.TagKey.ValueStringPointer()
-	input.TagPredicate = &opslevel.PredicateUpdateInput{
-		Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String())),
-		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	if planModel.TagPredicate != nil {
+		input.TagPredicate = planModel.TagPredicate.ToUpdateInput()
+	} else {
+		input.TagPredicate = &opslevel.PredicateUpdateInput{}
 	}
 
 	data, err := r.client.UpdateCheckTagDefined(input)
@@ -189,8 +201,7 @@ func (r *CheckTagDefinedResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	stateModel := NewCheckTagDefinedResourceModel(ctx, *data)
-	stateModel.EnableOn = planModel.EnableOn
+	stateModel := NewCheckTagDefinedResourceModel(ctx, *data, planModel)
 	stateModel.LastUpdated = timeLastUpdated()
 
 	tflog.Trace(ctx, "updated a check tag defined resource")

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -1,83 +1,220 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
+	"time"
 
-// func resourceCheckTagDefined() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a tag defined check",
-// 		Create:      wrap(resourceCheckTagDefinedCreate),
-// 		Read:        wrap(resourceCheckTagDefinedRead),
-// 		Update:      wrap(resourceCheckTagDefinedUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"tag_key": {
-// 				Type:        schema.TypeString,
-// 				Description: "The tag key where the tag predicate should be applied.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"tag_predicate": getPredicateInputSchema(false, DefaultPredicateDescription),
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckTagDefinedCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckTagDefinedCreateInput](checkCreateInput)
-// 	input.TagKey = d.Get("tag_key").(string)
-// 	input.TagPredicate = expandPredicate(d, "tag_predicate")
+var (
+	_ resource.ResourceWithConfigure   = &CheckTagDefinedResource{}
+	_ resource.ResourceWithImportState = &CheckTagDefinedResource{}
+)
 
-// 	resource, err := client.CreateCheckTagDefined(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+func NewCheckTagDefinedResource() resource.Resource {
+	return &CheckTagDefinedResource{}
+}
 
-// 	return resourceCheckTagDefinedRead(d, client)
-// }
+// CheckTagDefinedResource defines the resource implementation.
+type CheckTagDefinedResource struct {
+	CommonResourceClient
+}
 
-// func resourceCheckTagDefinedRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+type CheckTagDefinedResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+	TagKey       types.String   `tfsdk:"tag_key"`
+	TagPredicate PredicateModel `tfsdk:"tag_predicate"`
+}
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("tag_key", resource.TagKey); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("tag_predicate", flattenPredicate(resource.TagPredicate)); err != nil {
-// 		return err
-// 	}
+func NewCheckTagDefinedResourceModel(ctx context.Context, check opslevel.Check) CheckTagDefinedResourceModel {
+	var model CheckTagDefinedResourceModel
 
-// 	return nil
-// }
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// func resourceCheckTagDefinedUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckTagDefinedUpdateInput](checkUpdateInput)
+	model.TagKey = types.StringValue(check.TagKey)
+	model.TagPredicate = *NewPredicateModel(*check.TagPredicate)
 
-// 	if d.HasChange("tag_key") {
-// 		input.TagKey = opslevel.RefOf(d.Get("tag_key").(string))
-// 	}
-// 	if d.HasChange("tag_predicate") {
-// 		input.TagPredicate = expandPredicateUpdate(d, "tag_predicate")
-// 	}
+	return model
+}
 
-// 	_, err := client.UpdateCheckTagDefined(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckTagDefinedRead(d, client)
-// }
+func (r *CheckTagDefinedResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_tag_defined"
+}
+
+func (r *CheckTagDefinedResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Tag Defined Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"tag_key": schema.StringAttribute{
+				Description: "The tag key where the tag predicate should be applied.",
+				Required:    true,
+			},
+			"tag_predicate": PredicateSchema(),
+		}),
+	}
+}
+
+func (r *CheckTagDefinedResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckTagDefinedResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckTagDefinedCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.TagKey = planModel.TagKey.ValueString()
+	input.TagPredicate = &opslevel.PredicateInput{
+		Type:  opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String()),
+		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	}
+
+	data, err := r.client.CreateCheckTagDefined(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_tag_defined, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckTagDefinedResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a check tag defined resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckTagDefinedResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckTagDefinedResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check tag defined, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckTagDefinedResourceModel(ctx, *data)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckTagDefinedResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckTagDefinedResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckTagDefinedUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.TagKey = planModel.TagKey.ValueStringPointer()
+	input.TagPredicate = &opslevel.PredicateUpdateInput{
+		Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.TagPredicate.Type.String())),
+		Value: opslevel.RefOf(planModel.TagPredicate.Value.String()),
+	}
+
+	data, err := r.client.UpdateCheckTagDefined(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_tag_defined, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckTagDefinedResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a check tag defined resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckTagDefinedResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckTagDefinedResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check tag defined, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check tag defined resource")
+}
+
+func (r *CheckTagDefinedResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/resource_check_tag_defined.tftest.hcl
+++ b/tests/resource_check_tag_defined.tftest.hcl
@@ -1,0 +1,23 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_tag_defined" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_tag_defined.example.tag_key == "environment"
+    error_message = "wrong value for update_requires_comment in opslevel_check_tag_defined.example"
+  }
+
+  assert {
+    condition = opslevel_check_tag_defined.example.tag_predicate == {
+      type  = "contains"
+      value = "dev"
+    }
+    error_message = "wrong update_frequency in opslevel_check_tag_defined.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,19 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Check Tag Defined
+
+resource "opslevel_check_tag_defined" "example" {
+  name     = "foo"
+  enabled  = true
+  category = var.test_id
+  level    = var.test_id
+  owner    = var.test_id
+  filter   = var.test_id
+  tag_key  = "environment"
+  tag_predicate = {
+    type  = "contains"
+    value = "dev"
+  }
+}


### PR DESCRIPTION
## Issues

Add tag defined check

## Tophatting

Create
```bash
  # opslevel_check_tag_defined.example will be created
  + resource "opslevel_check_tag_defined" "example" {
      + category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description   = (known after apply)
      + enabled       = true
      + id            = (known after apply)
      + last_updated  = (known after apply)
      + level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name          = "foo"
      + tag_key       = "environment"
      + tag_predicate = {
          + type  = "contains"
          + value = "dev"
        }
    }

```

Create without predicate

```bash
  # opslevel_check_tag_defined.example will be created
  + resource "opslevel_check_tag_defined" "example" {
      + category     = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description  = (known after apply)
      + enabled      = true
      + id           = (known after apply)
      + last_updated = (known after apply)
      + level        = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name         = "foo"
      + tag_key      = "environment"
    }

```

update predicate

```bash
  # opslevel_check_tag_defined.example will be updated in-place
  ~ resource "opslevel_check_tag_defined" "example" {
        id            = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI0MTY3"
      + last_updated  = (known after apply)
        name          = "foo"
      ~ tag_predicate = {
          ~ type  = "contains" -> "exists"
          - value = "dev" -> null
        }
        # (5 unchanged attributes hidden)
    }

```

update remove predicate

```
  # opslevel_check_tag_defined.example will be updated in-place
  ~ resource "opslevel_check_tag_defined" "example" {
        id            = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI0MTY3"
      + last_updated  = (known after apply)
        name          = "foo"
      - tag_predicate = {
          - type = "exists" -> null
        } -> null
        # (5 unchanged attributes hidden)
    }

```

delete
```bash
  # opslevel_check_tag_defined.example will be destroyed
  # (because opslevel_check_tag_defined.example is not in configuration)
  - resource "opslevel_check_tag_defined" "example" {
      - category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - description = "Verifies that the service has the specified tag defined." -> null
      - enabled     = true -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI0MTY3" -> null
      - level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name        = "foo" -> null
      - tag_key     = "environment" -> null
    }

```
