### PR TITLE
fix OPSLEVEL_API_TIMEOUT default, validate API TOKEN during config va…

### DIFF
--- a/.changes/unreleased/Bugfix-20240419-114112.yaml
+++ b/.changes/unreleased/Bugfix-20240419-114112.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix default value for OPSLEVEL_API_TIMEOUT when not provided
+time: 2024-04-19T11:41:12.842603-05:00

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -66,7 +66,7 @@ func (p *OpslevelProvider) ValidateConfig(ctx context.Context, req provider.Vali
 		return
 	}
 
-	if providerModel.ApiUrl.IsNull() && os.Getenv("OPSLEVEL_API_TOKEN") == "" {
+	if providerModel.ApiToken.IsNull() && os.Getenv("OPSLEVEL_API_TOKEN") == "" {
 		resp.Diagnostics.AddError(
 			"Provider Config Error",
 			"An OPSLEVEL_API_TOKEN is needed to authenticate with the opslevel client. "+


### PR DESCRIPTION
## Issues

[Provider authentication is broken in v0.12.0-0](https://github.com/OpsLevel/terraform-provider-opslevel/issues/303)

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
