### PR TITLE
Add tag resource

### DIFF
--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -183,6 +183,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 		NewServiceRepositoryResource,
 		NewServiceTagResource,
 		NewSystemResource,
+		NewTagResource,
 		NewTeamContactResource,
 		NewTeamResource,
 		NewTeamTagResource,

--- a/opslevel/resource_opslevel_tag.go
+++ b/opslevel/resource_opslevel_tag.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/opslevel/resource_opslevel_tag.go
+++ b/opslevel/resource_opslevel_tag.go
@@ -60,7 +60,7 @@ func (r *TagResource) Metadata(ctx context.Context, req resource.MetadataRequest
 func (r *TagResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "Domain Resource",
+		MarkdownDescription: "Tag Resource",
 
 		Attributes: map[string]schema.Attribute{
 			"resource_identifier": schema.StringAttribute{

--- a/opslevel/resource_opslevel_tag.go
+++ b/opslevel/resource_opslevel_tag.go
@@ -41,7 +41,7 @@ type TagResourceModel struct {
 	LastUpdated types.String `tfsdk:"last_updated"`
 }
 
-func NewTagResourceModel(ctx context.Context, tag opslevel.Tag, planModel TagResourceModel) (TagResourceModel, diag.Diagnostics) {
+func NewTagResourceModel(ctx context.Context, tag opslevel.Tag, planModel TagResourceModel) TagResourceModel {
 	var stateModel TagResourceModel
 
 	stateModel.TargetResource = RequiredStringValue(planModel.TargetResource.ValueString())
@@ -50,7 +50,7 @@ func NewTagResourceModel(ctx context.Context, tag opslevel.Tag, planModel TagRes
 	stateModel.Value = RequiredStringValue(tag.Value)
 	stateModel.Id = types.StringValue(string(tag.Id))
 
-	return stateModel, diag.Diagnostics{}
+	return stateModel
 }
 
 func (r *TagResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -130,8 +130,7 @@ func (r *TagResource) Create(ctx context.Context, req resource.CreateRequest, re
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create tag, got error: %s", err))
 		return
 	}
-	stateModel, diags := NewTagResourceModel(ctx, *data, planModel)
-	resp.Diagnostics.Append(diags...)
+	stateModel := NewTagResourceModel(ctx, *data, planModel)
 	stateModel.LastUpdated = timeLastUpdated()
 
 	tflog.Trace(ctx, "created a tag resource")
@@ -173,8 +172,7 @@ func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	stateModel, diags := NewTagResourceModel(ctx, *tag, planModel)
-	resp.Diagnostics.Append(diags...)
+	stateModel := NewTagResourceModel(ctx, *tag, planModel)
 
 	// Save updated planModel into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)

--- a/opslevel/resource_opslevel_tag.go
+++ b/opslevel/resource_opslevel_tag.go
@@ -1,154 +1,207 @@
 package opslevel
 
-// import (
-// 	"fmt"
+import (
+	"context"
+	"fmt"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-// 	"github.com/opslevel/opslevel-go/v2024"
-// )
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func resourceTag() *schema.Resource {
-// 	return &schema.Resource{
-// 		Description: "Manages a tag. Only uses API's 'tag create', not 'tag assign'.",
-// 		Create:      wrap(resourceTagCreate),
-// 		Read:        wrap(resourceTagRead),
-// 		Update:      wrap(resourceTagUpdate),
-// 		Delete:      wrap(resourceTagDelete),
-// 		Schema: map[string]*schema.Schema{
-// 			"last_updated": {
-// 				Type:     schema.TypeString,
-// 				Optional: true,
-// 				Computed: true,
-// 			},
-// 			"resource_identifier": {
-// 				Type:        schema.TypeString,
-// 				Description: "The id or human-friendly, unique identifier of the resource this tag belongs to.",
-// 				ForceNew:    true,
-// 				Required:    true,
-// 			},
-// 			"resource_type": {
-// 				Type:         schema.TypeString,
-// 				Description:  "The resource type that the tag applies to.",
-// 				ForceNew:     true,
-// 				Required:     true,
-// 				ValidateFunc: validation.StringInSlice(opslevel.AllTaggableResource, false),
-// 			},
-// 			"key": {
-// 				Type:        schema.TypeString,
-// 				Description: "The key of the tag.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"value": {
-// 				Type:        schema.TypeString,
-// 				Description: "The value of the tag.",
-// 				ForceNew:    false,
-// 				Required:    true,
-// 			},
-// 			"returned_resource": {
-// 				Type:     schema.TypeString,
-// 				Computed: true,
-// 			},
-// 		},
-// 	}
-// }
+var _ resource.ResourceWithConfigure = &TagResource{}
 
-// func resourceTagCreate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	resourceId := d.Get("resource_identifier").(string)
-// 	resourceType := opslevel.TaggableResource(d.Get("resource_type").(string))
-// 	resource, err := client.GetTaggableResource(resourceType, resourceId)
-// 	if err != nil {
-// 		return err
-// 	}
+var _ resource.ResourceWithImportState = &TagResource{}
 
-// 	tagCreateInput := opslevel.TagCreateInput{
-// 		Key:   d.Get("key").(string),
-// 		Value: d.Get("value").(string),
-// 		Type:  opslevel.RefOf(resourceType),
-// 	}
+func NewTagResource() resource.Resource {
+	return &TagResource{}
+}
 
-// 	if opslevel.IsID(resourceId) {
-// 		tagCreateInput.Id = opslevel.NewID(resourceId)
-// 	} else {
-// 		tagCreateInput.Alias = opslevel.RefOf(resourceId)
-// 	}
-// 	newTag, err := client.CreateTag(tagCreateInput)
-// 	if err != nil {
-// 		return err
-// 	}
+// TagResource defines the resource implementation.
+type TagResource struct {
+	CommonResourceClient
+}
 
-// 	d.SetId(string(newTag.Id))
-// 	d.Set("returned_resource", resource.ResourceId())
-// 	d.Set("resource_type", resourceType)
+// TagResourceModel describes the Domain managed resource.
+type TagResourceModel struct {
+	TargetResource types.String `tfsdk:"resource_identifier"`
+	TargetType     types.String `tfsdk:"resource_type"`
+	Key            types.String `tfsdk:"key"`
+	Value          types.String `tfsdk:"value"`
 
-// 	return resourceTagRead(d, client)
-// }
+	Id          types.String `tfsdk:"id"`
+	LastUpdated types.String `tfsdk:"last_updated"`
+}
 
-// func resourceTagRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	resourceId := d.Get("returned_resource").(string)
-// 	resourceType := opslevel.TaggableResource(d.Get("resource_type").(string))
-// 	resource, err := client.GetTaggableResource(resourceType, resourceId)
-// 	if err != nil {
-// 		return err
-// 	}
+func NewTagResourceModel(ctx context.Context, tag opslevel.Tag, planModel TagResourceModel) (TagResourceModel, diag.Diagnostics) {
+	var stateModel TagResourceModel
 
-// 	tags, err := resource.GetTags(client, nil)
-// 	if err != nil {
-// 		return fmt.Errorf("Unable to get tags from '%s' with id '%s'", resourceType, resourceId)
-// 	}
-// 	id := d.Id()
-// 	tag, err := tags.GetTagById(*opslevel.NewID(id))
-// 	if err != nil || tag == nil {
-// 		return fmt.Errorf(
-// 			"Tag '%s' for type %s with id '%s' not found. %s",
-// 			id,
-// 			resource.ResourceType(),
-// 			resource.ResourceId(),
-// 			err,
-// 		)
-// 	}
+	stateModel.TargetResource = RequiredStringValue(planModel.TargetResource.ValueString())
+	stateModel.TargetType = RequiredStringValue(planModel.TargetType.ValueString())
+	stateModel.Key = RequiredStringValue(tag.Key)
+	stateModel.Value = RequiredStringValue(tag.Value)
+	stateModel.Id = types.StringValue(string(tag.Id))
 
-// 	if err := d.Set("resource_identifier", d.Get("resource_identifier").(string)); err != nil {
-// 		return err
-// 	}
+	return stateModel, diag.Diagnostics{}
+}
 
-// 	if err := d.Set("resource_type", string(resource.ResourceType())); err != nil {
-// 		return err
-// 	}
+func (r *TagResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_tag"
+}
 
-// 	if err := d.Set("key", tag.Key); err != nil {
-// 		return err
-// 	}
+func (r *TagResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Domain Resource",
 
-// 	if err := d.Set("value", tag.Value); err != nil {
-// 		return err
-// 	}
+		Attributes: map[string]schema.Attribute{
+			"resource_identifier": schema.StringAttribute{
+				Description: "The id or human-friendly, unique identifier of the resource this tag belongs to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"resource_type": schema.StringAttribute{
+				Description: "The resource type that the tag applies to.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(opslevel.AllTaggableResource...),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"key": schema.StringAttribute{
+				Description: "The key of the tag.",
+				Required:    true,
+			},
+			"value": schema.StringAttribute{
+				Description: "The value of the tag.",
+				Required:    true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The id of the tag created.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"last_updated": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
 
-// 	return nil
-// }
+func (r *TagResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel TagResourceModel
 
-// func resourceTagUpdate(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
+	// Read Terraform plan planModel into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
 
-// 	input := opslevel.TagUpdateInput{
-// 		Id:    opslevel.ID(id),
-// 		Key:   opslevel.RefOf(d.Get("key").(string)),
-// 		Value: opslevel.RefOf(d.Get("value").(string)),
-// 	}
-// 	if _, err := client.UpdateTag(input); err != nil {
-// 		return err
-// 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-// 	d.Set("last_updated", timeLastUpdated())
-// 	return resourceTagRead(d, client)
-// }
+	resourceId := planModel.TargetResource.ValueString()
+	resourceType := opslevel.TaggableResource(planModel.TargetType.ValueString())
+	tagCreateInput := opslevel.TagCreateInput{
+		Key:   planModel.Key.ValueString(),
+		Value: planModel.Value.ValueString(),
+		Type:  opslevel.RefOf(resourceType),
+	}
 
-// func resourceTagDelete(d *schema.ResourceData, client *opslevel.Client) error {
-// 	id := d.Id()
-// 	if err := client.DeleteTag(opslevel.ID(id)); err != nil {
-// 		return err
-// 	}
-// 	d.SetId("")
-// 	return nil
-// }
+	if opslevel.IsID(resourceId) {
+		tagCreateInput.Id = opslevel.NewID(resourceId)
+	} else {
+		tagCreateInput.Alias = opslevel.RefOf(resourceId)
+	}
+	data, err := r.client.CreateTag(tagCreateInput)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create tag, got error: %s", err))
+		return
+	}
+	stateModel, diags := NewTagResourceModel(ctx, *data, planModel)
+	resp.Diagnostics.Append(diags...)
+	stateModel.LastUpdated = timeLastUpdated()
+
+	tflog.Trace(ctx, "created a tag resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel TagResourceModel
+
+	// Read Terraform prior state planModel into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceId := planModel.TargetResource.ValueString()
+	resourceType := opslevel.TaggableResource(planModel.TargetType.ValueString())
+	data, err := r.client.GetTaggableResource(resourceType, resourceId)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read tag, got error: %s", err))
+		return
+	}
+	tags, err := data.GetTags(r.client, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get tags from '%s' with id '%s'", resourceType, resourceId))
+	}
+
+	id := planModel.Id.ValueString()
+	tag, err := tags.GetTagById(*opslevel.NewID(id))
+	if err != nil || tag == nil {
+		resp.Diagnostics.AddError("opslevel client error",
+			fmt.Sprintf("Tag '%s' for type %s with id '%s' not found. %s",
+				id,
+				data.ResourceType(),
+				data.ResourceId(),
+				err,
+			))
+		return
+	}
+
+	stateModel, diags := NewTagResourceModel(ctx, *tag, planModel)
+	resp.Diagnostics.Append(diags...)
+
+	// Save updated planModel into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *TagResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError("terraform plugin error", "tag assignments should never be updated, only replaced.\nplease file a bug report including your .tf file at: github.com/OpsLevel/terraform-provider-opslevel")
+}
+
+func (r *TagResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data TagResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteTag(asID(data.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete tag, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a tag resource")
+}
+
+func (r *TagResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/tests/resource_tag.tftest.hcl
+++ b/tests/resource_tag.tftest.hcl
@@ -1,0 +1,37 @@
+mock_provider "opslevel" {
+  alias  = "fake"
+  source = "./mock_resource"
+}
+
+run "resource_tag" {
+  providers = {
+    opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = can(opslevel_tag.example.id)
+    error_message = "can use field id in opslevel_tag.example"
+  }
+
+  assert {
+    condition     = opslevel_tag.example.resource_type == "Service"
+    error_message = "value for field resource_type is bad opslevel_tag.example"
+
+  }
+
+  assert {
+    condition     = opslevel_tag.example.resource_identifier == "test-service"
+    error_message = "value for field resource_identifier is bad opslevel_tag.example"
+  }
+
+  assert {
+    condition     = opslevel_tag.example.key == "yacht"
+    error_message = "value for field key is bad opslevel_tag.example"
+  }
+
+  assert {
+    condition     = opslevel_tag.example.value == "racing"
+    error_message = "value for field value is bad opslevel_tag.example"
+  }
+}
+

--- a/tests/resources.tf
+++ b/tests/resources.tf
@@ -629,3 +629,13 @@ resource "opslevel_check_tool_usage" "example" {
     value = "production"
   }
 }
+
+# Tag Resource
+
+resource "opslevel_tag" "example" {
+  resource_type       = "Service"
+  resource_identifier = "test-service"
+
+  key   = "yacht"
+  value = "racing"
+}


### PR DESCRIPTION
## Issues

Add tag resource

## Tophatting

Create
```bash
  # opslevel_tag.example will be created
  + resource "opslevel_tag" "example" {
      + id                  = (known after apply)
      + key                 = "foo"
      + last_updated        = (known after apply)
      + resource_identifier = "terraform-service"
      + resource_type       = "Service"
      + value               = "bar"
    }

```

Delete / Create
```
  # opslevel_tag.example must be replaced
-/+ resource "opslevel_tag" "example" {
      ~ id                  = "Z2lkOi8vb3BzbGV2ZWwvVGFnLzgyNzg4MDIy" -> (known after apply)
      + last_updated        = (known after apply)
      ~ value               = "bar" -> "billy" # forces replacement
        # (3 unchanged attributes hidden)
    }

```

Delete / Create - Domain
```
  # opslevel_tag.example must be replaced
-/+ resource "opslevel_tag" "example" {
      ~ id                  = "Z2lkOi8vb3BzbGV2ZWwvVGFnLzgyNzg4MDY0" -> (known after apply)
      + last_updated        = (known after apply)
      ~ resource_identifier = "testing" -> "my-domain" # forces replacement
      ~ resource_type       = "Service" -> "Domain" # forces replacement
        # (2 unchanged attributes hidden)
    }

```

Delete

```
  # opslevel_tag.example will be destroyed
  # (because opslevel_tag.example is not in configuration)
  - resource "opslevel_tag" "example" {
      - id                  = "Z2lkOi8vb3BzbGV2ZWwvVGFnLzgyNzg4MDY5" -> null
      - key                 = "foo" -> null
      - resource_identifier = "my-domain" -> null
      - resource_type       = "Domain" -> null
      - value               = "billy" -> null
    }

```