### PR TITLE
add rubric_categories datasource

### DIFF
--- a/.changes/unreleased/Feature-20240417-110524.yaml
+++ b/.changes/unreleased/Feature-20240417-110524.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add rubric_categories datasource back after upgrade
+time: 2024-04-17T11:05:24.692588-05:00

--- a/opslevel/datasource_opslevel_rubric_category.go
+++ b/opslevel/datasource_opslevel_rubric_category.go
@@ -30,11 +30,10 @@ type CategoryDataSourceModel struct {
 	Name   types.String     `tfsdk:"name"`
 }
 
-func NewCategoryDataSourceModel(ctx context.Context, category opslevel.Category, filter FilterBlockModel) CategoryDataSourceModel {
+func NewCategoryDataSourceModel(ctx context.Context, category opslevel.Category) CategoryDataSourceModel {
 	return CategoryDataSourceModel{
-		Filter: filter,
-		Id:     types.StringValue(string(category.Id)),
-		Name:   types.StringValue(category.Name),
+		Id:   ComputedStringValue(string(category.Id)),
+		Name: ComputedStringValue(category.Name),
 	}
 }
 
@@ -85,7 +84,8 @@ func (d *CategoryDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	categoryDataModel := NewCategoryDataSourceModel(ctx, *category, data.Filter)
+	categoryDataModel := NewCategoryDataSourceModel(ctx, *category)
+	categoryDataModel.Filter = data.Filter
 
 	// Save data into Terraform state
 	tflog.Trace(ctx, "read an OpsLevel Rubric Category data source")

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -194,6 +194,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewCategoryDataSource,
+		NewCategoryDataSourcesAll,
 		NewDomainDataSource,
 		NewDomainDataSourcesAll,
 		NewFilterDataSource,

--- a/tests/mock_datasource/rubric_category.tfmock.hcl
+++ b/tests/mock_datasource/rubric_category.tfmock.hcl
@@ -5,5 +5,3 @@ mock_data "opslevel_rubric_category" {
     # id intentionally omitted - will be assigned a random string
   }
 }
-
-


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/289

## Changelog

Changes:
- Add `rubric_categories` datasource

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_rubric_categories" "all" {}

output "found_all" {
  value = data.opslevel_rubric_categories.all
}
```

Run `terraform plan`
```terraform
data.opslevel_rubric_categories.all: Reading...
data.opslevel_rubric_categories.all: Read complete after 0s

Changes to Outputs:
  + found_all = {
      + rubric_categories = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDIx"
              + name = "Security"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDIy"
              + name = "Reliability"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDIz"
              + name = "Performance"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI0"
              + name = "Scalability"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI1"
              + name = "Observability"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI2"
              + name = "Infrastructure"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNDI3"
              + name = "Quality"
            },
        ]
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```