### PR TITLE
fix `'' was not found` for resource opslevel_service on `lifecycle_alias`, `tier_alias`

### DIFF
--- a/.changes/unreleased/Bugfix-20240506-165314.yaml
+++ b/.changes/unreleased/Bugfix-20240506-165314.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: Fix bug on resource `opslevel_service` where `'' was not found` error message
+  was thrown on all updates for `tier_alias`, `lifecycle_alias`
+time: 2024-05-06T16:53:14.469466-04:00

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -319,28 +319,15 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// NOTE: these fields cannot be unset at the GraphQL API level - we want to acknowledge this for now
-	var lifecycleAliasBeforeUpdate, tierAliasBeforeUpdate types.String
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("lifecycle_alias"), &lifecycleAliasBeforeUpdate)...)
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tier_alias"), &tierAliasBeforeUpdate)...)
-	if !lifecycleAliasBeforeUpdate.IsNull() && planModel.LifecycleAlias.IsNull() {
-		resp.Diagnostics.AddError("Known error", "Unable to unset 'lifecycle_alias' field for now. We have a planned fix for this.")
-		return
-	}
-	if !tierAliasBeforeUpdate.IsNull() && planModel.TierAlias.IsNull() {
-		resp.Diagnostics.AddError("Known error", "Unable to unset 'tier_alias' field for now. We have a planned fix for this.")
-		return
-	}
-
-	serviceUpdateInput := opslevel.ServiceUpdateInput{
-		Description:    opslevel.RefOf(planModel.Description.ValueString()),
-		Framework:      opslevel.RefOf(planModel.Framework.ValueString()),
+	serviceUpdateInput := opslevel.ServiceUpdateInputV2{
+		Description:    NullableStringConfigValue(planModel.Description),
+		Framework:      NullableStringConfigValue(planModel.Framework),
 		Id:             opslevel.NewID(planModel.Id.ValueString()),
-		Language:       opslevel.RefOf(planModel.Language.ValueString()),
-		LifecycleAlias: opslevel.RefOf(planModel.LifecycleAlias.ValueString()),
-		Name:           planModel.Name.ValueStringPointer(),
-		Product:        opslevel.RefOf(planModel.Product.ValueString()),
-		TierAlias:      opslevel.RefOf(planModel.TierAlias.ValueString()),
+		Language:       NullableStringConfigValue(planModel.Language),
+		LifecycleAlias: NullableStringConfigValue(planModel.LifecycleAlias),
+		Name:           opslevel.NewNullableValue(planModel.Name.ValueString()),
+		Product:        NullableStringConfigValue(planModel.Product),
+		TierAlias:      NullableStringConfigValue(planModel.TierAlias),
 	}
 	if planModel.Owner.ValueString() != "" {
 		serviceUpdateInput.OwnerInput = opslevel.NewIdentifier(planModel.Owner.ValueString())

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -302,22 +302,23 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 }
 
 func (r *ServiceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var planModel ServiceResourceModel
+	var stateModel ServiceResourceModel
 
 	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateModel)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	service, err := r.client.GetService(opslevel.ID(planModel.Id.ValueString()))
+	service, err := r.client.GetService(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read service, got error: %s", err))
 		return
 	}
 
-	stateModel, diags := NewServiceResourceModel(ctx, *service, planModel, false)
+	var diags diag.Diagnostics
+	stateModel, diags = NewServiceResourceModel(ctx, *service, stateModel, false)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -419,15 +420,15 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 }
 
 func (r *ServiceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var planModel ServiceResourceModel
+	var stateModel ServiceResourceModel
 
 	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateModel)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	err := r.client.DeleteService(planModel.Id.ValueString())
+	err := r.client.DeleteService(stateModel.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete service, got error: %s", err))
 		return

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -247,13 +247,19 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 			}
 		}
 	}
-	service, err = r.client.GetService(opslevel.ID(service.Id))
+	service, err = r.client.GetService(service.Id)
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get service after creation, got error: %s", err))
 		return
 	}
 
 	stateModel, diags := NewServiceResourceModel(ctx, *service)
+	resp.Diagnostics.Append(diags...)
+
+	if stateModel.Description.IsNull() && !planModel.Description.IsNull() && planModel.Description.ValueString() == "" {
+		stateModel.Description = types.StringValue("")
+	}
+
 	switch planModel.Owner.ValueString() {
 	case string(service.Owner.Id), service.Owner.Alias:
 		stateModel.Owner = planModel.Owner
@@ -293,6 +299,11 @@ func (r *ServiceResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	stateModel, diags := NewServiceResourceModel(ctx, *service)
 	resp.Diagnostics.Append(diags...)
+
+	if stateModel.Description.IsNull() && !planModel.Description.IsNull() && planModel.Description.ValueString() == "" {
+		stateModel.Description = types.StringValue("")
+	}
+
 	switch planModel.Owner.ValueString() {
 	case string(service.Owner.Id), service.Owner.Alias:
 		stateModel.Owner = planModel.Owner
@@ -384,7 +395,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 	}
 
-	service, err = r.client.GetService(opslevel.ID(service.Id))
+	service, err = r.client.GetService(service.Id)
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get service after update, got error: %s", err))
 		return
@@ -393,6 +404,10 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	stateModel, diags := NewServiceResourceModel(ctx, *service)
 	stateModel.LastUpdated = timeLastUpdated()
 	resp.Diagnostics.Append(diags...)
+
+	if stateModel.Description.IsNull() && !planModel.Description.IsNull() && planModel.Description.ValueString() == "" {
+		stateModel.Description = types.StringValue("")
+	}
 
 	switch planModel.Owner.ValueString() {
 	case string(service.Owner.Id), service.Owner.Alias:

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -66,9 +66,6 @@ func NewServiceResourceModel(ctx context.Context, service opslevel.Service, cach
 		Product:         OptionalStringValue(service.Product),
 		TierAlias:       OptionalStringValue(service.Tier.Alias),
 	}
-	if setLastUpdated {
-		serviceResourceModel.LastUpdated = timeLastUpdated()
-	}
 
 	if len(service.ManagedAliases) == 0 {
 		serviceResourceModel.Aliases = types.ListNull(types.StringType)
@@ -124,6 +121,9 @@ func NewServiceResourceModel(ctx context.Context, service opslevel.Service, cach
 		return serviceResourceModel, diags
 	}
 
+	if setLastUpdated {
+		serviceResourceModel.LastUpdated = timeLastUpdated()
+	}
 	return serviceResourceModel, diags
 }
 

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -245,6 +245,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// TODO: the post create/update steps are the same and can be extracted into a function so we repeat less code
 	givenAliases, diags := ListValueToStringSlice(ctx, planModel.Aliases)
 	if diags != nil && diags.HasError() {
 		resp.Diagnostics.AddError("Config error", fmt.Sprintf("Unable to handle given service aliases: '%s'", planModel.Aliases))
@@ -281,6 +282,8 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 			}
 		}
 	}
+
+	// fetch the service again, since other mutations are performed after the create/update step
 	service, err = r.client.GetService(service.Id)
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get service after creation, got error: %s", err))
@@ -397,6 +400,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 	}
 
+	// fetch the service again, since other mutations are performed after the create/update step
 	service, err = r.client.GetService(service.Id)
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get service after update, got error: %s", err))

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -256,10 +256,23 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	stateModel, diags := NewServiceResourceModel(ctx, *service)
 	resp.Diagnostics.Append(diags...)
 
+	// after creating resource model, differentiate between a basic field being unset (null) vs empty string ("")
+	// TODO: find a way to do this without repeating code
 	if stateModel.Description.IsNull() && !planModel.Description.IsNull() && planModel.Description.ValueString() == "" {
 		stateModel.Description = types.StringValue("")
 	}
+	if stateModel.Framework.IsNull() && !planModel.Framework.IsNull() && planModel.Framework.ValueString() == "" {
+		stateModel.Framework = types.StringValue("")
+	}
+	if stateModel.Language.IsNull() && !planModel.Language.IsNull() && planModel.Language.ValueString() == "" {
+		stateModel.Language = types.StringValue("")
+	}
+	if stateModel.Product.IsNull() && !planModel.Product.IsNull() && planModel.Product.ValueString() == "" {
+		stateModel.Product = types.StringValue("")
+	}
 
+	// after creating resource model, set the owner to alias/ID or to null
+	// TODO: find a way to do this without repeating code
 	switch planModel.Owner.ValueString() {
 	case string(service.Owner.Id), service.Owner.Alias:
 		stateModel.Owner = planModel.Owner
@@ -302,6 +315,15 @@ func (r *ServiceResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	if stateModel.Description.IsNull() && !planModel.Description.IsNull() && planModel.Description.ValueString() == "" {
 		stateModel.Description = types.StringValue("")
+	}
+	if stateModel.Framework.IsNull() && !planModel.Framework.IsNull() && planModel.Framework.ValueString() == "" {
+		stateModel.Framework = types.StringValue("")
+	}
+	if stateModel.Language.IsNull() && !planModel.Language.IsNull() && planModel.Language.ValueString() == "" {
+		stateModel.Language = types.StringValue("")
+	}
+	if stateModel.Product.IsNull() && !planModel.Product.IsNull() && planModel.Product.ValueString() == "" {
+		stateModel.Product = types.StringValue("")
 	}
 
 	switch planModel.Owner.ValueString() {
@@ -407,6 +429,15 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	if stateModel.Description.IsNull() && !planModel.Description.IsNull() && planModel.Description.ValueString() == "" {
 		stateModel.Description = types.StringValue("")
+	}
+	if stateModel.Framework.IsNull() && !planModel.Framework.IsNull() && planModel.Framework.ValueString() == "" {
+		stateModel.Framework = types.StringValue("")
+	}
+	if stateModel.Language.IsNull() && !planModel.Language.IsNull() && planModel.Language.ValueString() == "" {
+		stateModel.Language = types.StringValue("")
+	}
+	if stateModel.Product.IsNull() && !planModel.Product.IsNull() && planModel.Product.ValueString() == "" {
+		stateModel.Product = types.StringValue("")
 	}
 
 	switch planModel.Owner.ValueString() {

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -24,14 +24,12 @@ func OptionalStringValue(value string) basetypes.StringValue {
 	return types.StringValue(unquote(value))
 }
 
-// Returns the config value as a NullableValue[string]
-// Will only be treated as `null` if value is not set in the config OR if it is explicitly set to null
-// Empty strings are NOT treated as `null`
-func NullableStringConfigValue(s types.String) *opslevel.NullableValue[string] {
+// Returns value from config as a string OR null if the value is not set/explicitly set to null (supports empty strings)
+func NullableStringConfigValue(s types.String) *opslevel.Nullable[string] {
 	if s.IsNull() {
-		return opslevel.NewNullValue[string]()
+		return opslevel.NewNull[string]()
 	}
-	return opslevel.NewNullableValue(s.ValueString())
+	return opslevel.NewNullableFrom(s.ValueString())
 }
 
 // Syntactic sugar for OptionalStringValue

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -24,9 +24,11 @@ func OptionalStringValue(value string) basetypes.StringValue {
 	return types.StringValue(unquote(value))
 }
 
-// Returns the config value as a NullableValue[string]. If the value is not set, null, or "" in the config, the value will be treated as null.
+// Returns the config value as a NullableValue[string]
+// Will only be treated as `null` if value is not set in the config OR if it is explicitly set to null
+// Empty strings are NOT treated as `null`
 func NullableStringConfigValue(s types.String) *opslevel.NullableValue[string] {
-	if s.ValueString() == "" {
+	if s.IsNull() {
 		return opslevel.NewNullValue[string]()
 	}
 	return opslevel.NewNullableValue(s.ValueString())

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -24,6 +24,14 @@ func OptionalStringValue(value string) basetypes.StringValue {
 	return types.StringValue(unquote(value))
 }
 
+// Returns the config value as a NullableValue[string]. If the value is not set, null, or "" in the config, the value will be treated as null.
+func NullableStringConfigValue(s types.String) *opslevel.NullableValue[string] {
+	if s.ValueString() == "" {
+		return opslevel.NewNullValue[string]()
+	}
+	return opslevel.NewNullableValue(s.ValueString())
+}
+
 // Syntactic sugar for OptionalStringValue
 func ComputedStringValue(value string) basetypes.StringValue {
 	return OptionalStringValue(value)


### PR DESCRIPTION
## Issues

https://github.com/OpsLevel/team-platform/issues/356

## Changelog

- [x] Adapt for https://github.com/OpsLevel/opslevel-go/pull/397
- [x] Tophatting
- [x] Fix difference between `planModel` and `stateModel` - this is named incorrectly in `Delete()`, `Read()` functions.
- [x] Make a `changie` entry

## Tophatting

### The config

```
# main.tf

resource "opslevel_service" "mon_service" {
  description = "hello world"
  framework = "rails"
  language = "ruby"
  lifecycle_alias = "pre-alpha"
  name = "mon_service"
  owner = "team_platform_3"
  tier_alias = "tier_4"
}

```

### Create a service

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_service.mon_service will be created
  + resource "opslevel_service" "mon_service" {
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "mon_service"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_service.mon_service: Creating...
opslevel_service.mon_service: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]

```

### Set the owner (fails on old version because of tier, lifecycle alias)

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.mon_service will be updated in-place
  ~ resource "opslevel_service" "mon_service" {
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ"
      + last_updated = (known after apply)
        name         = "mon_service"
      + owner        = "team_platform_3"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.mon_service: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]
opslevel_service.mon_service: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]

```

### Set some other fields - description, framework, tier_alias

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.mon_service will be updated in-place
  ~ resource "opslevel_service" "mon_service" {
      + description  = "hello world"
      + framework    = "rails"
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ"
      + last_updated = (known after apply)
        name         = "mon_service"
      + tier_alias   = "tier_4"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.mon_service: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]
opslevel_service.mon_service: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]
```

### Unset tier_alias, framework - set the lifecycle alias

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.mon_service will be updated in-place
  ~ resource "opslevel_service" "mon_service" {
      - framework       = "rails" -> null
        id              = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ"
      + last_updated    = (known after apply)
      + lifecycle_alias = "pre-alpha"
        name            = "mon_service"
      - tier_alias      = "tier_4" -> null
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.mon_service: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]
opslevel_service.mon_service: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]

```

### Unset all fields except for name

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.mon_service will be updated in-place
  ~ resource "opslevel_service" "mon_service" {
      - description     = "hello world" -> null
        id              = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ"
      + last_updated    = (known after apply)
      - lifecycle_alias = "pre-alpha" -> null
        name            = "mon_service"
      - owner           = "team_platform_3" -> null
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.mon_service: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]
opslevel_service.mon_service: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]

```

### Destroy

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_service.mon_service will be destroyed
  - resource "opslevel_service" "mon_service" {
      - id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ" -> null
      - name = "mon_service" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_service.mon_service: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjE4NjQ]
opslevel_service.mon_service: Destruction complete after 1s

```
