### PR TITLE
add new property assignment resource

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -155,6 +155,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 		NewDomainResource,
 		NewFilterResource,
 		NewInfrastructureResource,
+		NewPropertyAssignmentResource,
 		NewPropertyDefinitionResource,
 		NewRepositoryResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_property_assignment.go
+++ b/opslevel/resource_opslevel_property_assignment.go
@@ -59,6 +59,7 @@ func (resource *PropertyAssignmentResource) Schema(ctx context.Context, req reso
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"last_updated": schema.StringAttribute{
@@ -72,14 +73,14 @@ func (resource *PropertyAssignmentResource) Schema(ctx context.Context, req reso
 				Description: "The custom property definition's ID or alias.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"owner": schema.StringAttribute{
 				Description: "The ID or alias of the entity (currently only supports service) that the property has been assigned to.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"value": schema.StringAttribute{
@@ -89,7 +90,7 @@ func (resource *PropertyAssignmentResource) Schema(ctx context.Context, req reso
 					JsonStringValidator(),
 				},
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 		},

--- a/opslevel/resource_opslevel_property_assignment.go
+++ b/opslevel/resource_opslevel_property_assignment.go
@@ -1,113 +1,174 @@
 package opslevel
 
-// import (
-// 	"fmt"
-// 	"strings"
+import (
+	"context"
+	"fmt"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func resourcePropertyAssignment() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages properties assigned to entities (like Services)",
-// 		Create:      wrap(resourcePropertyAssignmentCreate),
-// 		Read:        wrap(resourcePropertyAssignmentRead),
-// 		Delete:      wrap(resourcePropertyAssignmentDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: map[string]*schema.Schema{
-// 			"last_updated": {
-// 				Type:     schema.TypeString,
-// 				Optional: true,
-// 				Computed: true,
-// 			},
-// 			"definition": {
-// 				Type:        schema.TypeString,
-// 				Description: "The custom property definition's ID or alias.",
-// 				Required:    true,
-// 				ForceNew:    true,
-// 			},
-// 			"owner": {
-// 				Type:        schema.TypeString,
-// 				Description: "The ID or alias of the entity that the property has been assigned to.",
-// 				Required:    true,
-// 				ForceNew:    true,
-// 			},
-// 			"value": {
-// 				Type:        schema.TypeString,
-// 				Description: "The value of the custom property.",
-// 				Required:    true,
-// 				ForceNew:    true,
-// 			},
-// 		},
-// 	}
-// }
+var _ resource.ResourceWithConfigure = &PropertyAssignmentResource{}
 
-// func resourcePropertyAssignmentCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	input := opslevel.PropertyInput{
-// 		Owner:      *opslevel.NewIdentifier(d.Get("owner").(string)),
-// 		Definition: *opslevel.NewIdentifier(d.Get("definition").(string)),
-// 		Value:      opslevel.JsonString(d.Get("value").(string)),
-// 	}
+type PropertyAssignmentResource struct {
+	CommonResourceClient
+}
 
-// 	resource, err := client.PropertyAssign(input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(fmt.Sprintf("%s:%s", resource.Owner.Id(), resource.Definition.Id))
+func NewPropertyAssignmentResource() resource.Resource {
+	return &PropertyAssignmentResource{}
+}
 
-// 	return resourcePropertyAssignmentRead(d, client)
-// }
+type PropertyAssignmentResourceModel struct {
+	Definition  types.String `tfsdk:"definition"`
+	Id          types.String `tfsdk:"id"`
+	LastUpdated types.String `tfsdk:"last_updated"`
+	Locked      types.Bool   `tfsdk:"locked"`
+	Owner       types.String `tfsdk:"owner"`
+	Value       types.String `tfsdk:"value"`
+}
 
-// func resourcePropertyAssignmentRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	// an invalid id can be passed in by using 'terraform import', validate the it before attaching the id to the resource
-// 	parts := strings.SplitN(d.Id(), ":", 2)
-// 	if len(parts) != 2 {
-// 		return fmt.Errorf("[%s] invalid property assignment id, should be in format 'ownerId:definitionId' (only a single colon between both ids, no spaces or special characters)", d.Id())
-// 	}
-// 	ownerId := parts[0]
-// 	definitionId := parts[1]
-// 	if !opslevel.IsID(ownerId) {
-// 		return fmt.Errorf("[%s] invalid ownerId", ownerId)
-// 	}
-// 	if !opslevel.IsID(definitionId) {
-// 		return fmt.Errorf("[%s] invalid definitionId", definitionId)
-// 	}
+func NewPropertyAssignmentResourceModel(assignment opslevel.Property) PropertyAssignmentResourceModel {
+	model := PropertyAssignmentResourceModel{
+		Locked: types.BoolValue(assignment.Locked),
+		Value:  types.StringValue(string(*assignment.Value)),
+	}
+	// TODO: do we need to keep using this method of setting an ID in the new plugin version?
+	// the API does not have unique ID's for property assignments, so what we did in the past was use <owner_id>:<definition_id>
+	// keeping this for now just in case it's necessary for backwards compatability.
+	model.Id = RequiredStringValue(fmt.Sprintf("%s:%s", assignment.Owner.Id(), assignment.Definition.Id))
 
-// 	resource, err := client.GetProperty(ownerId, definitionId)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	// if resource was fetched correctly, attach the id to the resource
-// 	d.SetId(fmt.Sprintf("%s:%s", ownerId, definitionId))
+	return model
+}
 
-// 	if err := d.Set("definition", d.Get("definition")); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("owner", d.Get("owner")); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("value", string(*resource.Value)); err != nil {
-// 		return err
-// 	}
+func (resource *PropertyAssignmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_property_assignment"
+}
 
-// 	return nil
-// }
+func (resource *PropertyAssignmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Property Assignment Resource",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of this resource.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Computed: true,
+			},
+			"locked": schema.BoolAttribute{
+				Description: "If locked = true, the property has been set in opslevel.yml and cannot be modified in Terraform!",
+				Computed:    true,
+			},
+			"definition": schema.StringAttribute{
+				Description: "The custom property definition's ID or alias.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"owner": schema.StringAttribute{
+				Description: "The ID or alias of the entity (currently only supports service) that the property has been assigned to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"value": schema.StringAttribute{
+				Description: "The value of the custom property (must be a valid JSON value or null or object).",
+				Optional:    true,
+				Validators: []validator.String{
+					JsonStringValidator(),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
 
-// func resourcePropertyAssignmentDelete(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := strings.Split(d.Id(), ":")
-// 	if len(id) != 2 {
-// 		return fmt.Errorf("[%s] invalid property assignment id, should be in format 'ownerId:definitionId' (only a single colon between both ids, no spaces or special characters)", d.Id())
-// 	}
-// 	ownerId := id[0]
-// 	definitionId := id[1]
-// 	err := client.PropertyUnassign(ownerId, definitionId)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId("")
+func (resource *PropertyAssignmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel PropertyAssignmentResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-// 	return nil
-// }
+	definition := planModel.Definition.ValueString()
+	owner := planModel.Owner.ValueString()
+	value := opslevel.JsonString(planModel.Value.ValueString())
+	input := opslevel.PropertyInput{
+		Definition: *opslevel.NewIdentifier(planModel.Definition.ValueString()),
+		Owner:      *opslevel.NewIdentifier(planModel.Owner.ValueString()),
+		Value:      value,
+	}
+	assignment, err := resource.client.PropertyAssign(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("failed to assign property (%s) on service (%s), got error: %s", definition, owner, err))
+		return
+	}
+
+	stateModel := NewPropertyAssignmentResourceModel(*assignment)
+	stateModel.LastUpdated = timeLastUpdated()
+	// user is free to use either alias or ID for 'owner' and 'definition' fields
+	stateModel.Owner = planModel.Owner
+	stateModel.Definition = planModel.Definition
+
+	tflog.Trace(ctx, fmt.Sprintf("assigned property (%s) on service (%s) with value: '%s'", definition, owner, value))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (resource *PropertyAssignmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel PropertyAssignmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	definition := planModel.Definition.ValueString()
+	owner := planModel.Owner.ValueString()
+	assignment, err := resource.client.GetProperty(owner, definition)
+	if err != nil || assignment == nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read property assignment (%s) on service (%s), got error: %s", definition, owner, err))
+		return
+	}
+	value := *assignment.Value
+
+	stateModel := NewPropertyAssignmentResourceModel(*assignment)
+	// user is free to use either alias or ID for 'owner' and 'definition' fields
+	stateModel.Owner = planModel.Owner
+	stateModel.Definition = planModel.Definition
+
+	tflog.Trace(ctx, fmt.Sprintf("read property assignment (%s) on service (%s) with value: '%s'", definition, owner, value))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (resource *PropertyAssignmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError("terraform plugin error", "property assignments should never be updated, only replaced.\nplease file a bug report including your .tf file at: github.com/OpsLevel/terraform-provider-opslevel")
+}
+
+func (resource *PropertyAssignmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel PropertyAssignmentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	definition := planModel.Definition.ValueString()
+	owner := planModel.Owner.ValueString()
+	err := resource.client.PropertyUnassign(owner, definition)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("failed to unassign property (%s) on service (%s), got error: %s", definition, owner, err))
+		return
+	}
+	tflog.Trace(ctx, fmt.Sprintf("unassigned property (%s) on service (%s)", definition, owner))
+}

--- a/tests/mock_resource/property_assignment.tfmock.hcl
+++ b/tests/mock_resource/property_assignment.tfmock.hcl
@@ -1,0 +1,7 @@
+mock_resource "opslevel_property_assignment" {
+  defaults = {
+    # id intentionally omitted - will be assigned a random string
+    id     = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU"
+    locked = false
+  }
+}

--- a/tests/mock_resource/property_assignment.tfmock.hcl
+++ b/tests/mock_resource/property_assignment.tfmock.hcl
@@ -1,6 +1,5 @@
 mock_resource "opslevel_property_assignment" {
   defaults = {
-    # id intentionally omitted - will be assigned a random string
     id     = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU"
     locked = false
   }

--- a/tests/mock_resource/property_definition.tfmock.hcl
+++ b/tests/mock_resource/property_definition.tfmock.hcl
@@ -1,0 +1,5 @@
+mock_resource "opslevel_property_definition" {
+  defaults = {
+    # id intentionally omitted - will be assigned a random string
+  }
+}

--- a/tests/resource_property_assignment.tftest.hcl
+++ b/tests/resource_property_assignment.tftest.hcl
@@ -1,0 +1,76 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_property_assignment_using_aliases" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_aliases.id == "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU"
+    error_message = "expected ID (legacy field) to have 2 aliases separated by a ':'"
+  }
+
+  assert {
+    condition     = can(opslevel_property_assignment.color_picker_using_aliases.last_updated)
+    error_message = "expected last updated to exist"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_aliases.owner == "some_service"
+    error_message = "unexpected value for owner"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_aliases.definition == "some_definition"
+    error_message = "unexpected value for definition"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_aliases.value == "\"green\""
+    error_message = "unexpected value field"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_aliases.locked == false
+    error_message = "unexpected value for locked"
+  }
+}
+
+run "resource_property_assignment_using_ids" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_id.id == "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU"
+    error_message = "expected ID (legacy field) to have 2 aliases separated by a ':'"
+  }
+
+  assert {
+    condition     = can(opslevel_property_assignment.color_picker_using_id.last_updated)
+    error_message = "expected last updated to exist"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_id.owner == "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ"
+    error_message = "unexpected value for owner"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_id.definition == "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU"
+    error_message = "unexpected value for definition"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_id.value == "{\"hello\":\"world\",\"key\":null}"
+    error_message = "unexpected value field"
+  }
+
+  assert {
+    condition     = opslevel_property_assignment.color_picker_using_id.locked == false
+    error_message = "unexpected value for locked"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -63,6 +63,20 @@ resource "opslevel_infrastructure" "big_infra" {
   schema = "Big Database"
 }
 
+# Property Assignment
+
+resource "opslevel_property_assignment" "color_picker_using_aliases" {
+  owner      = "some_service"
+  definition = "some_definition"
+  value      = jsonencode("green")
+}
+
+resource "opslevel_property_assignment" "color_picker_using_id" {
+  owner      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ"
+  definition = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU"
+  value      = jsonencode({ "hello" : "world", "key" : null })
+}
+
 # Property Definition
 
 resource "opslevel_property_definition" "color_picker" {


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/308

https://registry.terraform.io/providers/OpsLevel/opslevel/latest/docs/resources/property_assignment

## Changelog

- [x] Add property assignment resource
- [x] Unit tests

## Tophatting

Config:

```
resource "opslevel_property_definition" "container" {
  name                    = "Container"
  allowed_in_config_files = true
  property_display_status = "visible"
  schema = jsonencode({
    "type" : "object",
    "properties" : {
      "container_id" : {
        "type" : "string",
        "format" : "uuid"
      },
      "build_date" : {
        "type" : "string",
        "format" : "date-time"
      },
      "container_name" : {
        "type" : "string",
        "pattern" : "^gcr.io/[a-z]+"
      }
    },
    "required" : [
      "container_id",
      "container_name"
    ]
  })
}

resource "opslevel_property_assignment" "container" {
  owner      = "sample_shopping_cart_service"
  definition = opslevel_property_definition.container.id
  value      = jsonencode({ "container_id" : "1c6098d6-952a-4062-9293-1dc06e991118", "container_name" : "gcr.io/containername" })
}

```

### Delete

```
Terraform will perform the following actions:

  # opslevel_property_assignment.container will be destroyed
  # (because opslevel_property_assignment.container is not in configuration)
  - resource "opslevel_property_assignment" "container" {
      - definition = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY" -> null
      - id         = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOA:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY" -> null
      - locked     = false -> null
      - owner      = "sample_shopping_cart_service" -> null
      - value      = jsonencode(
            {
              - container_id   = "1c6098d6-952a-4062-9293-1dc06e991118"
              - container_name = "gcr.io/containername"
            }
        ) -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_property_assignment.container: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOA:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY]
opslevel_property_assignment.container: Destruction complete after 1s

```

### Create

```
Terraform will perform the following actions:

  # opslevel_property_assignment.container will be created
  + resource "opslevel_property_assignment" "container" {
      + definition   = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY"
      + id           = (known after apply)
      + last_updated = (known after apply)
      + locked       = (known after apply)
      + owner        = "sample_shopping_cart_service"
      + value        = jsonencode(
            {
              + container_id   = "1c6098d6-952a-4062-9293-1dc06e991118"
              + container_name = "gcr.io/containername"
            }
        )
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_property_assignment.container: Creating...
opslevel_property_assignment.container: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOA:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```

![image](https://github.com/OpsLevel/terraform-provider-opslevel/assets/37668804/e4c31af7-7c23-4549-9bc1-c72797e7b086)


### Update (should always replace.)

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # opslevel_property_assignment.container must be replaced
-/+ resource "opslevel_property_assignment" "container" {
      ~ definition   = "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY" -> "Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU" # forces replacement
      ~ id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOA:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY" -> (known after apply)
      + last_updated = (known after apply)
      ~ locked       = false -> (known after apply)
      ~ owner        = "sample_shopping_cart_service" -> "sample_inventory_tracker" # forces replacement
      ~ value        = jsonencode(
            {
              - container_id   = "1c6098d6-952a-4062-9293-1dc06e991118"
              - container_name = "gcr.io/containername"
            }
        ) -> "\"blue\""
    }

Plan: 1 to add, 0 to change, 1 to destroy.
opslevel_property_assignment.container: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOA:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzY]
opslevel_property_assignment.container: Destruction complete after 0s
opslevel_property_assignment.container: Creating...
opslevel_property_assignment.container: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8zNzU]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.

```