### PR TITLE
add custom event check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckCustomEventResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_custom_event.go
+++ b/opslevel/resource_opslevel_check_custom_event.go
@@ -1,137 +1,250 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
 
-// func resourceCheckCustomEvent() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a custom event check.",
-// 		Create:      wrap(resourceCheckCustomEventCreate),
-// 		Read:        wrap(resourceCheckCustomEventRead),
-// 		Update:      wrap(resourceCheckCustomEventUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"integration": {
-// 				Type:        schema.TypeString,
-// 				Description: "The integration id this check will use.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"pass_pending": {
-// 				Type:        schema.TypeBool,
-// 				Description: "True if this check should pass by default. Otherwise the default 'pending' state counts as a failure.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"service_selector": {
-// 				Type:        schema.TypeString,
-// 				Description: "A jq expression that will be ran against your payload. This will parse out the service identifier.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"success_condition": {
-// 				Type:        schema.TypeString,
-// 				Description: "A jq expression that will be ran against your payload. A truthy value will result in the check passing.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"message": {
-// 				Type:        schema.TypeString,
-// 				Description: "The check result message template. It is compiled with Liquid and formatted in Markdown.",
-// 				ForceNew:    false,
-// 				Optional:    true,
-// 			},
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckCustomEventCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckCustomEventCreateInput](checkCreateInput)
+var (
+	_ resource.ResourceWithConfigure   = &CheckCustomEventResource{}
+	_ resource.ResourceWithImportState = &CheckCustomEventResource{}
+)
 
-// 	input.IntegrationId = *opslevel.NewID(d.Get("integration").(string))
-// 	input.PassPending = opslevel.Bool(d.Get("pass_pending").(bool))
-// 	input.ServiceSelector = d.Get("service_selector").(string)
-// 	input.SuccessCondition = d.Get("success_condition").(string)
-// 	input.ResultMessage = opslevel.RefOf(d.Get("message").(string))
+func NewCheckCustomEventResource() resource.Resource {
+	return &CheckCustomEventResource{}
+}
 
-// 	resource, err := client.CreateCheckCustomEvent(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+// CheckCustomEventResource defines the resource implementation.
+type CheckCustomEventResource struct {
+	CommonResourceClient
+}
 
-// 	return resourceCheckCustomEventRead(d, client)
-// }
+type CheckCustomEventResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// func resourceCheckCustomEventRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+	Integration      types.String `tfsdk:"integration"`
+	PassPending      types.Bool   `tfsdk:"pass_pending"`
+	ServiceSelector  types.String `tfsdk:"service_selector"`
+	SuccessCondition types.String `tfsdk:"success_condition"`
+	Message          types.String `tfsdk:"message"`
+}
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+func NewCheckCustomEventResourceModel(ctx context.Context, check opslevel.Check, planModel CheckCustomEventResourceModel) CheckCustomEventResourceModel {
+	var stateModel CheckCustomEventResourceModel
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
+	stateModel.Category = RequiredStringValue(string(check.Category.Id))
+	stateModel.Description = ComputedStringValue(check.Description)
+	if planModel.Enabled.IsNull() {
+		stateModel.Enabled = types.BoolValue(false)
+	} else {
+		stateModel.Enabled = OptionalBoolValue(&check.Enabled)
+	}
+	if planModel.EnableOn.IsNull() {
+		stateModel.EnableOn = types.StringNull()
+	} else {
+		// We pass through the plan value because of time formatting issue to ensure the state gets the exact value the customer specified
+		stateModel.EnableOn = planModel.EnableOn
+	}
+	stateModel.Filter = OptionalStringValue(string(check.Filter.Id))
+	stateModel.Id = ComputedStringValue(string(check.Id))
+	stateModel.Level = RequiredStringValue(string(check.Level.Id))
+	stateModel.Name = RequiredStringValue(check.Name)
+	stateModel.Notes = OptionalStringValue(check.Notes)
+	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
 
-// 	if err := d.Set("integration", resource.Integration.Id); err != nil {
-// 		return err
-// 	}
+	stateModel.Integration = RequiredStringValue(string(check.CustomEventCheckFragment.Integration.Id))
+	stateModel.PassPending = RequiredBoolValue(check.CustomEventCheckFragment.PassPending)
+	stateModel.ServiceSelector = RequiredStringValue(check.CustomEventCheckFragment.ServiceSelector)
+	stateModel.SuccessCondition = RequiredStringValue(check.CustomEventCheckFragment.SuccessCondition)
+	stateModel.Message = OptionalStringValue(check.CustomEventCheckFragment.ResultMessage)
 
-// 	if err := d.Set("pass_pending", resource.PassPending); err != nil {
-// 		return err
-// 	}
-// 	if _, ok := d.GetOk("service_selector"); ok {
-// 		if err := d.Set("service_selector", resource.ServiceSelector); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	if _, ok := d.GetOk("success_condition"); ok {
-// 		if err := d.Set("success_condition", resource.SuccessCondition); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	if _, ok := d.GetOk("message"); ok {
-// 		if err := d.Set("message", resource.ResultMessage); err != nil {
-// 			return err
-// 		}
-// 	}
+	return stateModel
+}
 
-// 	return nil
-// }
+func (r *CheckCustomEventResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_custom_event"
+}
 
-// func resourceCheckCustomEventUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckCustomEventUpdateInput](checkUpdateInput)
+func (r *CheckCustomEventResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Custom Event Resource",
 
-// 	if d.HasChange("integration") {
-// 		input.IntegrationId = opslevel.NewID(d.Get("integration").(string))
-// 	}
-// 	input.PassPending = opslevel.Bool(d.Get("pass_pending").(bool))
-// 	if d.HasChange("service_selector") {
-// 		input.ServiceSelector = opslevel.RefOf(d.Get("service_selector").(string))
-// 	}
-// 	if d.HasChange("success_condition") {
-// 		input.SuccessCondition = opslevel.RefOf(d.Get("success_condition").(string))
-// 	}
-// 	if d.HasChange("message") {
-// 		message := d.Get("message").(string)
-// 		input.ResultMessage = &message
-// 	}
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"integration": schema.StringAttribute{
+				Description: "The integration id this check will use.",
+				Required:    true,
+			},
+			"pass_pending": schema.BoolAttribute{
+				Description: "True if this check should pass by default. Otherwise the default 'pending' state counts as a failure.",
+				Required:    true,
+			},
+			"service_selector": schema.StringAttribute{
+				Description: "A jq expression that will be ran against your payload. This will parse out the service identifier.",
+				Required:    true,
+			},
+			"success_condition": schema.StringAttribute{
+				Description: "A jq expression that will be ran against your payload. A truthy value will result in the check passing.",
+				Required:    true,
+			},
+			"message": schema.StringAttribute{
+				Description: "The check result message template. It is compiled with Liquid and formatted in Markdown.",
+				Optional:    true,
+			},
+		}),
+	}
+}
 
-// 	_, err := client.UpdateCheckCustomEvent(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("last_updated", timeLastUpdated()); err != nil {
-// 		return err
-// 	}
-// 	return resourceCheckCustomEventRead(d, client)
-// }
+func (r *CheckCustomEventResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckCustomEventResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := opslevel.CheckCustomEventCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
+
+	input.IntegrationId = asID(planModel.Integration)
+	input.PassPending = planModel.PassPending.ValueBoolPointer()
+	input.ServiceSelector = planModel.ServiceSelector.ValueString()
+	input.SuccessCondition = planModel.SuccessCondition.ValueString()
+	input.ResultMessage = opslevel.RefOf(planModel.Message.ValueString())
+
+	data, err := r.client.CreateCheckCustomEvent(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_custom_event, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckCustomEventResourceModel(ctx, *data, planModel)
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a check custom event resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckCustomEventResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckCustomEventResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check custom event, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckCustomEventResourceModel(ctx, *data, planModel)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckCustomEventResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckCustomEventResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := opslevel.CheckCustomEventUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		Id:         asID(planModel.Id),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      opslevel.RefOf(planModel.Notes.ValueString()),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
+
+	input.IntegrationId = opslevel.RefOf(asID(planModel.Integration))
+	input.PassPending = planModel.PassPending.ValueBoolPointer()
+	input.ServiceSelector = opslevel.RefOf(planModel.ServiceSelector.ValueString())
+	input.SuccessCondition = opslevel.RefOf(planModel.SuccessCondition.ValueString())
+	input.ResultMessage = opslevel.RefOf(planModel.Message.ValueString())
+
+	data, err := r.client.UpdateCheckCustomEvent(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_custom_event, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckCustomEventResourceModel(ctx, *data, planModel)
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a check custom event resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckCustomEventResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckCustomEventResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check custom event, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check custom event resource")
+}
+
+func (r *CheckCustomEventResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/resource_check_custom_event.tftest.hcl
+++ b/tests/resource_check_custom_event.tftest.hcl
@@ -1,0 +1,35 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_custom_event" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_custom_event.example.name == "foo"
+    error_message = "wrong value name for opslevel_check_custom_event.example"
+  }
+
+  assert {
+    condition     = opslevel_check_custom_event.example.integration == var.test_id
+    error_message = "wrong value integration for opslevel_check_custom_event.example"
+  }
+
+  assert {
+    condition     = opslevel_check_custom_event.example.pass_pending == true
+    error_message = "wrong value pass_pending for opslevel_check_custom_event.example"
+  }
+
+  assert {
+    condition     = opslevel_check_custom_event.example.service_selector == ".messages[] | .incident.service.id"
+    error_message = "wrong value service_selector for opslevel_check_custom_event.example"
+  }
+
+  assert {
+    condition     = opslevel_check_custom_event.example.success_condition == ".messages[] |   select(.incident.service.id == $ctx.alias) | .incident.status == \"resolved\""
+    error_message = "wrong value success_condition for opslevel_check_custom_event.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,28 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Check Custom Event
+
+resource "opslevel_check_custom_event" "example" {
+  name              = "foo"
+  enabled           = true
+  category          = var.test_id
+  level             = var.test_id
+  owner             = var.test_id
+  filter            = var.test_id
+  integration       = var.test_id
+  pass_pending      = true
+  service_selector  = ".messages[] | .incident.service.id"
+  success_condition = ".messages[] |   select(.incident.service.id == $ctx.alias) | .incident.status == \"resolved\""
+  message           = <<-EOT
+  {% if check.passed %}
+    ### Check passed
+  {% else %}
+    ### Check failed
+    service **{{ data.messages[ctx.index].incident.service.id }}** has an unresolved incident.
+  {% endif %}
+  OpsLevel note: here you can fill in more details about this check. You can even include `data` from the payload, `params` specified in the URL and context `ctx` such as the service alias for the current evaluation.
+  EOT
+  notes             = "Optional additional info on why this check is run or how to fix it"
+}


### PR DESCRIPTION
## Issues

Add Custom Event Check


## Tophatting

Create
```bash
  # opslevel_check_custom_event.example will be created
  + resource "opslevel_check_custom_event" "example" {
      + category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description       = (known after apply)
      + enabled           = true
      + id                = (known after apply)
      + integration       = "Z2lkOi8vb3BzbGV2ZWwvSW50ZWdyYXRpb25zOjpFdmVudHM6OkdlbmVyaWNJbnRlZ3JhdGlvbi81Mzkw"
      + last_updated      = (known after apply)
      + level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + message           = <<-EOT
            {% if check.passed %}
              ### Check passed
            {% else %}
              ### Check failed
              service **{{ data.messages[ctx.index].incident.service.id }}** has an unresolved incident.
            {% endif %}
            OpsLevel note: here you can fill in more details about this check. You can even include `data` from the payload, `params` specified in the URL and context `ctx` such as the service alias for the current evaluation.
        EOT
      + name              = "foo"
      + notes             = "Optional additional info on why this check is run or how to fix it"
      + pass_pending      = true
      + service_selector  = ".messages[] | .incident.service.id"
      + success_condition = ".messages[] |   select(.incident.service.id == $ctx.alias) | .incident.status == \"resolved\""
    }

```

update - remove message
```bash
  # opslevel_check_custom_event.example will be updated in-place
  ~ resource "opslevel_check_custom_event" "example" {
      ~ description       = "Requires a JSON payload to be sent to the integration endpoint to complete a check for the service." -> (known after apply)
        id                = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpHZW5lcmljLzI0MTc4"
      + last_updated      = (known after apply)
      - message           = <<-EOT
            {% if check.passed %}
              ### Check passed
            {% else %}
              ### Check failed
              service **{{ data.messages[ctx.index].incident.service.id }}** has an unresolved incident.
            {% endif %}
            OpsLevel note: here you can fill in more details about this check. You can even include `data` from the payload, `params` specified in the URL and context `ctx` such as the service alias for the current evaluation.
        EOT -> null
        name              = "foo"
        # (8 unchanged attributes hidden)
    }

```

update service_selector and pass_pending
```
  # opslevel_check_custom_event.example will be updated in-place
  ~ resource "opslevel_check_custom_event" "example" {
      ~ description       = "Requires a JSON payload to be sent to the integration endpoint to complete a check for the service." -> (known after apply)
        id                = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpHZW5lcmljLzI0MTc4"
      + last_updated      = (known after apply)
        name              = "foo"
      ~ pass_pending      = true -> false
      ~ service_selector  = ".messages[] | .incident.service.id" -> "."
        # (6 unchanged attributes hidden)
    }

```


Delete
```bash
  # opslevel_check_custom_event.example will be destroyed
  # (because opslevel_check_custom_event.example is not in configuration)
  - resource "opslevel_check_custom_event" "example" {
      - category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - description       = "Requires a JSON payload to be sent to the integration endpoint to complete a check for the service." -> null
      - enabled           = true -> null
      - id                = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpHZW5lcmljLzI0MTc4" -> null
      - integration       = "Z2lkOi8vb3BzbGV2ZWwvSW50ZWdyYXRpb25zOjpFdmVudHM6OkdlbmVyaWNJbnRlZ3JhdGlvbi81Mzkw" -> null
      - level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name              = "foo" -> null
      - notes             = "Optional additional info on why this check is run or how to fix it" -> null
      - pass_pending      = false -> null
      - service_selector  = "." -> null
      - success_condition = ".messages[] |   select(.incident.service.id == $ctx.alias) | .incident.status == \"resolved\"" -> null
    }

```