### PR TITLE
update examples for docs, add some missing resource examples

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,13 @@ tasks:
       - task: lint
       - task: test
 
+  docs:
+    desc: Generate docs
+    cmds:
+      - go get github.com/hashicorp/terraform-plugin-docs@v0.13.0
+      - go get github.com/hashicorp/terraform-plugin-docs/internal/provider@v0.13.0
+      - go generate
+
   fix:
     desc: Fix formatting, linting, go.mod, and update submodule
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,6 +27,7 @@ tasks:
 
   docs:
     desc: Generate docs
+    aliases: ["doc"]
     cmds:
       - go get github.com/hashicorp/terraform-plugin-docs@v0.13.0
       - go get github.com/hashicorp/terraform-plugin-docs/internal/provider@v0.13.0

--- a/examples/data-sources/opslevel_domains/data-source.tf
+++ b/examples/data-sources/opslevel_domains/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_domains" "all" {
-}
+data "opslevel_domains" "all" {}
 
 output "found" {
   value = data.opslevel_domains.all

--- a/examples/data-sources/opslevel_domains/data-source.tf
+++ b/examples/data-sources/opslevel_domains/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_domains" "all" {}
 
-output "found" {
-  value = data.opslevel_domains.all
+output "all" {
+  value = data.opslevel_domains.all.domains
+}
+
+output "domain_names" {
+  value = sort(data.opslevel_domains.all.domains[*].name)
 }

--- a/examples/data-sources/opslevel_filters/data-source.tf
+++ b/examples/data-sources/opslevel_filters/data-source.tf
@@ -1,5 +1,10 @@
 data "opslevel_filters" "all" {}
 
-output "found" {
-  value = data.opslevel_filters.all.id[0]
+output "all" {
+  value = data.opslevel_filters.all.filters
 }
+
+output "filter_names" {
+  value = sort(data.opslevel_filters.all.filters[*].name)
+}
+

--- a/examples/data-sources/opslevel_filters/data-source.tf
+++ b/examples/data-sources/opslevel_filters/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_filters" "all" {
-}
+data "opslevel_filters" "all" {}
 
 output "found" {
   value = data.opslevel_filters.all.id[0]

--- a/examples/data-sources/opslevel_integrations/data-source.tf
+++ b/examples/data-sources/opslevel_integrations/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_integrations" "all" {
-}
+data "opslevel_integrations" "all" {}
 
 output "found" {
   value = data.opslevel_integrations.all.id[0]

--- a/examples/data-sources/opslevel_integrations/data-source.tf
+++ b/examples/data-sources/opslevel_integrations/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_integrations" "all" {}
 
-output "found" {
-  value = data.opslevel_integrations.all.id[0]
+output "all" {
+  value = data.opslevel_integrations.all.integrations
+}
+
+output "integration_names" {
+  value = sort(data.opslevel_integrations.all.integrations[*].name)
 }

--- a/examples/data-sources/opslevel_lifecycles/data-source.tf
+++ b/examples/data-sources/opslevel_lifecycles/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_lifecycles" "all" {}
 
-output "found" {
-  value = data.opslevel_lifecycles.all.aliases[0]
+output "all" {
+  value = data.opslevel_lifecycles.all.lifecycles
+}
+
+output "lifecycle_names" {
+  value = sort(data.opslevel_lifecycles.all.lifecycles[*].name)
 }

--- a/examples/data-sources/opslevel_lifecycles/data-source.tf
+++ b/examples/data-sources/opslevel_lifecycles/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_lifecycles" "all" {
-}
+data "opslevel_lifecycles" "all" {}
 
 output "found" {
   value = data.opslevel_lifecycles.all.aliases[0]

--- a/examples/data-sources/opslevel_property_definitions/data-source.tf
+++ b/examples/data-sources/opslevel_property_definitions/data-source.tf
@@ -1,5 +1,13 @@
 data "opslevel_property_definitions" "all" {}
 
-output "all_schemas" {
-  value = data.opslevel_property_definitions.all.schemas
+output "all" {
+  value = data.opslevel_property_definitions.all.property_definitions
+}
+
+output "property_definition_names" {
+  value = sort(data.opslevel_property_definitions.all.property_definitions[*].name)
+}
+
+output "property_definition_schemas" {
+  value = data.opslevel_property_definitions.all.property_definitions[*].schema
 }

--- a/examples/data-sources/opslevel_property_definitions/data-source.tf
+++ b/examples/data-sources/opslevel_property_definitions/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_property_definitions" "all" {
-}
+data "opslevel_property_definitions" "all" {}
 
 output "all_schemas" {
   value = data.opslevel_property_definitions.all.schemas

--- a/examples/data-sources/opslevel_repositories/data-source.tf
+++ b/examples/data-sources/opslevel_repositories/data-source.tf
@@ -5,11 +5,10 @@ data "opslevel_tier" "tier2" {
   }
 }
 
-data "opslevel_repositories" "all" {
-}
+data "opslevel_repositories" "all" {}
 
 data "opslevel_repositories" "tier2" {
-  filter {
+  filter = {
     field = "tier"
     value = data.opslevel_tier.tier2.alias
   }
@@ -22,3 +21,4 @@ output "all" {
 output "tier2" {
   value = data.opslevel_repositories.tier2.names
 }
+

--- a/examples/data-sources/opslevel_repositories/data-source.tf
+++ b/examples/data-sources/opslevel_repositories/data-source.tf
@@ -1,11 +1,11 @@
+data "opslevel_repositories" "all" {}
+
 data "opslevel_tier" "tier2" {
   filter {
     field = "alias"
     value = "tier_2"
   }
 }
-
-data "opslevel_repositories" "all" {}
 
 data "opslevel_repositories" "tier2" {
   filter = {
@@ -15,10 +15,14 @@ data "opslevel_repositories" "tier2" {
 }
 
 output "all" {
-  value = data.opslevel_repositories.all.names
+  value = data.opslevel_repositories.all.repositories
 }
 
-output "tier2" {
-  value = data.opslevel_repositories.tier2.names
+output "tier2_repositories" {
+  value = data.opslevel_repositories.tier2.repositories
+}
+
+output "all_repository_names" {
+  value = sort(data.opslevel_repositories.all.repositories[*].name)
 }
 

--- a/examples/data-sources/opslevel_rubric_categories/data-source.tf
+++ b/examples/data-sources/opslevel_rubric_categories/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_rubric_categories" "all" {
-}
+data "opslevel_rubric_categories" "all" {}
 
 output "found" {
   value = data.opslevel_rubric_categories.all.ids[0]

--- a/examples/data-sources/opslevel_rubric_categories/data-source.tf
+++ b/examples/data-sources/opslevel_rubric_categories/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_rubric_categories" "all" {}
 
-output "found" {
-  value = data.opslevel_rubric_categories.all.ids[0]
+output "all" {
+  value = data.opslevel_rubric_categories.all.rubric_categories
+}
+
+output "category_names" {
+  value = sort(data.opslevel_rubric_categories.all.rubric_categories[*].name)
 }

--- a/examples/data-sources/opslevel_rubric_levels/data-source.tf
+++ b/examples/data-sources/opslevel_rubric_levels/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_rubric_levels" "all" {}
 
-output "found" {
-  value = data.opslevel_rubric_levels.all.ids[0]
+output "all" {
+  value = data.opslevel_rubric_levels.all.rubric_levels
+}
+
+output "level_names" {
+  value = sort(data.opslevel_rubric_levels.all.rubric_levels[*].name)
 }

--- a/examples/data-sources/opslevel_rubric_levels/data-source.tf
+++ b/examples/data-sources/opslevel_rubric_levels/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_rubric_levels" "all" {
-}
+data "opslevel_rubric_levels" "all" {}
 
 output "found" {
   value = data.opslevel_rubric_levels.all.ids[0]

--- a/examples/data-sources/opslevel_scorecards/data-source.tf
+++ b/examples/data-sources/opslevel_scorecards/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_scorecards" "all" {}
 
-output "found" {
-  value = data.opslevel_scorecards.all.ids[0]
+output "all" {
+  value = data.opslevel_scorecards.all.scorecards
+}
+
+output "scorecard_names" {
+  value = sort(data.opslevel_scorecards.all.scorecards[*].name)
 }

--- a/examples/data-sources/opslevel_scorecards/data-source.tf
+++ b/examples/data-sources/opslevel_scorecards/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_scorecards" "all" {
-}
+data "opslevel_scorecards" "all" {}
 
 output "found" {
   value = data.opslevel_scorecards.all.ids[0]

--- a/examples/data-sources/opslevel_services/data-source.tf
+++ b/examples/data-sources/opslevel_services/data-source.tf
@@ -5,18 +5,17 @@ data "opslevel_tier" "tier1" {
   }
 }
 
-data "opslevel_services" "all" {
-}
+data "opslevel_services" "all" {}
 
 data "opslevel_services" "tier1" {
-  filter {
+  filter = {
     field = "tier"
     value = data.opslevel_tier.tier1.alias
   }
 }
 
 data "opslevel_services" "frontend" {
-  filter {
+  filter = {
     field = "owner"
     value = "frontend"
   }

--- a/examples/data-sources/opslevel_services/data-source.tf
+++ b/examples/data-sources/opslevel_services/data-source.tf
@@ -1,11 +1,11 @@
+data "opslevel_services" "all" {}
+
 data "opslevel_tier" "tier1" {
   filter {
     field = "alias"
     value = "tier_1"
   }
 }
-
-data "opslevel_services" "all" {}
 
 data "opslevel_services" "tier1" {
   filter = {
@@ -22,13 +22,22 @@ data "opslevel_services" "frontend" {
 }
 
 output "all_services" {
-  value = data.opslevel_services.all.names
+  value = data.opslevel_services.all.services
+}
+
+output "all_service_names" {
+  value = sort(data.opslevel_services.all.services[*].name)
 }
 
 output "tier1_services" {
-  value = data.opslevel_services.tier1.names
+  value = data.opslevel_services.tier1.services
 }
 
 output "frontend_services" {
-  value = data.opslevel_services.frontend.urls
+  value = data.opslevel_services.frontend.services
+}
+
+
+output "frontend_services_urls" {
+  value = sort(data.opslevel_services.frontend.services[*].url)
 }

--- a/examples/data-sources/opslevel_systems/data-source.tf
+++ b/examples/data-sources/opslevel_systems/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_systems" "all" {}
 
-output "found" {
-  value = data.opslevel_systems.all
+output "all" {
+  value = data.opslevel_systems.all.systems
+}
+
+output "system_names" {
+  value = sort(data.opslevel_systems.all.systems[*].name)
 }

--- a/examples/data-sources/opslevel_systems/data-source.tf
+++ b/examples/data-sources/opslevel_systems/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_systems" "all" {
-}
+data "opslevel_systems" "all" {}
 
 output "found" {
   value = data.opslevel_systems.all

--- a/examples/data-sources/opslevel_teams/data-source.tf
+++ b/examples/data-sources/opslevel_teams/data-source.tf
@@ -1,12 +1,4 @@
-data "opslevel_teams" "all" {
-}
-
-data "opslevel_teams" "leet" {
-  filter {
-    field = "manager-email"
-    value = "0p5l3v3l@example.com"
-  }
-}
+data "opslevel_teams" "all" {}
 
 output "found" {
   value = data.opslevel_teams.all.ids[3]

--- a/examples/data-sources/opslevel_teams/data-source.tf
+++ b/examples/data-sources/opslevel_teams/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_teams" "all" {}
 
-output "found" {
-  value = data.opslevel_teams.all.ids[3]
+output "all" {
+  value = data.opslevel_teams.all.teams
+}
+
+output "team_names" {
+  value = sort(data.opslevel_teams.all.teams[*].name)
 }

--- a/examples/data-sources/opslevel_tiers/data-source.tf
+++ b/examples/data-sources/opslevel_tiers/data-source.tf
@@ -1,5 +1,13 @@
 data "opslevel_tiers" "all" {}
 
-output "found" {
-  value = data.opslevel_tiers.all.aliases[0]
+output "all" {
+  value = data.opslevel_tiers.all.tiers
+}
+
+output "tier_aliases" {
+  value = sort(data.opslevel_tiers.all.tiers[*].alias)
+}
+
+output "tier_names" {
+  value = sort(data.opslevel_tiers.all.tiers[*].name)
 }

--- a/examples/data-sources/opslevel_tiers/data-source.tf
+++ b/examples/data-sources/opslevel_tiers/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_tiers" "all" {
-}
+data "opslevel_tiers" "all" {}
 
 output "found" {
   value = data.opslevel_tiers.all.aliases[0]

--- a/examples/data-sources/opslevel_user/data-source.tf
+++ b/examples/data-sources/opslevel_user/data-source.tf
@@ -1,0 +1,7 @@
+data "opslevel_user" "foo" {
+  identifier = "foo@example.com"
+}
+
+output "foo" {
+  value = data.opslevel_user.foo
+}

--- a/examples/data-sources/opslevel_users/data-source.tf
+++ b/examples/data-sources/opslevel_users/data-source.tf
@@ -1,5 +1,4 @@
-data "opslevel_users" "all" {
-}
+data "opslevel_users" "all" {}
 
 output "found" {
   value = data.opslevel_users.all.emails[0]

--- a/examples/data-sources/opslevel_users/data-source.tf
+++ b/examples/data-sources/opslevel_users/data-source.tf
@@ -1,5 +1,13 @@
 data "opslevel_users" "all" {}
 
-output "found" {
-  value = data.opslevel_users.all.emails[0]
+output "all" {
+  value = data.opslevel_users.all.users
+}
+
+output "user_emails" {
+  value = sort(data.opslevel_users.all.users[*].email)
+}
+
+output "user_names" {
+  value = sort(data.opslevel_users.all.users[*].name)
 }

--- a/examples/data-sources/opslevel_webhook_action/data-source.tf
+++ b/examples/data-sources/opslevel_webhook_action/data-source.tf
@@ -1,3 +1,15 @@
-resource "opslevel_webhook_action" "example" {
-  identifier = "example"
+data "opslevel_webhook_action" "by_alias" {
+  identifier = "webhook_action_alias"
+}
+
+data "opslevel_webhook_action" "by_id" {
+  identifier = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS83NzQ0"
+}
+
+output "found_by_alias" {
+  value = data.opslevel_webhook_action.by_alias
+}
+
+output "found_by_id" {
+  value = data.opslevel_webhook_action.by_id
 }

--- a/examples/data-sources/opslevel_webhook_actions/data-source.tf
+++ b/examples/data-sources/opslevel_webhook_actions/data-source.tf
@@ -1,0 +1,5 @@
+data "opslevel_webhook_actions" "all" {}
+
+output "all_webhook_actions" {
+  value = data.opslevel_webhook_actions.all
+}

--- a/examples/data-sources/opslevel_webhook_actions/data-source.tf
+++ b/examples/data-sources/opslevel_webhook_actions/data-source.tf
@@ -1,5 +1,9 @@
 data "opslevel_webhook_actions" "all" {}
 
 output "all_webhook_actions" {
-  value = data.opslevel_webhook_actions.all
+  value = data.opslevel_webhook_actions.all.webhook_actions
+}
+
+output "webhook_action_names" {
+  value = data.opslevel_webhook_actions.all.webhook_actions[*].name
 }

--- a/examples/resources/opslevel_check_alert_source_usage/resource.tf
+++ b/examples/resources/opslevel_check_alert_source_usage/resource.tf
@@ -35,7 +35,7 @@ resource "opslevel_check_alert_source_usage" "example" {
   notes    = "Optional additional info on why this check is run or how to fix it"
 
   alert_type = "pagerduty" # one of: "pagerduty", "datadog", "opsgenie"
-  alert_name_predicate {
+  alert_name_predicate = {
     type  = "contains"
     value = "dev"
   }

--- a/examples/resources/opslevel_check_custom_event/resource.tf
+++ b/examples/resources/opslevel_check_custom_event/resource.tf
@@ -31,8 +31,9 @@ data "opslevel_integration" "kubernetes" {
 }
 
 resource "opslevel_check_custom_event" "example" {
-  name    = "foo"
-  enabled = true
+  name         = "foo"
+  pass_pending = true
+  enabled      = true
   # To set a future enable date remove field 'enabled' and use 'enable_on'
   # enable_on = "2022-05-23T14:14:18.782000Z"
   category          = data.opslevel_rubric_category.security.id
@@ -53,3 +54,4 @@ resource "opslevel_check_custom_event" "example" {
   EOT
   notes             = "Optional additional info on why this check is run or how to fix it"
 }
+

--- a/examples/resources/opslevel_check_manual/resource.tf
+++ b/examples/resources/opslevel_check_manual/resource.tf
@@ -32,7 +32,7 @@ resource "opslevel_check_manual" "example" {
   level     = data.opslevel_rubric_level.bronze.id
   owner     = data.opslevel_team.devs.id
   filter    = data.opslevel_filter.tier1.id
-  update_frequency {
+  update_frequency = {
     starting_data = time_static.initial.id
     time_scale    = "week"
     value         = 1

--- a/examples/resources/opslevel_check_repository_file/resource.tf
+++ b/examples/resources/opslevel_check_repository_file/resource.tf
@@ -24,8 +24,9 @@ data "opslevel_filter" "tier1" {
 }
 
 resource "opslevel_check_repository_file" "example" {
-  name    = "foo"
-  enabled = true
+  name              = "foo"
+  enabled           = true
+  use_absolute_root = false
   # To set a future enable date remove field 'enabled' and use 'enable_on'
   # enable_on = "2022-05-23T14:14:18.782000Z"
   category         = data.opslevel_rubric_category.security.id
@@ -40,3 +41,4 @@ resource "opslevel_check_repository_file" "example" {
   }
   notes = "Optional additional info on why this check is run or how to fix it"
 }
+

--- a/examples/resources/opslevel_check_service_property/resource.tf
+++ b/examples/resources/opslevel_check_service_property/resource.tf
@@ -33,7 +33,7 @@ resource "opslevel_check_service_property" "example" {
   owner    = data.opslevel_team.devs.id
   filter   = data.opslevel_filter.tier1.id
   property = "language"
-  predicate {
+  predicate = {
     type  = "equals"
     value = "python"
   }

--- a/examples/resources/opslevel_check_tool_usage/resource.tf
+++ b/examples/resources/opslevel_check_tool_usage/resource.tf
@@ -33,11 +33,11 @@ resource "opslevel_check_tool_usage" "example" {
   owner         = data.opslevel_team.devs.id
   filter        = data.opslevel_filter.tier1.id
   tool_category = "metrics"
-  tool_name_predicate {
+  tool_name_predicate = {
     type  = "equals"
     value = "datadog"
   }
-  environment_predicate {
+  environment_predicate = {
     type  = "equals"
     value = "production"
   }

--- a/examples/resources/opslevel_service_tag/resource.tf
+++ b/examples/resources/opslevel_service_tag/resource.tf
@@ -1,0 +1,11 @@
+resource "opslevel_service_tag" "service_tag_1" {
+  key     = "hello"
+  value   = "world"
+  service = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOQ"
+}
+
+resource "opslevel_service_tag" "service_tag_2" {
+  key           = "hello_with_alias"
+  value         = "world_with_alias"
+  service_alias = "cart"
+}

--- a/examples/resources/opslevel_team_tag/resource.tf
+++ b/examples/resources/opslevel_team_tag/resource.tf
@@ -1,0 +1,11 @@
+resource "opslevel_team_tag" "team_tag_1" {
+  key   = "hello"
+  value = "world"
+  team  = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQxMg"
+}
+
+resource "opslevel_team_tag" "team_tag_2" {
+  key        = "hello_with_alias"
+  value      = "world_with_alias"
+  team_alias = "team_foo"
+}

--- a/examples/resources/opslevel_trigger_definition/resource.tf
+++ b/examples/resources/opslevel_trigger_definition/resource.tf
@@ -73,4 +73,5 @@ Your request for {{ service.name }} has succeeded. See the incident here: {{resp
 Please contact [{{ action_owner.name }}]({{ action_owner.href }}) for more help.
 {% endif %}
   EOT
+  published                = true
 }


### PR DESCRIPTION
## Issues

[Ensure the terraform registry docs generator still works](https://github.com/OpsLevel/team-platform/issues/349)

## Changelog

Update datasources and resources configs in `examples/` directory.
Updates like ` alert_name_predicate {` --> ` alert_name_predicate = {` are a result of updating blocks to SingleNestedAttributes and will need to be documented in the 1.0 release.
Added examples for:
- `opslevel_webhook_actions` datasource
- `opslevel_user`  datasource
- `opslevel_service_tag` resource
- `opslevel_team_tag` resource

- [X] List your changes here
- [ ] Make a `changie` entry, N/A docs

## Tophatting

`task docs`
