### PR TITLE
can unset parent domain on system update

### DIFF
--- a/.changes/unreleased/Bugfix-20240502-161321.yaml
+++ b/.changes/unreleased/Bugfix-20240502-161321.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: can now unset parent Domain field from System
+time: 2024-05-02T16:13:21.36324-05:00

--- a/opslevel/resource_opslevel_system.go
+++ b/opslevel/resource_opslevel_system.go
@@ -177,8 +177,13 @@ func (r *SystemResource) Update(ctx context.Context, req resource.UpdateRequest,
 		Description: opslevel.RefOf(planModel.Description.ValueString()),
 		OwnerId:     opslevel.NewID(planModel.Owner.ValueString()),
 		Note:        opslevel.RefOf(planModel.Note.ValueString()),
-		Parent:      opslevel.NewIdentifier(planModel.Domain.ValueString()),
 	}
+	if planModel.Domain.IsNull() {
+		systemInput.Parent = opslevel.NewIdentifier()
+	} else {
+		systemInput.Parent = opslevel.NewIdentifier(planModel.Domain.ValueString())
+	}
+
 	system, err := r.client.UpdateSystem(planModel.Id.ValueString(), systemInput)
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update system, got error: %s", err))


### PR DESCRIPTION
## Issues

[Issue unsetting System parent Domain id](https://github.com/OpsLevel/team-platform/issues/345)

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this file:
```tf
resource "opslevel_system" "example" {
  name        = "Sound system 2"
  description = "Sound system is the best system"
  owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  domain      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzUyNDg0Nw"
  note        = "But this one goes to 11"
}
```

### Create system, `terraform apply`:
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_system.example will be created
  + resource "opslevel_system" "example" {
      + aliases      = (known after apply)
      + description  = "Sound system is the best system"
      + domain       = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzUyNDg0Nw"
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "Sound system 2"
      + note         = "But this one goes to 11"
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_system.example: Creating...
opslevel_system.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Update file:
```tf
resource "opslevel_system" "example" {
  name        = "Sound system 2"
  description = "Sound system is the best system"
  owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5"
  domain      = null
  note        = "But this one goes to 11"
}
```

### Update system, `terraform apply`:
```tf
opslevel_system.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_system.example will be updated in-place
  ~ resource "opslevel_system" "example" {
      ~ aliases      = [
          - "sound_system_2_2",
        ] -> (known after apply)
      - domain       = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzUyNDg0Nw" -> null
        id           = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc"
      + last_updated = (known after apply)
        name         = "Sound system 2"
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_system.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc]
opslevel_system.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Remove system, `terraform destroy`:
```tf
opslevel_system.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_system.example will be destroyed
  - resource "opslevel_system" "example" {
      - aliases     = [
          - "sound_system_2_2",
        ] -> null
      - description = "Sound system is the best system" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc" -> null
      - name        = "Sound system 2" -> null
      - note        = "But this one goes to 11" -> null
      - owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS85NzU5" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_system.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzIyNjE1Mjc]
opslevel_system.example: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```