### PR TITLE
add services datasource back in

### DIFF
--- a/.changes/unreleased/Feature-20240423-132752.yaml
+++ b/.changes/unreleased/Feature-20240423-132752.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add services datasource back after upgrade
+time: 2024-04-23T13:27:52.137466-05:00

--- a/opslevel/datasource_opslevel_repositories_all.go
+++ b/opslevel/datasource_opslevel_repositories_all.go
@@ -84,7 +84,7 @@ func (d *RepositoriesDataSourcesAll) Read(ctx context.Context, req datasource.Re
 	} else {
 		repos, err = d.client.ListRepositories(nil)
 	}
-	if err != nil || repos == nil || repos.Nodes == nil {
+	if err != nil || repos == nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read OpsLevel Repositories data source, got error: %s", err))
 		return
 	}
@@ -93,6 +93,6 @@ func (d *RepositoriesDataSourcesAll) Read(ctx context.Context, req datasource.Re
 	stateModel.Filter = planModel.Filter
 
 	// Save data into Terraform state
-	tflog.Trace(ctx, "read an OpsLevel Repository data source")
+	tflog.Trace(ctx, "listed all OpsLevel Repository data sources")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
 }

--- a/opslevel/datasource_opslevel_services.go
+++ b/opslevel/datasource_opslevel_services.go
@@ -1,78 +1,149 @@
 package opslevel
 
-// import (
-// 	"github.com/opslevel/opslevel-go/v2024"
+import (
+	"context"
+	"fmt"
+	"strings"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-// )
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
 
-// func datasourceServices() *schema.Resource {
-// 	return &schema.Resource{
-// 		Read: wrap(datasourceServicesRead),
-// 		Schema: map[string]*schema.Schema{
-// 			"filter": getDatasourceFilter(false, []string{"framework", "language", "lifecycle", "owner", "product", "tag", "tier"}),
-// 			"ids": {
-// 				Type:     schema.TypeList,
-// 				Computed: true,
-// 				Elem:     &schema.Schema{Type: schema.TypeString},
-// 			},
-// 			"names": {
-// 				Type:     schema.TypeList,
-// 				Computed: true,
-// 				Elem:     &schema.Schema{Type: schema.TypeString},
-// 			},
-// 			"urls": {
-// 				Type:     schema.TypeList,
-// 				Computed: true,
-// 				Elem:     &schema.Schema{Type: schema.TypeString},
-// 			},
-// 		},
-// 	}
-// }
+// Ensure ServiceDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &ServiceDataSource{}
 
-// func datasourceServicesRead(d *schema.ResourceData, client *opslevel.Client) error {
-// 	field := d.Get("filter.0.field").(string)
-// 	value := d.Get("filter.0.value").(string)
+func NewServiceDataSourcesAll() datasource.DataSource {
+	return &ServiceDataSourcesAll{}
+}
 
-// 	var services *opslevel.ServiceConnection
-// 	var err error
+// ServiceDataSource manages a Service data source.
+type ServiceDataSourcesAll struct {
+	CommonDataSourceClient
+}
 
-// 	switch field {
-// 	case "framework":
-// 		services, err = client.ListServicesWithFramework(value, nil)
-// 	case "language":
-// 		services, err = client.ListServicesWithLanguage(value, nil)
-// 	case "lifecycle":
-// 		services, err = client.ListServicesWithLifecycle(value, nil)
-// 	case "owner":
-// 		services, err = client.ListServicesWithOwner(value, nil)
-// 	case "product":
-// 		services, err = client.ListServicesWithProduct(value, nil)
-// 	case "tag":
-// 		services, err = client.ListServicesWithTag(opslevel.NewTagArgs(value), nil)
-// 	case "tier":
-// 		services, err = client.ListServicesWithTier(value, nil)
-// 	default:
-// 		services, err = client.ListServices(nil)
-// 	}
-// 	if err != nil {
-// 		return err
-// 	}
+// ServiceDataSourcesAllModel describes the data source data model.
+type ServiceDataSourcesAllModel struct {
+	Filter   *filterBlockModel                `tfsdk:"filter"`
+	Services []serviceMinimalaDataSourceModel `tfsdk:"services"`
+}
 
-// 	count := len(services.Nodes)
-// 	ids := make([]string, count)
-// 	names := make([]string, count)
-// 	urls := make([]string, count)
-// 	for i, item := range services.Nodes {
-// 		ids[i] = string(item.Id)
-// 		names[i] = item.Name
-// 		urls[i] = item.HtmlURL
-// 	}
+func NewServiceDataSourcesAllModel(services []opslevel.Service) ServiceDataSourcesAllModel {
+	serviceDataSourcesModel := []serviceMinimalaDataSourceModel{}
+	for _, service := range services {
+		serviceModel := serviceMinimalaDataSourceModel{
+			Id:   ComputedStringValue(string(service.Id)),
+			Name: ComputedStringValue(service.Name),
+			Url:  ComputedStringValue(service.HtmlURL),
+		}
+		serviceDataSourcesModel = append(serviceDataSourcesModel, serviceModel)
+	}
+	return ServiceDataSourcesAllModel{Services: serviceDataSourcesModel}
+}
 
-// 	d.SetId(timeID())
-// 	d.Set("ids", ids)
-// 	d.Set("names", names)
-// 	d.Set("urls", urls)
+func (d *ServiceDataSourcesAll) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_services"
+}
 
-// 	return nil
-// }
+var serviceMinimalSchemaAttrs = map[string]schema.Attribute{
+	"id": schema.StringAttribute{
+		Description: "The id of the service",
+		Computed:    true,
+	},
+	"name": schema.StringAttribute{
+		Description: "The display name of the service.",
+		Computed:    true,
+	},
+	"url": schema.StringAttribute{
+		Description: "A link to the HTML page for the resource",
+		Computed:    true,
+	},
+}
+
+type serviceMinimalaDataSourceModel struct {
+	Id   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+	Url  types.String `tfsdk:"url"`
+}
+
+func (d *ServiceDataSourcesAll) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	validFieldNames := []string{"framework", "language", "lifecycle", "owner", "product", "tag", "tier"}
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Services data source",
+
+		Attributes: map[string]schema.Attribute{
+			"filter": schema.SingleNestedAttribute{
+				Description: fmt.Sprintf(
+					"Used to filter services by one of '%s'",
+					strings.Join(validFieldNames, "`, `"),
+				),
+				Optional:   true,
+				Attributes: FilterAttrs(validFieldNames),
+			},
+			"services": schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: serviceMinimalSchemaAttrs,
+				},
+				Description: "List of Service data sources",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *ServiceDataSourcesAll) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var planModel, stateModel ServiceDataSourcesAllModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &planModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var services *opslevel.ServiceConnection
+	var err error
+
+	if planModel.Filter == nil {
+		services, err = d.client.ListServices(nil)
+	} else {
+		switch planModel.Filter.Field.ValueString() {
+		case "framework":
+			services, err = d.client.ListServicesWithFramework(planModel.Filter.Value.ValueString(), nil)
+		case "language":
+			services, err = d.client.ListServicesWithLanguage(planModel.Filter.Value.ValueString(), nil)
+		case "lifecycle":
+			services, err = d.client.ListServicesWithLifecycle(planModel.Filter.Value.ValueString(), nil)
+		case "owner":
+			services, err = d.client.ListServicesWithOwner(planModel.Filter.Value.ValueString(), nil)
+		case "product":
+			services, err = d.client.ListServicesWithProduct(planModel.Filter.Value.ValueString(), nil)
+		case "tag":
+			tagArgs, tagArgsErr := opslevel.NewTagArgs(planModel.Filter.Value.ValueString())
+			if tagArgsErr != nil {
+				resp.Diagnostics.AddError("Client Error",
+					fmt.Sprintf("Unable to create TagArgs from '%s', got error: '%s'", planModel.Filter.Value.ValueString(), err),
+				)
+				return
+			}
+			services, err = d.client.ListServicesWithTag(tagArgs, nil)
+		case "tier":
+			services, err = d.client.ListServicesWithTier(planModel.Filter.Value.ValueString(), nil)
+		default:
+			services, err = d.client.ListServices(nil)
+		}
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to list services datasource, got error: %s", err))
+		return
+	}
+
+	stateModel = NewServiceDataSourcesAllModel(services.Nodes)
+	stateModel.Filter = planModel.Filter
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "listed all OpsLevel Service data sources")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}

--- a/opslevel/datasource_opslevel_services_all.go
+++ b/opslevel/datasource_opslevel_services_all.go
@@ -24,13 +24,13 @@ type ServiceDataSourcesAll struct {
 	CommonDataSourceClient
 }
 
-// ServiceDataSourcesAllModel describes the data source data model.
-type ServiceDataSourcesAllModel struct {
+// serviceDataSourcesAllModel describes the data source data model.
+type serviceDataSourcesAllModel struct {
 	Filter   *filterBlockModel                `tfsdk:"filter"`
 	Services []serviceMinimalaDataSourceModel `tfsdk:"services"`
 }
 
-func NewServiceDataSourcesAllModel(services []opslevel.Service) ServiceDataSourcesAllModel {
+func NewServiceDataSourcesAllModel(services []opslevel.Service) serviceDataSourcesAllModel {
 	serviceDataSourcesModel := []serviceMinimalaDataSourceModel{}
 	for _, service := range services {
 		serviceModel := serviceMinimalaDataSourceModel{
@@ -40,7 +40,7 @@ func NewServiceDataSourcesAllModel(services []opslevel.Service) ServiceDataSourc
 		}
 		serviceDataSourcesModel = append(serviceDataSourcesModel, serviceModel)
 	}
-	return ServiceDataSourcesAllModel{Services: serviceDataSourcesModel}
+	return serviceDataSourcesAllModel{Services: serviceDataSourcesModel}
 }
 
 func (d *ServiceDataSourcesAll) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -94,7 +94,7 @@ func (d *ServiceDataSourcesAll) Schema(ctx context.Context, req datasource.Schem
 }
 
 func (d *ServiceDataSourcesAll) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var planModel, stateModel ServiceDataSourcesAllModel
+	var planModel, stateModel serviceDataSourcesAllModel
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &planModel)...)

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -235,6 +235,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewRepositoryDataSource,
 		NewScorecardDataSource,
 		NewServiceDataSource,
+		NewServiceDataSourcesAll,
 		NewSystemDataSource,
 		NewSystemDataSourcesAll,
 		NewTeamDataSource,


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/289

## Changelog

Changes:
- Add `services` datasource

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

Using this file:
```terraform
# main.tf
data "opslevel_services" "all" {}

data "opslevel_services" "by_framework" {
  filter = {
    field = "framework"
    value = "terraform"
  }
}

data "opslevel_services" "by_language" {
  filter = {
    field = "language"
    value = "Go"
  }
}

data "opslevel_services" "by_lifecycle" {
  filter = {
    field = "lifecycle"
    value = "alpha"
  }
}

data "opslevel_services" "by_owner" {
  filter = {
    field = "owner"
    value = "frontend"
  }
}

data "opslevel_services" "by_product" {
  filter = {
    field = "product"
    value = "OSS"
  }
}

data "opslevel_services" "by_tag" {
  filter = {
    field = "tag"
    value = "environment:dev"
  }
}

data "opslevel_services" "by_tier" {
  filter = {
    field = "tier"
    value = "tier_4"
  }
}

output "all" {
  value = data.opslevel_services.all
}

output "by_framework" {
  value = data.opslevel_services.by_framework
}

output "by_language" {
  value = data.opslevel_services.by_language
}

output "by_lifecycle" {
  value = data.opslevel_services.by_lifecycle
}

output "by_owner" {
  value = data.opslevel_services.by_owner
}

output "by_product" {
  value = data.opslevel_services.by_product
}

output "by_tag" {
  value = data.opslevel_services.by_tag
}

output "by_tier" {
  value = data.opslevel_services.by_tier
}

output "all" {
  value = data.opslevel_services.all
}
```

Run `terraform plan`
```terraform
data.opslevel_services.by_tag: Reading...
data.opslevel_services.by_language: Reading...
data.opslevel_services.by_lifecycle: Reading...
data.opslevel_services.by_owner: Reading...
data.opslevel_services.all: Reading...
data.opslevel_services.by_product: Reading...
data.opslevel_services.by_tier: Reading...
data.opslevel_services.by_framework: Reading...
data.opslevel_services.by_framework: Read complete after 1s
data.opslevel_services.by_language: Read complete after 1s
data.opslevel_services.by_tag: Read complete after 1s
data.opslevel_services.by_owner: Read complete after 1s
data.opslevel_services.by_tier: Read complete after 1s
data.opslevel_services.by_lifecycle: Read complete after 1s
data.opslevel_services.by_product: Read complete after 1s
data.opslevel_services.all: Read complete after 7s

Changes to Outputs:
  + all          = {
      + filter   = null
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDgwMzQ"
              + name = "10662"
              + url  = "https://app.opslevel.com/services/10662"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82NzYw"
              + name = "A La Carte Service"
              + url  = "https://app.opslevel.com/services/a_la_carte_service"
            },
           # manually removed most services from output, there are a lot....
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82NzE5"
              + name = "Zz Random"
              + url  = "https://app.opslevel.com/services/zz_random"
            },
        ]
    }
  + by_framework = {
      + filter   = {
          + field = "framework"
          + value = "Backstage"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85ODI3"
              + name = "Catalog Service"
              + url  = "https://app.opslevel.com/services/catalog_service"
            },
        ]
    }
  + by_language  = {
      + filter   = {
          + field = "language"
          + value = "Go"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80MjI3Mw"
              + name = "purelb"
              + url  = "https://app.opslevel.com/services/purelb"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80MjI3Nw"
              + name = "purelb"
              + url  = "https://app.opslevel.com/services/purelb_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MjEwOQ"
              + name = "Chaosww"
              + url  = "https://app.opslevel.com/services/chaosww"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MjExMQ"
              + name = "brand new gitlab22"
              + url  = "https://app.opslevel.com/services/brand_new_gitlab22"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MzkwOA"
              + name = "DB Deployer"
              + url  = "https://app.opslevel.com/services/db_deployer"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83ODEyMQ"
              + name = "hello world 2"
              + url  = "https://app.opslevel.com/services/hello_world_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MjM5Nw"
              + name = "kubernetes-sync"
              + url  = "https://app.opslevel.com/services/kubernetes-sync"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzIxNw"
              + name = "SVC from CLI"
              + url  = "https://app.opslevel.com/services/svc_from_cli"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzIxOA"
              + name = "SVC from CLI"
              + url  = "https://app.opslevel.com/services/svc_from_cli_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDY3MTA"
              + name = "local-build-0.6.3-kubernetes-sync"
              + url  = "https://app.opslevel.com/services/local-build-0_6_3-kubernetes-sync"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDc5MTA"
              + name = "local-build-1.2.3-kubernetes-sync"
              + url  = "https://app.opslevel.com/services/local-build-1_2_3-kubernetes-sync"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDc5MTI"
              + name = "sync-kubernetes-sync"
              + url  = "https://app.opslevel.com/services/sync-kubernetes-sync"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5Nzc"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5Nzg"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5Nzk"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_3"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5ODE"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_4"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5ODI"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_5"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5ODM"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_6"
            },
        ]
    }
  + by_lifecycle = {
      + filter   = {
          + field = "lifecycle"
          + value = "alpha"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zMTY4"
              + name = "abc 999"
              + url  = "https://app.opslevel.com/services/abc_999"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81NDgx"
              + name = "Goldfish Service"
              + url  = "https://app.opslevel.com/services/goldfish_service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83NzM1"
              + name = "monorepo service 1"
              + url  = "https://app.opslevel.com/services/monorepo_service_1"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xNjgwMA"
              + name = "other-primary"
              + url  = "https://app.opslevel.com/services/other-primary"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDEw"
              + name = "Procurement Service"
              + url  = "https://app.opslevel.com/services/procurement_service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDEx"
              + name = "Procurement Service"
              + url  = "https://app.opslevel.com/services/procurement_service_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85NjY5"
              + name = "Rails Monolith"
              + url  = "https://app.opslevel.com/services/rails_monolith"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5Nzc"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5Nzg"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5Nzk"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_3"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5ODE"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_4"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5ODI"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_5"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTg5ODM"
              + name = "tophatting-service"
              + url  = "https://app.opslevel.com/services/tophatting-service_6"
            },
        ]
    }
  + by_owner     = {
      + filter   = {
          + field = "owner"
          + value = "frontend"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDA4"
              + name = "A yml test 2"
              + url  = "https://app.opslevel.com/services/a_yml_test_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83NjM0"
              + name = "Datalake"
              + url  = "https://app.opslevel.com/services/datalake"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80MjI4MA"
              + name = "Analytics"
              + url  = "https://app.opslevel.com/services/analytics"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80ODEyMg"
              + name = "A yml test 2"
              + url  = "https://app.opslevel.com/services/a_yml_test_2_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MzA3OQ"
              + name = "A system yml test"
              + url  = "https://app.opslevel.com/services/a_system_yml_test"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MzA4MA"
              + name = "A system yml test"
              + url  = "https://app.opslevel.com/services/a_system_yml_test_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MzUyMg"
              + name = "Chaos"
              + url  = "https://app.opslevel.com/services/chaos"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MjExMg"
              + name = "laugh"
              + url  = "https://app.opslevel.com/services/laugh"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MjExMw"
              + name = "new abc"
              + url  = "https://app.opslevel.com/services/new_abc"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MjExOA"
              + name = "new interactor test again"
              + url  = "https://app.opslevel.com/services/new_interactor_test_again"
            },
        ]
    }
  + by_product   = {
      + filter   = {
          + field = "product"
          + value = "OSS"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83ODEyMQ"
              + name = "hello world 2"
              + url  = "https://app.opslevel.com/services/hello_world_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzIxNw"
              + name = "SVC from CLI"
              + url  = "https://app.opslevel.com/services/svc_from_cli"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzIxOA"
              + name = "SVC from CLI"
              + url  = "https://app.opslevel.com/services/svc_from_cli_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTU"
              + name = "coredns"
              + url  = "https://app.opslevel.com/services/coredns"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTY"
              + name = "cluster-autoscaler"
              + url  = "https://app.opslevel.com/services/cluster-autoscaler"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTc"
              + name = "metrics-server"
              + url  = "https://app.opslevel.com/services/metrics-server"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTg"
              + name = "ebs-csi-controller"
              + url  = "https://app.opslevel.com/services/ebs-csi-controller"
            },
        ]
    }
  + by_tag       = {
      + filter   = {
          + field = "tag"
          + value = "environment:dev"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTU"
              + name = "coredns"
              + url  = "https://app.opslevel.com/services/coredns"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTY"
              + name = "cluster-autoscaler"
              + url  = "https://app.opslevel.com/services/cluster-autoscaler"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTc"
              + name = "metrics-server"
              + url  = "https://app.opslevel.com/services/metrics-server"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDYwOTg"
              + name = "ebs-csi-controller"
              + url  = "https://app.opslevel.com/services/ebs-csi-controller"
            },
        ]
    }
  + by_tier      = {
      + filter   = {
          + field = "tier"
          + value = "tier_4"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84NzEyNA"
              + name = "39e54e5b69dded010f18fc8ab03c53fa69891305e1a79ebed469e33d258c652e"
              + url  = "https://app.opslevel.com/services/39e54e5b69dded010f18fc8ab03c53fa69891305e1a79ebed469e33d258c652e"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Nzk3"
              + name = "a test service"
              + url  = "https://app.opslevel.com/services/a_test_service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83NzI1"
              + name = "A4"
              + url  = "https://app.opslevel.com/services/a4"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84NzA3MA"
              + name = "Android App"
              + url  = "https://app.opslevel.com/services/android_app"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjA0"
              + name = "Android_Post_office"
              + url  = "https://app.opslevel.com/services/android_post_office"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zMjcw"
              + name = "Ashley Service 2"
              + url  = "https://app.opslevel.com/services/ashley_service_2_3"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Nzk1"
              + name = "atp"
              + url  = "https://app.opslevel.com/services/atp"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zMDcx"
              + name = "Bad Tier Test"
              + url  = "https://app.opslevel.com/services/bad_tier_test"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80NjQyMQ"
              + name = "Bugs Bunny"
              + url  = "https://app.opslevel.com/services/bugs_bunny"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MTQyOQ"
              + name = "computer"
              + url  = "https://app.opslevel.com/services/computer"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80NjQyMg"
              + name = "Daffy Duck"
              + url  = "https://app.opslevel.com/services/daffy_duck"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MjExNw"
              + name = "Delivery Service"
              + url  = "https://app.opslevel.com/services/delivery_service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83ODEyMQ"
              + name = "hello world 2"
              + url  = "https://app.opslevel.com/services/hello_world_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84NzA3MQ"
              + name = "monorepo hackday test"
              + url  = "https://app.opslevel.com/services/monorepo_hackday_test"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDgxMzQ"
              + name = "name set from web"
              + url  = "https://app.opslevel.com/services/name_set_from_web"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xNjgwMA"
              + name = "other-primary"
              + url  = "https://app.opslevel.com/services/other-primary"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80NjM2MA"
              + name = "Oven"
              + url  = "https://app.opslevel.com/services/oven"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80NjQyMw"
              + name = "Road Runner"
              + url  = "https://app.opslevel.com/services/road_runner"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zMjYxMw"
              + name = "shopping Cart Service"
              + url  = "https://app.opslevel.com/services/shopping_cart_service_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzIxNw"
              + name = "SVC from CLI"
              + url  = "https://app.opslevel.com/services/svc_from_cli"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzIxOA"
              + name = "SVC from CLI"
              + url  = "https://app.opslevel.com/services/svc_from_cli_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMDc5NjI"
              + name = "tsvc"
              + url  = "https://app.opslevel.com/services/tsvc"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80NjQyNQ"
              + name = "Tweety"
              + url  = "https://app.opslevel.com/services/tweety"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xNjkxNA"
              + name = "yikes-config"
              + url  = "https://app.opslevel.com/services/yikes-config"
            },
        ]
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```