### PR TITLE
add known error to service update

### DIFF
--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -316,6 +316,19 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// NOTE: these fields cannot be unset at the GraphQL API level - we want to acknowledge this for now
+	var lifecycleAliasBeforeUpdate, tierAliasBeforeUpdate types.String
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("lifecycle_alias"), &lifecycleAliasBeforeUpdate)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tier_alias"), &tierAliasBeforeUpdate)...)
+	if !lifecycleAliasBeforeUpdate.IsNull() && planModel.LifecycleAlias.IsNull() {
+		resp.Diagnostics.AddError("Known error", "Unable to unset 'lifecycle_alias' field for now. We have a planned fix for this.")
+		return
+	}
+	if !tierAliasBeforeUpdate.IsNull() && planModel.TierAlias.IsNull() {
+		resp.Diagnostics.AddError("Known error", "Unable to unset 'tier_alias' field for now. We have a planned fix for this.")
+		return
+	}
+
 	serviceUpdateInput := opslevel.ServiceUpdateInput{
 		Description:    opslevel.RefOf(planModel.Description.ValueString()),
 		Framework:      opslevel.RefOf(planModel.Framework.ValueString()),


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Acknowledge known issue raised by customer

- [X] List your changes here
- [ ] Make a `changie` entry, N/A this simply acknowledges known issues

## Tophatting

```tf
resource "opslevel_service" "test" {
  aliases                       = ["one-test-one", "TWO-TEST-TW2O", "two-test-two"]
  api_document_path             = "my/path/doc.yaml"
  description                   = "fancy things"
  framework                     = "da-best"
  language                      = "go"
  lifecycle_alias = "alpha"
  name            = "tophatting-service"
  owner                         = "platform"
  preferred_api_document_source = "PUSH"
  product                       = "tophat"
  tags                          = ["key:value"]
  tier_alias                    = "tier_2"
}
```

### Create service, `terraform apply`
```tf
opslevel_service.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.test will be updated in-place
  ~ resource "opslevel_service" "test" {
      - aliases                       = [
          - "one-test-one",
          - "TWO-TEST-TW2O",
          - "two-test-two",
        ] -> null
      - api_document_path             = "my/path/doc.yaml" -> null
      - description                   = "fancy things" -> null
      - framework                     = "da-best" -> null
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE"
      - language                      = "go" -> null
      + last_updated                  = (known after apply)
        name                          = "tophatting-service"
      - owner                         = "platform" -> null
      - preferred_api_document_source = "PUSH" -> null
      - product                       = "tophat" -> null
      - tags                          = [
          - "key:value",
        ] -> null
      - tier_alias                    = "tier_2" -> null
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE]
╷
│ Error: Known error
│ 
│   with opslevel_service.test,
│   on main.tf line 1, in resource "opslevel_service" "test":
│    1: resource "opslevel_service" "test" {
│ 
│ Unable to unset 'tier_alias' field for now. We have a planned fix for this.
```

### Unset `tier_alias` field

```tf
opslevel_service.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.test will be updated in-place
  ~ resource "opslevel_service" "test" {
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE"
      + last_updated                  = (known after apply)
        name                          = "tophatting-service"
        tags                          = [
            "key:value",
        ]
      - tier_alias                    = "tier_2" -> null
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE]
╷
│ Error: Known error
│ 
│   with opslevel_service.test,
│   on main.tf line 1, in resource "opslevel_service" "test":
│    1: resource "opslevel_service" "test" {
│ 
│ Unable to unset 'tier_alias' field for now. We have a planned fix for this.
╵
task: Failed to run task "terraform-apply": exit status 1
```

### Unset `lifecycle_alias` field

```tf
opslevel_service.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.test will be updated in-place
  ~ resource "opslevel_service" "test" {
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE"
      + last_updated                  = (known after apply)
      - lifecycle_alias               = "alpha" -> null
        name                          = "tophatting-service"
        tags                          = [
            "key:value",
        ]
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjAxNTE]
╷
│ Error: Known error
│ 
│   with opslevel_service.test,
│   on main.tf line 1, in resource "opslevel_service" "test":
│    1: resource "opslevel_service" "test" {
│ 
│ Unable to unset 'lifecycle_alias' field for now. We have a planned fix for this.
```