### PR TITLE
Ft/read languages from repo data source

### DIFF
--- a/.changes/unreleased/Feature-20240502-204105.yaml
+++ b/.changes/unreleased/Feature-20240502-204105.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add new output to the `opslevel_repository` data source
+time: 2024-05-02T20:41:05.106569+01:00

--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -33,6 +33,7 @@ data "opslevel_repository" "bar" {
 ### Read-Only
 
 - `name` (String) The display name of the repository.
-- `url` (String) The url of the the repository.
+- `url` (String) The url of the repository.
+- `languages` (List) List of maps containing all languages and their coverage detected on the repository.
 
 

--- a/opslevel/datasource_opslevel_repository.go
+++ b/opslevel/datasource_opslevel_repository.go
@@ -3,7 +3,6 @@ package opslevel
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -26,8 +25,8 @@ type RepositoryDataSource struct {
 
 // LanguagesModel describes the model for the Languages data of the repository.
 type LanguagesModel struct {
-	Name  types.String `tfsdk:"name"`
-	Usage types.String `tfsdk:"usage"`
+	Name  types.String  `tfsdk:"name"`
+	Usage types.Float64 `tfsdk:"usage"`
 }
 
 // RepositoryDataSourceModel describes the data source data model.
@@ -50,9 +49,7 @@ func LanguagesValue(value []opslevel.Language) []LanguagesModel {
 	for _, lang := range value {
 		language := LanguagesModel{
 			Name:  types.StringValue(lang.Name),
-			Usage: types.StringValue(strconv.FormatFloat(float64(lang.Usage), 'f', -1, 32)),
-			// convert the Usage float32 value to StringValue instead of NumberValue or Float64Value to keep the exact same value
-			// eg: a value of 0.55404 to type number or float64 converts to 0.5540400147, where to string, it remains the same.
+			Usage: types.Float64Value(lang.Usage),
 		}
 
 		languages = append(languages, language)
@@ -97,7 +94,7 @@ var repositoryDatasourceSchemaAttrs = map[string]schema.Attribute{
 				"name": schema.StringAttribute{
 					Optional: true,
 				},
-				"usage": schema.StringAttribute{
+				"usage": schema.Float64Attribute{
 					Optional: true,
 				},
 			},

--- a/opslevel/datasource_opslevel_repository.go
+++ b/opslevel/datasource_opslevel_repository.go
@@ -41,23 +41,23 @@ type RepositoryDataSourceModel struct {
 
 // LanguagesValue function converts the raw opslevel data to terraform friendly format
 func LanguagesValue(value []opslevel.Language) []LanguagesModel {
-    var languages []LanguagesModel
+	var languages []LanguagesModel
 
-    if len(value) == 0 {
-        return []LanguagesModel{}
-    }
+	if len(value) == 0 {
+		return []LanguagesModel{}
+	}
 
-    for _, lang := range value {
-        language := LanguagesModel{
-            Name:  types.StringValue(lang.Name),
-            Usage: types.StringValue(strconv.FormatFloat(float64(lang.Usage), 'f', -1, 32)),
-            // convert the Usage float32 value to StringValue instead of NumberValue or Float64Value to keep the exact same value
-            // eg: a value of 0.55404 to type number or float64 converts to 0.5540400147, where to string, it remains the same.
-        }
+	for _, lang := range value {
+		language := LanguagesModel{
+			Name:  types.StringValue(lang.Name),
+			Usage: types.StringValue(strconv.FormatFloat(float64(lang.Usage), 'f', -1, 32)),
+			// convert the Usage float32 value to StringValue instead of NumberValue or Float64Value to keep the exact same value
+			// eg: a value of 0.55404 to type number or float64 converts to 0.5540400147, where to string, it remains the same.
+		}
 
-        languages = append(languages, language)
-    }
-    return languages
+		languages = append(languages, language)
+	}
+	return languages
 }
 
 func NewRepositoryDataSourceModel(repository opslevel.Repository) RepositoryDataSourceModel {
@@ -89,20 +89,20 @@ var repositoryDatasourceSchemaAttrs = map[string]schema.Attribute{
 		Description: "The url of the the repository.",
 		Computed:    true,
 	},
-    "languages": schema.ListNestedAttribute{
-        Description:  "The list of programming languages used in the repository.",
-        Computed:     true,
-        NestedObject: schema.NestedAttributeObject{
-            Attributes: map[string]schema.Attribute{
-                "name": schema.StringAttribute{
-                        Optional: true,
-                },
-                "usage": schema.StringAttribute{
-                        Optional: true,
-                },
-            },
-        },
-    },
+	"languages": schema.ListNestedAttribute{
+		Description: "The list of programming languages used in the repository.",
+		Computed:    true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"name": schema.StringAttribute{
+					Optional: true,
+				},
+				"usage": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+	},
 }
 
 func (d *RepositoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {


### PR DESCRIPTION
## Description
Reading and adding the `languages` attribute to the `opslevel_repository` data source.

the intended use here is for people to be able to programatically read the languages of any one repo, detect the language with the highest coverage, and assign it to the `opslevel_service` resource corresponding with the repo.

use case example:
```hcl
locals {
  // identify the highest coverage out of all detected languages
  highest_lang_coverage = max([for k, v in data.opslevel_repository.this.languages : tonumber(v.usage)]...)
  // find the object of the language w the highest coverage from the returned list of languages by using the previously identified highest coverage number
  main_repo_language = element([for k, v in data.opslevel_repository.this.languages : v if lookup(v, "usage") == tostring(local.highest_lang_coverage)], 0)
}

data "opslevel_repository" "this" {
  alias = "github.com:cool-org/cool-service"
}

resource "opslevel_service" "this" {
  name = "cool-service"

  lifecycle_alias = data.opslevel_lifecycle.this.alias
  tier_alias      = data.opslevel_tier.this.alias
  owner           = opslevel_team.cool-team.id
  
  // set language using the newly added datasource output
  language = local.main_repo_language.name
}

// attach repo to service
resource "opslevel_service_repository" "this" {
  service    = opslevel_service.this.id
  repository = data.opslevel_repository.this.id

  name           = "cool-service"
  base_directory = "/"
}
```

this method allows us to populate the `language` attribute of the service efficiently. as even if a repo is attached to a service (like i do with the `opslevel_service_repository` resource in the example above), the service will not inherit the available language details of the repository.


## Changelog

- [ ] add a new output (`languages`) to the `opslevel_repository` data source
- [ ] format the output into a list of objects.
- [ ] update repository data source docs as per the change

## Tophatting

data source languages output
```hcl

output "data" {
  value = data.opslevel_repository.this.languages
}
```
result in:
```
Outputs:

data = tolist([
  {
    "name" = "HCL"
    "usage" = "0.55404"
  },
  {
    "name" = "JavaScript"
    "usage" = "0.07078"
  },
  {
    "name" = "TypeScript"
    "usage" = "0.37518"
  },
])
```
