### PR TITLE
Add service property check

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -153,6 +153,7 @@ func (p *OpslevelProvider) Configure(ctx context.Context, req provider.Configure
 func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCheckManualResource,
+		NewCheckServicePropertyResource,
 		NewDomainResource,
 		NewInfrastructureResource,
 		NewRubricCategoryResource,

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -88,7 +88,7 @@ func (r *CheckServicePropertyResource) Schema(ctx context.Context, req resource.
 
 		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
 			"property": schema.StringAttribute{
-				Description: "",
+				Description: "The property of the service that the check will verify.",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(opslevel.AllServicePropertyTypeEnum...),

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -1,85 +1,236 @@
 package opslevel
 
-// import (
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+import (
+	"context"
+	"fmt"
 
-// func resourceCheckServiceProperty() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a service property check.",
-// 		Create:      wrap(resourceCheckServicePropertyCreate),
-// 		Read:        wrap(resourceCheckServicePropertyRead),
-// 		Update:      wrap(resourceCheckServicePropertyUpdate),
-// 		Delete:      wrap(resourceCheckDelete),
-// 		Importer: &schema.ResourceImporter{
-// 			State: schema.ImportStatePassthrough,
-// 		},
-// 		Schema: getCheckSchema(map[string]*schema.Schema{
-// 			"property": {
-// 				Type:         schema.TypeString,
-// 				Description:  "The property of the service that the check will verify.",
-// 				ForceNew:     false,
-// 				Required:     true,
-// 				ValidateFunc: validation.StringInSlice(opslevel.AllServicePropertyTypeEnum, false),
-// 			},
-// 			"predicate": getPredicateInputSchema(false, DefaultPredicateDescription),
-// 		}),
-// 	}
-// }
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
 
-// func resourceCheckServicePropertyCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkCreateInput := getCheckCreateInputFrom(d)
-// 	input := opslevel.NewCheckCreateInputTypeOf[opslevel.CheckServicePropertyCreateInput](checkCreateInput)
-// 	input.ServiceProperty = opslevel.ServicePropertyTypeEnum(d.Get("property").(string))
-// 	input.PropertyValuePredicate = expandPredicate(d, "predicate")
+var (
+	_ resource.ResourceWithConfigure   = &CheckServicePropertyResource{}
+	_ resource.ResourceWithImportState = &CheckServicePropertyResource{}
+)
 
-// 	resource, err := client.CreateCheckServiceProperty(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.SetId(string(resource.Id))
+func NewCheckServicePropertyResource() resource.Resource {
+	return &CheckServicePropertyResource{}
+}
 
-// 	return resourceCheckServicePropertyRead(d, client)
-// }
+// CheckServicePropertyResource defines the resource implementation.
+type CheckServicePropertyResource struct {
+	CommonResourceClient
+}
 
-// func resourceCheckServicePropertyRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+type CheckServicePropertyResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+	LastUpdated types.String `tfsdk:"last_updated"`
 
-// 	resource, err := client.GetCheck(opslevel.ID(id))
-// 	if err != nil {
-// 		return err
-// 	}
+	Property  types.String    `tfsdk:"property"`
+	Predicate *PredicateModel `tfsdk:"predicate"`
+}
 
-// 	if err := setCheckData(d, resource); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("property", string(resource.Property)); err != nil {
-// 		return err
-// 	}
-// 	if err := d.Set("predicate", flattenPredicate(resource.Predicate)); err != nil {
-// 		return err
-// 	}
+func NewCheckServicePropertyResourceModel(ctx context.Context, check opslevel.Check, planModel CheckServicePropertyResourceModel) CheckServicePropertyResourceModel {
+	var stateModel CheckServicePropertyResourceModel
 
-// 	return nil
-// }
+	stateModel.Category = RequiredStringValue(string(check.Category.Id))
+	stateModel.Description = ComputedStringValue(check.Description)
+	if planModel.Enabled.IsNull() {
+		stateModel.Enabled = types.BoolValue(false)
+	} else {
+		stateModel.Enabled = OptionalBoolValue(&check.Enabled)
+	}
+	if planModel.EnableOn.IsNull() {
+		stateModel.EnableOn = types.StringNull()
+	} else {
+		// We pass through the plan value because of time formatting issue to ensure the state gets the exact value the customer specified
+		stateModel.EnableOn = planModel.EnableOn
+	}
+	stateModel.Filter = OptionalStringValue(string(check.Filter.Id))
+	stateModel.Id = ComputedStringValue(string(check.Id))
+	stateModel.Level = RequiredStringValue(string(check.Level.Id))
+	stateModel.Name = RequiredStringValue(check.Name)
+	stateModel.Notes = OptionalStringValue(check.Notes)
+	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
 
-// func resourceCheckServicePropertyUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	checkUpdateInput := getCheckUpdateInputFrom(d)
-// 	input := opslevel.NewCheckUpdateInputTypeOf[opslevel.CheckServicePropertyUpdateInput](checkUpdateInput)
+	stateModel.Property = RequiredStringValue(string(check.ServicePropertyCheckFragment.Property))
+	if check.ServicePropertyCheckFragment.Predicate != nil {
+		stateModel.Predicate = NewPredicateModel(*check.ServicePropertyCheckFragment.Predicate)
+	}
 
-// 	if d.HasChange("property") {
-// 		input.ServiceProperty = opslevel.RefOf(opslevel.ServicePropertyTypeEnum(d.Get("property").(string)))
-// 	}
-// 	if d.HasChange("predicate") {
-// 		input.PropertyValuePredicate = expandPredicateUpdate(d, "predicate")
-// 	}
+	return stateModel
+}
 
-// 	_, err := client.UpdateCheckServiceProperty(*input)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceCheckServicePropertyRead(d, client)
-// }
+func (r *CheckServicePropertyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_service_property"
+}
+
+func (r *CheckServicePropertyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check Service Property Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			"property": schema.StringAttribute{
+				Description: "",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(opslevel.AllServicePropertyTypeEnum...),
+				},
+			},
+			"predicate": PredicateSchema(),
+		}),
+	}
+}
+
+func (r *CheckServicePropertyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckServicePropertyResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := opslevel.CheckServicePropertyCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
+
+	input.ServiceProperty = opslevel.ServicePropertyTypeEnum(planModel.Property.ValueString())
+	if planModel.Predicate != nil {
+		input.PropertyValuePredicate = planModel.Predicate.ToCreateInput()
+	}
+
+	data, err := r.client.CreateCheckServiceProperty(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check_service_property, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckServicePropertyResourceModel(ctx, *data, planModel)
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a check service property resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckServicePropertyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckServicePropertyResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check service property, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckServicePropertyResourceModel(ctx, *data, planModel)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckServicePropertyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckServicePropertyResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := opslevel.CheckServicePropertyUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		Id:         asID(planModel.Id),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      opslevel.RefOf(planModel.Notes.ValueString()),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
+
+	input.ServiceProperty = opslevel.RefOf(opslevel.ServicePropertyTypeEnum(planModel.Property.ValueString()))
+	if planModel.Predicate != nil {
+		input.PropertyValuePredicate = planModel.Predicate.ToUpdateInput()
+	} else {
+		input.PropertyValuePredicate = &opslevel.PredicateUpdateInput{}
+	}
+
+	data, err := r.client.UpdateCheckServiceProperty(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check_service_property, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckServicePropertyResourceModel(ctx, *data, planModel)
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "updated a check service property resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckServicePropertyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckServicePropertyResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check service property, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check service property resource")
+}
+
+func (r *CheckServicePropertyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/resource_check_service_property.tftest.hcl
+++ b/tests/resource_check_service_property.tftest.hcl
@@ -1,0 +1,23 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_check_service_property" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_check_service_property.example.property == "language"
+    error_message = "wrong value for property in opslevel_check_service_property.example"
+  }
+
+  assert {
+    condition = opslevel_check_service_property.example.predicate == {
+      type  = "equals"
+      value = "python"
+    }
+    error_message = "wrong value for predicate in opslevel_check_service_property.example"
+  }
+}

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -173,3 +173,19 @@ resource "opslevel_check_manual" "example" {
   update_requires_comment = false
   notes                   = "Optional additional info on why this check is run or how to fix it"
 }
+
+# Check Service Property
+
+resource "opslevel_check_service_property" "example" {
+  name     = "foo"
+  enabled  = true
+  category = var.test_id
+  level    = var.test_id
+  owner    = var.test_id
+  filter   = var.test_id
+  property = "language"
+  predicate = {
+    type  = "equals"
+    value = "python"
+  }
+}


### PR DESCRIPTION
## Issues

Add service property check

## Tophatting

Create - without predicate
```bash
  # opslevel_check_service_property.example will be created
  + resource "opslevel_check_service_property" "example" {
      + category     = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1"
      + description  = (known after apply)
      + enabled      = true
      + id           = (known after apply)
      + last_updated = (known after apply)
      + level        = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name         = "foo"
      + property     = "language"
    }

```

update - add predicate
```bash
  # opslevel_check_service_property.example will be updated in-place
  ~ resource "opslevel_check_service_property" "example" {
      ~ description  = "The service has a language." -> (known after apply)
        id           = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjQxNzk"
      + last_updated = (known after apply)
        name         = "foo"
      + predicate    = {
          + type = "exists"
        }
        # (4 unchanged attributes hidden)
    }

```

update - remove predicate

```
  # opslevel_check_service_property.example will be updated in-place
  ~ resource "opslevel_check_service_property" "example" {
      ~ description  = "The service has a language." -> (known after apply)
        id           = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjQxNzk"
      + last_updated = (known after apply)
        name         = "foo"
      - predicate    = {
          - type = "exists" -> null
        } -> null
        # (4 unchanged attributes hidden)
    }

```

update - change property

```bash
  # opslevel_check_service_property.example will be updated in-place
  ~ resource "opslevel_check_service_property" "example" {
      ~ description  = "The service has a language." -> (known after apply)
        id           = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjQxNzk"
      + last_updated = (known after apply)
        name         = "foo"
      ~ property     = "language" -> "framework"
        # (3 unchanged attributes hidden)
    }
```

Delete
```bash
  # opslevel_check_service_property.example will be destroyed
  # (because opslevel_check_service_property.example is not in configuration)
  - resource "opslevel_check_service_property" "example" {
      - category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTY1" -> null
      - description = "The service has a framework." -> null
      - enabled     = true -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjQxNzk" -> null
      - level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name        = "foo" -> null
      - property    = "framework" -> null
    }

```