### PR TITLE
Add alert source usage check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckAlertSourceUsageResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -1,86 +1,227 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
+	"time"
 
-// func resourceCheckAlertSourceUsage() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages an alert source usage check",
-// 		Create:      wrap(resourceCheckAlertSourceUsageCreate),
-// 		Read:        wrap(resourceCheckAlertSourceUsageRead),
-// 		Update:      wrap(resourceCheckAlertSourceUsageUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"alert_type": {
-// 				Type:         schema.TypeString,
-// 				Description:  "The type of the alert source.",
-// 				ForceNew:     false,
-// 				Required:     true,
-// 				ValidateFunc: validation.StringInSlice(opslevel.AllAlertSourceTypeEnum, false),
-// 			},
-// 			"alert_name_predicate": getPredicateInputSchema(false, DefaultPredicateDescription),
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckAlertSourceUsageCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckAlertSourceUsageCreateInput](checkCreateInput)
-// 	input.AlertSourceType = opslevel.RefOf(opslevel.AlertSourceTypeEnum(d.Get("alert_type").(string)))
-// 	input.AlertSourceNamePredicate = expandPredicate(d, "alert_name_predicate")
+var (
+	_ resource.ResourceWithConfigure   = &CheckAlertSourceUsageResource{}
+	_ resource.ResourceWithImportState = &CheckAlertSourceUsageResource{}
+)
 
-// 	resource, err := client.CreateCheckAlertSourceUsage(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+func NewCheckAlertSourceUsageResource() resource.Resource {
+	return &CheckAlertSourceUsageResource{}
+}
 
-// 	return resourceCheckAlertSourceUsageRead(d, client)
-// }
+// CheckAlertSourceUsageResource defines the resource implementation.
+type CheckAlertSourceUsageResource struct {
+	CommonResourceClient
+}
 
-// func resourceCheckAlertSourceUsageRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+type CheckAlertSourceUsageResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+	AlertType          types.String    `tfsdk:"alert_type"`
+	AlertNamePredicate *PredicateModel `tfsdk:"alert_name_predicate"`
+}
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("alert_type", string(resource.AlertSourceType)); err != nil {
-// 		return err
-// 	}
-// 	if _, ok := d.GetOk("alert_name_predicate"); ok {
-// 		if err := d.Set("alert_name_predicate", flattenPredicate(&resource.AlertSourceNamePredicate)); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	return nil
-// }
+func NewCheckAlertSourceUsageResourceModel(ctx context.Context, check opslevel.Check) CheckAlertSourceUsageResourceModel {
+	var model CheckAlertSourceUsageResourceModel
 
-// func resourceCheckAlertSourceUsageUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckAlertSourceUsageUpdateInput](checkUpdateInput)
+	model.Category = types.StringValue(string(check.Category.Id))
+	model.Enabled = types.BoolValue(check.Enabled)
+	model.EnableOn = types.StringValue(check.EnableOn.Time.Format(time.RFC3339))
+	model.Filter = types.StringValue(string(check.Filter.Id))
+	model.Id = types.StringValue(string(check.Id))
+	model.Level = types.StringValue(string(check.Level.Id))
+	model.Name = types.StringValue(check.Name)
+	model.Notes = types.StringValue(check.Notes)
+	model.Owner = types.StringValue(string(check.Owner.Team.Id))
+	model.LastUpdated = timeLastUpdated()
 
-// 	if d.HasChange("alert_type") {
-// 		input.AlertSourceType = opslevel.RefOf(opslevel.AlertSourceTypeEnum(d.Get("alert_type").(string)))
-// 	}
-// 	if d.HasChange("alert_name_predicate") {
-// 		input.AlertSourceNamePredicate = expandPredicateUpdate(d, "alert_name_predicate")
-// 	}
+	model.AlertType = types.StringValue(string(check.AlertSourceType))
+	model.AlertNamePredicate = NewPredicateModel(check.AlertSourceNamePredicate)
 
-// 	_, err := client.UpdateCheckAlertSourceUsage(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckAlertSourceUsageRead(d, client)
-// }
+	return model
+}
+
+func (r *CheckAlertSourceUsageResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_alert_source_usage"
+}
+
+func (r *CheckAlertSourceUsageResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Alert Source Usage Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"alert_type": schema.StringAttribute{
+				Description: "",
+				Required:    true,
+				Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllAlertSourceTypeEnum...)},
+			},
+			"alert_name_predicate": PredicateSchema(),
+		}),
+	}
+}
+
+func (r *CheckAlertSourceUsageResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckAlertSourceUsageResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+	}
+	input := opslevel.CheckAlertSourceUsageCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.AlertSourceType = opslevel.RefOf(opslevel.AlertSourceTypeEnum(planModel.AlertType.ValueString()))
+	if planModel.AlertNamePredicate != nil {
+		input.AlertSourceNamePredicate = &opslevel.PredicateInput{
+			Type:  opslevel.PredicateTypeEnum(planModel.AlertNamePredicate.Type.String()),
+			Value: opslevel.RefOf(planModel.AlertNamePredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.CreateCheckAlertSourceUsage(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_alert_source_usage, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckAlertSourceUsageResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a check alert source usage resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckAlertSourceUsageResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckAlertSourceUsageResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check alert source usage, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckAlertSourceUsageResourceModel(ctx, *data)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckAlertSourceUsageResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckAlertSourceUsageResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("error", err.Error())
+		return
+	}
+	input := opslevel.CheckAlertSourceUsageUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		EnableOn:   &iso8601.Time{Time: enabledOn},
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+
+	input.AlertSourceType = opslevel.RefOf(opslevel.AlertSourceTypeEnum(planModel.AlertType.ValueString()))
+	if planModel.AlertNamePredicate != nil {
+		input.AlertSourceNamePredicate = &opslevel.PredicateUpdateInput{
+			Type:  opslevel.RefOf(opslevel.PredicateTypeEnum(planModel.AlertNamePredicate.Type.String())),
+			Value: opslevel.RefOf(planModel.AlertNamePredicate.Value.String()),
+		}
+	}
+
+	data, err := r.client.UpdateCheckAlertSourceUsage(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_alert_source_usage, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckAlertSourceUsageResourceModel(ctx, *data)
+	stateModel.EnableOn = planModel.EnableOn
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a check alert source usage resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckAlertSourceUsageResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckAlertSourceUsageResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check alert source usage, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check alert source usage resource")
+}
+
+func (r *CheckAlertSourceUsageResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -88,7 +88,7 @@ func (r *CheckAlertSourceUsageResource) Schema(ctx context.Context, req resource
 
 		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
 			"alert_type": schema.StringAttribute{
-				Description: "",
+				Description: "The type of the alert source.",
 				Required:    true,
 				Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllAlertSourceTypeEnum...)},
 			},

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -50,6 +50,7 @@ func NewCheckAlertSourceUsageResourceModel(ctx context.Context, check opslevel.C
 	var stateModel CheckAlertSourceUsageResourceModel
 
 	stateModel.Category = RequiredStringValue(string(check.Category.Id))
+	stateModel.Description = ComputedStringValue(check.Description)
 	if planModel.Enabled.IsNull() {
 		stateModel.Enabled = types.BoolValue(false)
 	} else {

--- a/tests/resource_check_alert_source_usage.tftest.hcl
+++ b/tests/resource_check_alert_source_usage.tftest.hcl
@@ -1,0 +1,23 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_alert_source_usage" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition = opslevel_check_alert_source_usage.example.alert_name_predicate == {
+      type  = "contains"
+      value = "dev"
+    }
+    error_message = "wrong alert_name_predicate in opslevel_check_alert_source_usage.example"
+  }
+
+  assert {
+    condition     = opslevel_check_alert_source_usage.example.alert_type == "pagerduty"
+    error_message = "wrong value for alert_type in opslevel_check_alert_source_usage.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,20 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Check Alert Source
+
+resource "opslevel_check_alert_source_usage" "example" {
+  name     = "foo"
+  enabled  = true
+  category = var.test_id
+  level    = var.test_id
+  owner    = var.test_id
+  filter   = var.test_id
+
+  alert_type = "pagerduty" # one of: "pagerduty", "datadog", "opsgenie"
+  alert_name_predicate = {
+    type  = "contains"
+    value = "dev"
+  }
+}


### PR DESCRIPTION
## Issues

Add alert source usage check

## Tophatting


Create
```bash
  # opslevel_check_alert_source_usage.example will be created
  + resource "opslevel_check_alert_source_usage" "example" {
      + alert_name_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      + alert_type           = "pagerduty"
      + category             = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description          = (known after apply)
      + enabled              = false
      + id                   = (known after apply)
      + last_updated         = (known after apply)
      + level                = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name                 = "foo"
    }

```

Update able to null out predicate
```bash
  ~ resource "opslevel_check_alert_source_usage" "example" {
      - alert_name_predicate = {
          - type  = "contains" -> null
          - value = "dev" -> null
        } -> null
      + description          = (known after apply)
        id                   = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI0MTMy"
      + last_updated         = (known after apply)
        name                 = "foo"
        # (4 unchanged attributes hidden)
    }

```

