### PR TITLE
Add tool usage check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckToolUsageResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -96,7 +96,7 @@ func (r *CheckToolUsageResource) Schema(ctx context.Context, req resource.Schema
 
 		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
 			"tool_category": schema.StringAttribute{
-				Description: "",
+				Description: "The category that the tool belongs to.",
 				Required:    true,
 				Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllToolCategory...)},
 			},

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -1,101 +1,257 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
+	"time"
 
-// func resourceCheckToolUsage() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a tool usage check",
-// 		Create:      wrap(resourceCheckToolUsageCreate),
-// 		Read:        wrap(resourceCheckToolUsageRead),
-// 		Update:      wrap(resourceCheckToolUsageUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"tool_category": {
-// 				Type:         schema.TypeString,
-// 				Description:  "The category that the tool belongs to.",
-// 				ForceNew:     false,
-// 				Required:     true,
-// 				ValidateFunc: validation.StringInSlice(opslevel.AllToolCategory, false),
-// 			},
-// 			"tool_name_predicate":   getPredicateInputSchema(false, DefaultPredicateDescription),
-// 			"tool_url_predicate":    getPredicateInputSchema(false, DefaultPredicateDescription),
-// 			"environment_predicate": getPredicateInputSchema(false, DefaultPredicateDescription),
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckToolUsageCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckToolUsageCreateInput](checkCreateInput)
-// 	input.ToolCategory = opslevel.ToolCategory(d.Get("tool_category").(string))
-// 	input.ToolNamePredicate = expandPredicate(d, "tool_name_predicate")
-// 	input.ToolUrlPredicate = expandPredicate(d, "tool_url_predicate")
-// 	input.EnvironmentPredicate = expandPredicate(d, "environment_predicate")
+var (
+	_ resource.ResourceWithConfigure   = &CheckToolUsageResource{}
+	_ resource.ResourceWithImportState = &CheckToolUsageResource{}
+)
 
-// 	resource, err := client.CreateCheckToolUsage(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+func NewCheckToolUsageResource() resource.Resource {
+	return &CheckToolUsageResource{}
+}
 
-// 	return resourceCheckToolUsageRead(d, client)
-// }
+// CheckToolUsageResource defines the resource implementation.
+type CheckToolUsageResource struct {
+	CommonResourceClient
+}
 
-// func resourceCheckToolUsageRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+type CheckToolUsageResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+	ToolCategory         types.String    `tfsdk:"tool_category"`
+	ToolNamePredicate    *PredicateModel `tfsdk:"tool_name_predicate"`
+	ToolUrlPredicate     *PredicateModel `tfsdk:"tool_url_predicate"`
+	EnvironmentPredicate *PredicateModel `tfsdk:"environment_predicate"`
+}
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("tool_category", string(resource.ToolCategory)); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("tool_name_predicate", flattenPredicate(resource.ToolNamePredicate)); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("tool_url_predicate", flattenPredicate(resource.ToolUrlPredicate)); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("environment_predicate", flattenPredicate(resource.EnvironmentPredicate)); err != nil {
-// 		return err
-// 	}
+func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check) CheckToolUsageResourceModel {
+	var model CheckToolUsageResourceModel
 
-// 	return nil
-// }
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// func resourceCheckToolUsageUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckToolUsageUpdateInput](checkUpdateInput)
+	model.ToolCategory = types.StringValue(string(check.ToolCategory))
+	model.ToolNamePredicate = NewPredicateModel(*check.ToolNamePredicate)
+	model.ToolUrlPredicate = NewPredicateModel(*check.ToolUrlPredicate)
+	model.EnvironmentPredicate = NewPredicateModel(*check.EnvironmentPredicate)
 
-// 	if d.HasChange("tool_category") {
-// 		input.ToolCategory = opslevel.RefOf(opslevel.ToolCategory(d.Get("tool_category").(string)))
-// 	}
-// 	if d.HasChange("tool_name_predicate") {
-// 		input.ToolNamePredicate = expandPredicateUpdate(d, "tool_name_predicate")
-// 	}
-// 	if d.HasChange("tool_url_predicate") {
-// 		input.ToolUrlPredicate = expandPredicateUpdate(d, "tool_url_predicate")
-// 	}
-// 	if d.HasChange("environment_predicate") {
-// 		input.EnvironmentPredicate = expandPredicateUpdate(d, "environment_predicate")
-// 	}
+	return model
+}
 
-// 	_, err := client.UpdateCheckToolUsage(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckToolUsageRead(d, client)
-// }
+func (r *CheckToolUsageResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_tool_usage"
+}
+
+func (r *CheckToolUsageResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Tool Usage Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"tool_category": schema.StringAttribute{
+				Description: "",
+				Required:    true,
+				Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllToolCategory...)},
+			},
+			"tool_name_predicate":   PredicateSchema(),
+			"tool_url_predicate":    PredicateSchema(),
+			"environment_predicate": PredicateSchema(),
+		}),
+	}
+}
+
+func (r *CheckToolUsageResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckToolUsageResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckToolUsageCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.ToolCategory = opslevel.ToolCategory(planModel.ToolCategory.ValueString())
+	if planModel.ToolNamePredicate != nil {
+		input.ToolNamePredicate = &opslevel.PredicateInput{
+			Type:  opslevel.PredicateTypeEnum(planModel.ToolNamePredicate.Type.String()),
+			Value: opslevel.RefOf(planModel.ToolNamePredicate.Value.String()),
+		}
+	}
+	if planModel.ToolUrlPredicate != nil {
+		input.ToolUrlPredicate = &opslevel.PredicateInput{
+			Type:  opslevel.PredicateTypeEnum(planModel.ToolUrlPredicate.Type.String()),
+			Value: opslevel.RefOf(planModel.ToolUrlPredicate.Value.String()),
+		}
+	}
+	if planModel.EnvironmentPredicate != nil {
+		input.EnvironmentPredicate = &opslevel.PredicateInput{
+			Type:  opslevel.PredicateTypeEnum(planModel.EnvironmentPredicate.Type.String()),
+			Value: opslevel.RefOf(planModel.EnvironmentPredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.CreateCheckToolUsage(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_tool_usage, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckToolUsageResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a check tool usage resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckToolUsageResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckToolUsageResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check tool usage, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckToolUsageResourceModel(ctx, *data)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckToolUsageResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckToolUsageUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.ToolCategory = opslevel.RefOf(opslevel.ToolCategory(planModel.ToolCategory.ValueString()))
+	if planModel.ToolNamePredicate != nil {
+		input.ToolNamePredicate = &opslevel.PredicateUpdateInput{
+			Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.ToolNamePredicate.Type.String())),
+			Value: opslevel.RefOf(planModel.ToolNamePredicate.Value.String()),
+		}
+	}
+	if planModel.ToolUrlPredicate != nil {
+		input.ToolUrlPredicate = &opslevel.PredicateUpdateInput{
+			Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.ToolUrlPredicate.Type.String())),
+			Value: opslevel.RefOf(planModel.ToolUrlPredicate.Value.String()),
+		}
+	}
+	if planModel.EnvironmentPredicate != nil {
+		input.EnvironmentPredicate = &opslevel.PredicateUpdateInput{
+			Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.EnvironmentPredicate.Type.String())),
+			Value: opslevel.RefOf(planModel.EnvironmentPredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.UpdateCheckToolUsage(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_tool_usage, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckToolUsageResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a check tool usage resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckToolUsageResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckToolUsageResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check tool usage, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check tool usage resource")
+}
+
+func (r *CheckToolUsageResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,23 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Check Tool Usage
+
+resource "opslevel_check_tool_usage" "example" {
+  name          = "foo"
+  enabled       = true
+  category      = var.test_id
+  level         = var.test_id
+  owner         = var.test_id
+  filter        = var.test_id
+  tool_category = "metrics"
+  tool_name_predicate = {
+    type  = "equals"
+    value = "datadog"
+  }
+  environment_predicate = {
+    type  = "equals"
+    value = "production"
+  }
+}

--- a/tests/resources_check_tool_usage.tftest.hcl
+++ b/tests/resources_check_tool_usage.tftest.hcl
@@ -1,0 +1,31 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_tool_usage" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_tool_usage.example.tool_category == "metrics"
+    error_message = "wrong value for tool_category in opslevel_check_tool_usage.example"
+  }
+
+  assert {
+    condition = opslevel_check_tool_usage.example.tool_name_predicate == {
+      type  = "equals"
+      value = "datadog"
+    }
+    error_message = "wrong tool_name_predicate in opslevel_check_tool_usage.example"
+  }
+
+  assert {
+    condition = opslevel_check_tool_usage.example.environment_predicate == {
+      type  = "equals"
+      value = "production"
+    }
+    error_message = "wrong environment_predicate in opslevel_check_tool_usage.example"
+  }
+}


### PR DESCRIPTION
## Issues

Add tool usage check

## Tophatting

create - no predicates
```bash
  # opslevel_check_tool_usage.example will be created
  + resource "opslevel_check_tool_usage" "example" {
      + category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description   = (known after apply)
      + enabled       = true
      + id            = (known after apply)
      + last_updated  = (known after apply)
      + level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name          = "foo"
      + tool_category = "metrics"
    }

```

create - name predicate
```bash
  # opslevel_check_tool_usage.example will be created
  + resource "opslevel_check_tool_usage" "example" {
      + category            = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description         = (known after apply)
      + enabled             = true
      + id                  = (known after apply)
      + last_updated        = (known after apply)
      + level               = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name                = "foo"
      + tool_category       = "metrics"
      + tool_name_predicate = {
          + type = "exists"
        }
    }
```

create - url predicate
```bash
  # opslevel_check_tool_usage.example will be created
  + resource "opslevel_check_tool_usage" "example" {
      + category           = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description        = (known after apply)
      + enabled            = true
      + id                 = (known after apply)
      + last_updated       = (known after apply)
      + level              = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name               = "foo"
      + tool_category      = "metrics"
      + tool_url_predicate = {
          + type  = "contains"
          + value = "https://"
        }
    }

```

create - env predicate
```bash
  # opslevel_check_tool_usage.example will be created
  + resource "opslevel_check_tool_usage" "example" {
      + category              = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description           = (known after apply)
      + enabled               = true
      + environment_predicate = {
          + type  = "contains"
          + value = "prod"
        }
      + id                    = (known after apply)
      + last_updated          = (known after apply)
      + level                 = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name                  = "foo"
      + tool_category         = "metrics"
    }

```

update - add predicates
```
  # opslevel_check_tool_usage.example will be updated in-place
  ~ resource "opslevel_check_tool_usage" "example" {
        id                    = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjQxNzI"
      + last_updated          = (known after apply)
        name                  = "foo"
      + tool_name_predicate   = {
          + type = "exists"
        }
      + tool_url_predicate    = {
          + type  = "contains"
          + value = "http://"
        }
        # (6 unchanged attributes hidden)
    }

```

update - modify predicates
```
  # opslevel_check_tool_usage.example will be updated in-place
  ~ resource "opslevel_check_tool_usage" "example" {
      ~ description           = "The service has a metrics tool whose name exists in an environment which contains 'prod' with a url which contains 'http://'." -> (known after apply)
      - environment_predicate = {
          - type  = "contains" -> null
          - value = "prod" -> null
        } -> null
        id                    = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjQxNzI"
      + last_updated          = (known after apply)
        name                  = "foo"
      ~ tool_name_predicate   = {
          ~ type  = "exists" -> "contains"
          + value = "datadog"
        }
      ~ tool_url_predicate    = {
          ~ type  = "contains" -> "exists"
          - value = "http://" -> null
        }
        # (4 unchanged attributes hidden)
    }

```

update - tool category
```bash
  # opslevel_check_tool_usage.example will be updated in-place
  ~ resource "opslevel_check_tool_usage" "example" {
      ~ description         = "The service has a metrics tool whose name contains 'datadog' with a url which exists ''." -> (known after apply)
        id                  = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjQxNzI"
      + last_updated        = (known after apply)
        name                = "foo"
      ~ tool_category       = "metrics" -> "logs"
        # (5 unchanged attributes hidden)
    }

```

delete
```bash
  # opslevel_check_tool_usage.example will be destroyed
  # (because opslevel_check_tool_usage.example is not in configuration)
  - resource "opslevel_check_tool_usage" "example" {
      - category           = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - description        = "The service has a metrics tool with a url which contains 'https://'." -> null
      - enabled            = true -> null
      - id                 = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjQxNzE" -> null
      - level              = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name               = "foo" -> null
      - tool_category      = "metrics" -> null
      - tool_url_predicate = {
          - type  = "contains" -> null
          - value = "https://" -> null
        } -> null
    }

````
