### PR TITLE
can filter services datasource by filter id

### DIFF
--- a/.changes/unreleased/Feature-20240425-160915.yaml
+++ b/.changes/unreleased/Feature-20240425-160915.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: can filter services datasource by filter id
+time: 2024-04-25T16:09:15.567149-05:00

--- a/opslevel/datasource_opslevel_services_all.go
+++ b/opslevel/datasource_opslevel_services_all.go
@@ -112,7 +112,7 @@ func (d *ServiceDataSourcesAll) Read(ctx context.Context, req datasource.ReadReq
 		case "filter":
 			filterId := planModel.Filter.Value.ValueString()
 			if opslevel.IsID(filterId) {
-				services, err = d.client.ListServicesWithFilterId(filterId, nil)
+				services, err = d.client.ListServicesWithFilter(filterId, nil)
 			} else {
 				resp.Diagnostics.AddError("Config Error",
 					fmt.Sprintf("'value' field in filter block must be a valid ID. Given '%s'", filterId),

--- a/opslevel/datasource_opslevel_services_all.go
+++ b/opslevel/datasource_opslevel_services_all.go
@@ -69,7 +69,7 @@ type serviceMinimalaDataSourceModel struct {
 }
 
 func (d *ServiceDataSourcesAll) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	validFieldNames := []string{"framework", "language", "lifecycle", "owner", "product", "tag", "tier"}
+	validFieldNames := []string{"filter", "framework", "language", "lifecycle", "owner", "product", "tag", "tier"}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Services data source",
 
@@ -109,6 +109,15 @@ func (d *ServiceDataSourcesAll) Read(ctx context.Context, req datasource.ReadReq
 		services, err = d.client.ListServices(nil)
 	} else {
 		switch planModel.Filter.Field.ValueString() {
+		case "filter":
+			filterId := planModel.Filter.Value.ValueString()
+			if opslevel.IsID(filterId) {
+				services, err = d.client.ListServicesWithFilterId(filterId, nil)
+			} else {
+				resp.Diagnostics.AddError("Config Error",
+					fmt.Sprintf("'value' field in filter block must be a valid ID. Given '%s'", filterId),
+				)
+			}
 		case "framework":
 			services, err = d.client.ListServicesWithFramework(planModel.Filter.Value.ValueString(), nil)
 		case "language":


### PR DESCRIPTION
## Issues

[Support the filterIdentifier argument in the services datasource in terraform ](https://github.com/OpsLevel/team-platform/issues/321)

## Changelog

Relies on [upstream PR being merged](https://github.com/OpsLevel/opslevel-go/pull/391)

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Using this config

```tf
data "opslevel_filter" "test_filter" {
  filter {
    field = "name"
    value = "JS Services"
  }
}

data "opslevel_services" "by_filter_id" {
  filter = {
    field = "filter"
    value = data.opslevel_filter.test_filter.id
  }
}

output "by_framework" {
  value = data.opslevel_services.by_filter_id
}
```

### Run `terraform plan`

```tf
data.opslevel_filter.test_filter: Reading...
data.opslevel_filter.test_filter: Read complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEwNTM]
data.opslevel_services.by_filter_id: Reading...
data.opslevel_services.by_filter_id: Read complete after 1s

Changes to Outputs:
  + by_framework = {
      + filter   = {
          + field = "filter"
          + value = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzEwNTM"
        }
      + services = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjk2"
              + name = "école"
              + url  = "https://app.opslevel.com/services/ecole"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xNDA3"
              + name = "My New Node Project Service"
              + url  = "https://app.opslevel.com/services/my_new_node_project_service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xNDA4"
              + name = "some new service"
              + url  = "https://app.opslevel.com/services/some_new_service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8zMTY4"
              + name = "abc 999"
              + url  = "https://app.opslevel.com/services/abc_999"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81Nzk2"
              + name = "JSONRPC APIz"
              + url  = "https://app.opslevel.com/services/jsonrpc_apiz"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS81ODAw"
              + name = "JSONRPC APIz"
              + url  = "https://app.opslevel.com/services/jsonrpc_apiz_2"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMTc2Ng"
              + name = "A Sniffle Test Repo Service"
              + url  = "https://app.opslevel.com/services/a_sniffle_test_repo_service"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS80NjQyMg"
              + name = "Daffy Duck"
              + url  = "https://app.opslevel.com/services/daffy_duck"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83MjExMA"
              + name = "rc10"
              + url  = "https://app.opslevel.com/services/rc10"
            },
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MjM4MA"
              + name = "JSONRPC APIz"
              + url  = "https://app.opslevel.com/services/jsonrpc_apiz_3"
            },
        ]
    }
```
