### PR TITLE
use new String type that matches GraphQL API

### DIFF
--- a/.changes/unreleased/Bugfix-20240504-210912.yaml
+++ b/.changes/unreleased/Bugfix-20240504-210912.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix unsetting Service lifecycleAlias and tierAlias on update
+time: 2024-05-04T21:09:12.98744-05:00

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -319,28 +319,15 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// NOTE: these fields cannot be unset at the GraphQL API level - we want to acknowledge this for now
-	var lifecycleAliasBeforeUpdate, tierAliasBeforeUpdate types.String
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("lifecycle_alias"), &lifecycleAliasBeforeUpdate)...)
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tier_alias"), &tierAliasBeforeUpdate)...)
-	if !lifecycleAliasBeforeUpdate.IsNull() && planModel.LifecycleAlias.IsNull() {
-		resp.Diagnostics.AddError("Known error", "Unable to unset 'lifecycle_alias' field for now. We have a planned fix for this.")
-		return
-	}
-	if !tierAliasBeforeUpdate.IsNull() && planModel.TierAlias.IsNull() {
-		resp.Diagnostics.AddError("Known error", "Unable to unset 'tier_alias' field for now. We have a planned fix for this.")
-		return
-	}
-
 	serviceUpdateInput := opslevel.ServiceUpdateInput{
 		Description:    opslevel.RefOf(planModel.Description.ValueString()),
 		Framework:      opslevel.RefOf(planModel.Framework.ValueString()),
 		Id:             opslevel.NewID(planModel.Id.ValueString()),
 		Language:       opslevel.RefOf(planModel.Language.ValueString()),
-		LifecycleAlias: opslevel.RefOf(planModel.LifecycleAlias.ValueString()),
+		LifecycleAlias: opslevel.NewString(planModel.LifecycleAlias.ValueString()),
 		Name:           planModel.Name.ValueStringPointer(),
 		Product:        opslevel.RefOf(planModel.Product.ValueString()),
-		TierAlias:      opslevel.RefOf(planModel.TierAlias.ValueString()),
+		TierAlias:      opslevel.NewString(planModel.TierAlias.ValueString()),
 	}
 	if planModel.Owner.ValueString() != "" {
 		serviceUpdateInput.OwnerInput = opslevel.NewIdentifier(planModel.Owner.ValueString())


### PR DESCRIPTION
## Issues

[fix unsetting Service lifecycleAlias and tierAlias fields](https://github.com/OpsLevel/team-platform/issues/356)

## Changelog

Use downstream `String` scalar that matches our GraphQL API. See [opslevel-go PR](https://github.com/OpsLevel/opslevel-go/pull/398) 
⚠️ Depends on this opslevel-go PR being merged first.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting


### With this config
```tf
resource "opslevel_service" "test" {
  api_document_path             = "my/path/doc.yaml"
  description                   = "fancy things"
  framework                     = "da-best"
  language                      = "go"
  lifecycle_alias               = "alpha"
  name                          = "tophatting-service"
  owner                         = "platform"
  preferred_api_document_source = "PUSH"
  product                       = "tophat"
  tags                          = ["key:value"]
  tier_alias                    = "tier_2"
}
```

### Create service with tierAlias and lifecycleAlias fields defined. Run `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_service.test will be created
  + resource "opslevel_service" "test" {
      + api_document_path             = "my/path/doc.yaml"
      + description                   = "fancy things"
      + framework                     = "da-best"
      + id                            = (known after apply)
      + language                      = "go"
      + last_updated                  = (known after apply)
      + lifecycle_alias               = "alpha"
      + name                          = "tophatting-service"
      + owner                         = "platform"
      + preferred_api_document_source = "PUSH"
      + product                       = "tophat"
      + tags                          = [
          + "key:value",
        ]
      + tier_alias                    = "tier_2"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_service.test: Creating...
opslevel_service.test: Creation complete after 3s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Unset `lifecycle_alias` and `tier_alias` fields
```tf
resource "opslevel_service" "test" {
  api_document_path             = "my/path/doc.yaml"
  description                   = "fancy things"
  framework                     = "da-best"
  language                      = "go"
  # lifecycle_alias               = "alpha"
  name                          = "tophatting-service"
  owner                         = "platform"
  preferred_api_document_source = "PUSH"
  product                       = "tophat"
  tags                          = ["key:value"]
  # tier_alias                    = "tier_2"
}
```

### Update service, setting tierAlias and lifecycleAlias fields to `null`. Run `terraform apply`
```tf
opslevel_service.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.test will be updated in-place
  ~ resource "opslevel_service" "test" {
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM"
      + last_updated                  = (known after apply)
      - lifecycle_alias               = "alpha" -> null
        name                          = "tophatting-service"
        tags                          = [
            "key:value",
        ]
      - tier_alias                    = "tier_2" -> null
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM]
opslevel_service.test: Modifications complete after 3s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Destroy service, `task destroy`
```tf
opslevel_service.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_service.test will be destroyed
  - resource "opslevel_service" "test" {
      - api_document_path             = "my/path/doc.yaml" -> null
      - description                   = "fancy things" -> null
      - framework                     = "da-best" -> null
      - id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM" -> null
      - language                      = "go" -> null
      - name                          = "tophatting-service" -> null
      - owner                         = "platform" -> null
      - preferred_api_document_source = "PUSH" -> null
      - product                       = "tophat" -> null
      - tags                          = [
          - "key:value",
        ] -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_service.test: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4MjM]
opslevel_service.test: Destruction complete after 3s

Destroy complete! Resources: 1 destroyed.
```