### PR TITLE
Add new property definition resource

### DIFF
--- a/examples/data-sources/opslevel_property_definition/data-source.tf
+++ b/examples/data-sources/opslevel_property_definition/data-source.tf
@@ -1,5 +1,5 @@
 data "opslevel_property_definition" "pd1" {
-  id = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjg"
+  identifier = "id_or_alias"
 }
 
 output "pd_schema" {

--- a/examples/data-sources/opslevel_property_definition/data-source.tf
+++ b/examples/data-sources/opslevel_property_definition/data-source.tf
@@ -1,5 +1,5 @@
 data "opslevel_property_definition" "pd1" {
-  identifier = "id_or_alias"
+  id = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjg"
 }
 
 output "pd_schema" {

--- a/examples/resources/opslevel_property_definition/resource.tf
+++ b/examples/resources/opslevel_property_definition/resource.tf
@@ -1,8 +1,8 @@
 resource "opslevel_property_definition" "color_picker" {
-  name   = "Color Picker"
+  name = "Color Picker"
   schema = jsonencode({
-    "type": "string",
-    "enum": [
+    "type" : "string",
+    "enum" : [
       "red",
       "green",
       "blue",

--- a/examples/resources/opslevel_property_definition/resource.tf
+++ b/examples/resources/opslevel_property_definition/resource.tf
@@ -1,4 +1,13 @@
-resource "opslevel_property_definition" "newpd" {
-  name   = "Friends Property"
-  schema = jsonencode({ "$ref" : "#/$defs/MyProp", "$defs" : { "MyProp" : { "properties" : { "name" : { "type" : "string", "title" : "the new name", "description" : "The name of a friend", "default" : "alex", "examples" : ["joe", "lucy"] } }, "additionalProperties" : false, "type" : "object", "required" : ["name"] } } })
+resource "opslevel_property_definition" "color_picker" {
+  name   = "Color Picker"
+  schema = jsonencode({
+    "type": "string",
+    "enum": [
+      "red",
+      "green",
+      "blue",
+    ]
+  })
+  allowed_in_config_files = false
+  property_display_status = "visible"
 }

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -155,6 +155,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 		NewDomainResource,
 		NewFilterResource,
 		NewInfrastructureResource,
+		NewPropertyDefinitionResource,
 		NewRepositoryResource,
 		NewRubricCategoryResource,
 		NewRubricLevelResource,

--- a/opslevel/resource_opslevel_property_definition.go
+++ b/opslevel/resource_opslevel_property_definition.go
@@ -174,7 +174,7 @@ func (resource *PropertyDefinitionResource) Update(ctx context.Context, req reso
 	}
 	input := opslevel.PropertyDefinitionInput{
 		AllowedInConfigFiles:  planModel.AllowedInConfigFiles.ValueBoolPointer(),
-		Description:           planModel.Description.ValueStringPointer(),
+		Description:           opslevel.RefOf(planModel.Description.ValueString()),
 		Name:                  planModel.Name.ValueStringPointer(),
 		PropertyDisplayStatus: propertyDisplayStatus,
 		Schema:                definitionSchema,

--- a/opslevel/resource_opslevel_property_definition.go
+++ b/opslevel/resource_opslevel_property_definition.go
@@ -3,9 +3,10 @@ package opslevel
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/tests/resource_property_definition.tftest.hcl
+++ b/tests/resource_property_definition.tftest.hcl
@@ -1,0 +1,47 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_property_definition" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = can(opslevel_property_definition.color_picker.id)
+    error_message = "expected ID to be set"
+  }
+
+  assert {
+    condition     = can(opslevel_property_definition.color_picker.last_updated)
+    error_message = "expected last updated to be set"
+  }
+
+  assert {
+    condition     = opslevel_property_definition.color_picker.allowed_in_config_files == false
+    error_message = "unexpected value for allowed_in_config_files"
+  }
+
+  assert {
+    condition     = opslevel_property_definition.color_picker.name == "Color Picker"
+    error_message = "unexpected value for name"
+  }
+
+  assert {
+    condition     = opslevel_property_definition.color_picker.property_display_status == "visible"
+    error_message = "unexpected value for property_display_status"
+  }
+
+  assert {
+    condition = opslevel_property_definition.color_picker.schema == jsonencode({
+      "type" : "string",
+      "enum" : [
+        "red",
+        "green",
+        "blue",
+      ]
+    })
+    error_message = "unexpected value for schema"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -63,6 +63,22 @@ resource "opslevel_infrastructure" "big_infra" {
   schema = "Big Database"
 }
 
+# Property Definition
+
+resource "opslevel_property_definition" "color_picker" {
+  name = "Color Picker"
+  schema = jsonencode({
+    "type" : "string",
+    "enum" : [
+      "red",
+      "green",
+      "blue",
+    ]
+  })
+  allowed_in_config_files = false
+  property_display_status = "visible"
+}
+
 # Repository resources
 
 resource "opslevel_repository" "with_alias" {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/308

https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/resources/property_definition

## Changelog

- [x] **HAD TO MAKE property_display_status required!**

```
Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_property_definition.color_picker: Creating...
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to opslevel_property_definition.color_picker, provider "provider[\"registry.terraform.io/opslevel/opslevel\"]" produced an unexpected new value: .property_display_status: was null, but now cty.StringVal("visible").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
task: Failed to run task "terraform-apply": exit status 1

```

- [x] Update validators - add a json object validator (and minor comments cleanup)
- [x] Add property definition resource
- [x] Unit tests
- [x] Update incorrect and outdated example

```
Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_property_definition.color_picker: Creating...
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to opslevel_property_definition.color_picker, provider "provider[\"registry.terraform.io/opslevel/opslevel\"]" produced an unexpected new value: .property_display_status: was null, but now cty.StringVal("visible").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
task: Failed to run task "terraform-apply": exit status 1

```

## Tophatting

Config:

```
resource "opslevel_property_definition" "color_picker" {
  name   = "Color picker"
  schema = jsonencode({
    "type": "string",
    "enum": [
      "red",
      "green",
      "blue"
    ]
  })
  allowed_in_config_files = false
  property_display_status = "visible"
}
```

### Create a PD

```
Terraform will perform the following actions:

  # opslevel_property_definition.color_picker will be created
  + resource "opslevel_property_definition" "color_picker" {
      + allowed_in_config_files = false
      + id                      = (known after apply)
      + last_updated            = (known after apply)
      + name                    = "Color picker"
      + property_display_status = "visible"
      + schema                  = jsonencode(
            {
              + enum = [
                  + "red",
                  + "green",
                  + "blue",
                ]
              + type = "string"
            }
        )
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_property_definition.color_picker: Creating...
opslevel_property_definition.color_picker: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjc]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```

## Update it

```
Terraform will perform the following actions:

  # opslevel_property_definition.color_picker will be updated in-place
  ~ resource "opslevel_property_definition" "color_picker" {
      + description             = "Pick a color - I dare you."
        id                      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjc"
      + last_updated            = (known after apply)
      ~ name                    = "Color picker" -> "Updated color picker"
      ~ schema                  = jsonencode(
          ~ {
              ~ enum = [
                    # (2 unchanged elements hidden)
                    "blue",
                  + "yellow",
                  + "purple",
                ]
                # (1 unchanged attribute hidden)
            }
        )
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_property_definition.color_picker: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjc]
opslevel_property_definition.color_picker: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjc]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

```

![image](https://github.com/OpsLevel/terraform-provider-opslevel/assets/37668804/2c29eed2-e729-48be-8c4b-e01edcc64faf)


## Delete it

```
Terraform will perform the following actions:

  # opslevel_property_definition.color_picker will be destroyed
  - resource "opslevel_property_definition" "color_picker" {
      - allowed_in_config_files = false -> null
      - description             = "Pick a color - I dare you." -> null
      - id                      = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjc" -> null
      - name                    = "Updated color picker" -> null
      - property_display_status = "visible" -> null
      - schema                  = jsonencode(
            {
              - enum = [
                  - "red",
                  - "green",
                  - "blue",
                  - "yellow",
                  - "purple",
                ]
              - type = "string"
            }
        ) -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_property_definition.color_picker: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNjc]
opslevel_property_definition.color_picker: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.

```