### PR TITLE
add repository resource, with tests

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -155,6 +155,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 		NewDomainResource,
 		NewFilterResource,
 		NewInfrastructureResource,
+		NewRepositoryResource,
 		NewRubricCategoryResource,
 		NewRubricLevelResource,
 		NewScorecardResource,

--- a/opslevel/resource_opslevel_repository.go
+++ b/opslevel/resource_opslevel_repository.go
@@ -1,99 +1,264 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
 
-// func resourceRepository() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages the ownership of a repository but does not create or delete the repository entity in OpsLevel.",
-// 		Create:      wrap(resourceRepositoryCreate),
-// 		Read:        wrap(resourceRepositoryRead),
-// 		Update:      wrap(resourceRepositoryUpdate),
-// 		Delete:      wrap(resourceRepositoryDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: map[string]*schema.Schema{
-// 			"last_updated": {
-// 				Type:     schema.TypeString,
-// 				Optional: true,
-// 				Computed: true,
-// 			},
-// 			"identifier": {
-// 				Type:        schema.TypeString,
-// 				Description: "The id or human-friendly, unique identifier for the repository.",
-// 				ForceNew:    true,
-// 				Optional:    true,
-// 			},
-// 			"owner": {
-// 				Type:        schema.TypeString,
-// 				Description: "The owner of the repository.",
-// 				ForceNew:    false,
-// 				Optional:    true,
-// 			},
-// 		},
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func resourceRepositoryCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	identifier := d.Get("identifier").(string)
-// 	var repository *opslevel.Repository
-// 	if opslevel.IsID(identifier) {
-// 		resource, err := client.GetRepository(*opslevel.NewID(identifier))
-// 		if err != nil {
-// 			return err
-// 		}
-// 		repository = resource
-// 	} else {
-// 		resource, err := client.GetRepositoryWithAlias(identifier)
-// 		if err != nil {
-// 			return err
-// 		}
-// 		repository = resource
-// 	}
+var _ resource.ResourceWithConfigure = &RepositoryResource{}
 
-// 	d.SetId(string(repository.Id))
+var _ resource.ResourceWithImportState = &RepositoryResource{}
 
-// 	return resourceRepositoryUpdate(d, client)
-// }
+func NewRepositoryResource() resource.Resource {
+	return &RepositoryResource{}
+}
 
-// func resourceRepositoryRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	repository, err := client.GetRepository(*opslevel.NewID(d.Id()))
-// 	if err != nil {
-// 		return err
-// 	}
+// RepositoryResource defines the resource implementation.
+type RepositoryResource struct {
+	CommonResourceClient
+}
 
-// 	if err := d.Set("owner", repository.Owner.Id); err != nil {
-// 		return err
-// 	}
+// RepositoryResourceModel describes the Repository managed resource.
+type RepositoryResourceModel struct {
+	Id          types.String `tfsdk:"id"`
+	Identifier  types.String `tfsdk:"identifier"`
+	LastUpdated types.String `tfsdk:"last_updated"`
+	Owner       types.String `tfsdk:"owner"`
+}
 
-// 	return nil
-// }
+func NewRepositoryResourceModel(ctx context.Context, repository opslevel.Repository) RepositoryResourceModel {
+	return RepositoryResourceModel{Id: ComputedStringValue(string(repository.Id))}
+}
 
-// func resourceRepositoryUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	input := opslevel.RepositoryUpdateInput{
-// 		Id: *opslevel.NewID(d.Id()),
-// 	}
+func (r *RepositoryResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_repository"
+}
 
-// 	if owner, ok := d.GetOk("owner"); ok {
-// 		input.OwnerId = opslevel.NewID(owner.(string))
-// 	} else {
-// 		input.OwnerId = opslevel.NewID("")
-// 	}
+func (r *RepositoryResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Repository Resource",
 
-// 	_, err := client.UpdateRepository(input)
-// 	if err != nil {
-// 		return err
-// 	}
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of the repository.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"identifier": schema.StringAttribute{
+				Description: "The id or human-friendly, unique identifier for the repository.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Computed: true,
+			},
+			"owner": schema.StringAttribute{
+				Description: "The owner of the repository.",
+				Optional:    true,
+			},
+		},
+	}
+}
 
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceRepositoryRead(d, client)
-// }
+func (r *RepositoryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel RepositoryResourceModel
 
-// func resourceRepositoryDelete(d *schema.ResourceData, client *opslevel.Client) error {
-// 	// No API call to make because the repository is not able to be deleted
-// 	d.SetId("")
-// 	return nil
-// }
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var err error
+	var repository *opslevel.Repository
+
+	identifier := planModel.Identifier.ValueString()
+	if opslevel.IsID(identifier) {
+		repository, err = r.client.GetRepository(*opslevel.NewID(identifier))
+	} else {
+		repository, err = r.client.GetRepositoryWithAlias(identifier)
+	}
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get repository, got error: %s", err))
+		return
+	}
+
+	updatedRepository, err := r.client.UpdateRepository(opslevel.RepositoryUpdateInput{
+		Id:      opslevel.ID(repository.Id),
+		OwnerId: opslevel.NewID(planModel.Owner.ValueString()),
+	})
+	if err != nil || updatedRepository == nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update repository, got error: %s", err))
+		return
+	}
+	stateModel := NewRepositoryResourceModel(ctx, *updatedRepository)
+
+	// Identifier from plan can be an id or alias
+	switch planModel.Identifier.ValueString() {
+	case string(updatedRepository.Id), updatedRepository.DefaultAlias:
+		stateModel.Identifier = planModel.Identifier
+	default:
+		resp.Diagnostics.AddError(
+			"opslevel client error",
+			fmt.Sprintf("given repository identifier '%s' did not match found repository's id '%s' or alias '%s'",
+				planModel.Identifier.ValueString(),
+				string(updatedRepository.Id),
+				updatedRepository.DefaultAlias,
+			),
+		)
+		return
+	}
+
+	// Owner from plan can be an id or alias
+	switch planModel.Owner.ValueString() {
+	case string(updatedRepository.Owner.Id), updatedRepository.Owner.Alias:
+		stateModel.Owner = planModel.Owner
+	case "":
+		stateModel.Owner = types.StringNull()
+	default:
+		resp.Diagnostics.AddError(
+			"opslevel client error",
+			fmt.Sprintf("repository owner found '%s' did not match given owner '%s'",
+				stateModel.Owner.ValueString(),
+				planModel.Owner.ValueString(),
+			),
+		)
+		return
+	}
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a repository resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *RepositoryResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel RepositoryResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readRepository, err := r.client.GetRepository(opslevel.ID(planModel.Id.ValueString()))
+	if err != nil || readRepository == nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read repository, got error: %s", err))
+		return
+	}
+	stateModel := NewRepositoryResourceModel(ctx, *readRepository)
+
+	// Identifier from plan can be an id or alias
+	switch planModel.Identifier.ValueString() {
+	case string(readRepository.Id), readRepository.DefaultAlias:
+		stateModel.Identifier = planModel.Identifier
+	default:
+		resp.Diagnostics.AddError(
+			"opslevel client error",
+			fmt.Sprintf("given repository identifier '%s' did not match found repository's id '%s' or alias '%s'",
+				planModel.Identifier.ValueString(),
+				string(readRepository.Id),
+				readRepository.DefaultAlias,
+			),
+		)
+		return
+	}
+
+	// Owner from plan can be an id or alias
+	switch planModel.Owner.ValueString() {
+	case string(readRepository.Owner.Id), readRepository.Owner.Alias:
+		stateModel.Owner = planModel.Owner
+	case "":
+		stateModel.Owner = types.StringNull()
+	default:
+		resp.Diagnostics.AddError(
+			"opslevel client error",
+			fmt.Sprintf("repository owner found '%s' did not match given owner '%s'",
+				stateModel.Owner.ValueString(),
+				planModel.Owner.ValueString(),
+			),
+		)
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *RepositoryResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel RepositoryResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatedRepository, err := r.client.UpdateRepository(opslevel.RepositoryUpdateInput{
+		Id:      opslevel.ID(planModel.Id.ValueString()),
+		OwnerId: opslevel.NewID(planModel.Owner.ValueString()),
+	})
+	if err != nil || updatedRepository == nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update repository, got error: %s", err))
+		return
+	}
+	stateModel := NewRepositoryResourceModel(ctx, *updatedRepository)
+
+	// Identifier from plan can be an id or alias
+	switch planModel.Identifier.ValueString() {
+	case string(updatedRepository.Id), updatedRepository.DefaultAlias:
+		stateModel.Identifier = planModel.Identifier
+	default:
+		resp.Diagnostics.AddError(
+			"opslevel client error",
+			fmt.Sprintf("given repository identifier '%s' did not match found repository's id '%s' or alias '%s'",
+				planModel.Identifier.ValueString(),
+				string(updatedRepository.Id),
+				updatedRepository.DefaultAlias,
+			),
+		)
+		return
+	}
+
+	// Owner from plan can be an id or alias
+	switch planModel.Owner.ValueString() {
+	case string(updatedRepository.Owner.Id), updatedRepository.Owner.Alias:
+		stateModel.Owner = planModel.Owner
+	case "":
+		stateModel.Owner = types.StringNull()
+	default:
+		resp.Diagnostics.AddError(
+			"opslevel client error",
+			fmt.Sprintf("repository owner found '%s' did not match given owner '%s'",
+				stateModel.Owner.ValueString(),
+				planModel.Owner.ValueString(),
+			),
+		)
+		return
+	}
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a repository resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *RepositoryResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	tflog.Trace(ctx, "unset a repository resource, actual repository not deleted")
+}
+
+func (r *RepositoryResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -260,7 +260,10 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	default:
 		resp.Diagnostics.AddError(
 			"opslevel client error",
-			fmt.Sprintf("service owner did not match given owner '%s'", stateModel.Owner.ValueString()),
+			fmt.Sprintf("service owner found '%s' did not match given owner '%s'",
+				stateModel.Owner.ValueString(),
+				planModel.Owner.ValueString(),
+			),
 		)
 		return
 	}

--- a/tests/mock_resource/repository.tfmock.hcl
+++ b/tests/mock_resource/repository.tfmock.hcl
@@ -1,0 +1,5 @@
+mock_resource "opslevel_repository" {
+  defaults = {
+    # id intentionally omitted - will be assigned a random string
+  }
+}

--- a/tests/resource_repository.tftest.hcl
+++ b/tests/resource_repository.tftest.hcl
@@ -1,0 +1,27 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_repository" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = can(opslevel_repository.mock_repo.id)
+    error_message = "id attribute missing from opslevel_repository.mock_repo"
+  }
+
+  assert {
+    condition     = opslevel_repository.mock_repo.identifier == "github.com:rocktavious/autopilot"
+    error_message = "wrong identifier for opslevel_repository.mock_repo"
+  }
+
+  assert {
+    condition     = opslevel_repository.mock_repo.owner == "developers"
+    error_message = "wrong owner for opslevel_repository.mock_repo"
+  }
+
+}
+

--- a/tests/resource_repository.tftest.hcl
+++ b/tests/resource_repository.tftest.hcl
@@ -3,24 +3,42 @@ mock_provider "opslevel" {
   source = "./mock_resource"
 }
 
-run "resource_repository" {
+run "resource_repository_with_alias" {
   providers = {
     opslevel = opslevel.fake
   }
 
   assert {
-    condition     = can(opslevel_repository.mock_repo.id)
-    error_message = "id attribute missing from opslevel_repository.mock_repo"
+    condition     = opslevel_repository.with_alias.identifier == "github.com:rocktavious/autopilot"
+    error_message = "wrong identifier for opslevel_repository.with_alias"
   }
 
   assert {
-    condition     = opslevel_repository.mock_repo.identifier == "github.com:rocktavious/autopilot"
-    error_message = "wrong identifier for opslevel_repository.mock_repo"
+    condition     = opslevel_repository.with_alias.owner == null
+    error_message = "expected null owner for opslevel_repository.with_alias"
+  }
+
+}
+
+
+run "resource_repository_with_id" {
+  providers = {
+    opslevel = opslevel.fake
   }
 
   assert {
-    condition     = opslevel_repository.mock_repo.owner == "developers"
-    error_message = "wrong owner for opslevel_repository.mock_repo"
+    condition     = can(opslevel_repository.with_id.id)
+    error_message = "id attribute missing from opslevel_repository.with_id"
+  }
+
+  assert {
+    condition     = opslevel_repository.with_id.identifier == var.test_id
+    error_message = "wrong identifier for opslevel_repository.with_id"
+  }
+
+  assert {
+    condition     = opslevel_repository.with_id.owner == var.test_id
+    error_message = "wrong owner for opslevel_repository.with_id"
   }
 
 }

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -63,6 +63,13 @@ resource "opslevel_infrastructure" "big_infra" {
   schema = "Big Database"
 }
 
+# Repository resources
+
+resource "opslevel_repository" "mock_repo" {
+  identifier = "github.com:rocktavious/autopilot"
+  owner      = "developers"
+}
+
 # Rubric Category resources
 
 resource "opslevel_rubric_category" "mock_category" {

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -65,9 +65,13 @@ resource "opslevel_infrastructure" "big_infra" {
 
 # Repository resources
 
-resource "opslevel_repository" "mock_repo" {
+resource "opslevel_repository" "with_alias" {
   identifier = "github.com:rocktavious/autopilot"
-  owner      = "developers"
+}
+
+resource "opslevel_repository" "with_id" {
+  identifier = var.test_id
+  owner      = var.test_id
 }
 
 # Rubric Category resources


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/308

## Changelog

[repository public docs](https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/resources/repository)

Changes:
- Add `repository` resource, with tests

- [X] List your changes here
- [ ] Make a `changie` entry

## Tophatting

### Using this file:
```tf
# main.tf
resource "opslevel_repository" "repo_with_alias" {
  identifier = "github.com:suraj-testing2/Shoes_Soda"
  owner      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU"
}

resource "opslevel_repository" "repo_with_id" {
  identifier = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw"
  owner      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU"
}
```

### Create Repository, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_repository.repo_with_alias will be created
  + resource "opslevel_repository" "repo_with_alias" {
      + id           = (known after apply)
      + identifier   = "github.com:suraj-testing2/Shoes_Soda"
      + last_updated = (known after apply)
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU"
    }

  # opslevel_repository.repo_with_id will be created
  + resource "opslevel_repository" "repo_with_id" {
      + id           = (known after apply)
      + identifier   = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw"
      + last_updated = (known after apply)
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
opslevel_repository.repo_with_id: Creating...
opslevel_repository.repo_with_alias: Creating...
opslevel_repository.repo_with_alias: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA]
opslevel_repository.repo_with_id: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

### Update this file:
```tf
# main.tf
resource "opslevel_repository" "repo_with_alias" {
  identifier = "github.com:suraj-testing2/Shoes_Soda"
  # owner      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU"
}

resource "opslevel_repository" "repo_with_id" {
  identifier = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw"
  # owner      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU"
}
```

### Update Repository, `terraform apply`
```tf
opslevel_repository.repo_with_id: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw]
opslevel_repository.repo_with_alias: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_repository.repo_with_alias will be updated in-place
  ~ resource "opslevel_repository" "repo_with_alias" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA"
      + last_updated = (known after apply)
      - owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU" -> null
        # (1 unchanged attribute hidden)
    }

  # opslevel_repository.repo_with_id will be updated in-place
  ~ resource "opslevel_repository" "repo_with_id" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw"
      + last_updated = (known after apply)
      - owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8yMjU" -> null
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
opslevel_repository.repo_with_id: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw]
opslevel_repository.repo_with_alias: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA]
opslevel_repository.repo_with_alias: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA]
opslevel_repository.repo_with_id: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
```

### Destroy Repository, `terraform destroy`
```tf
opslevel_repository.repo_with_alias: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA]
opslevel_repository.repo_with_id: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_repository.repo_with_alias will be destroyed
  - resource "opslevel_repository" "repo_with_alias" {
      - id         = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA" -> null
      - identifier = "github.com:suraj-testing2/Shoes_Soda" -> null
    }

  # opslevel_repository.repo_with_id will be destroyed
  - resource "opslevel_repository" "repo_with_id" {
      - id         = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw" -> null
      - identifier = "Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw" -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.
opslevel_repository.repo_with_alias: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzNA]
opslevel_repository.repo_with_id: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvUmVwb3NpdG9yaWVzOjpHaXRodWIvNDYzMw]
opslevel_repository.repo_with_id: Destruction complete after 0s
opslevel_repository.repo_with_alias: Destruction complete after 0s

Destroy complete! Resources: 2 destroyed.
```