### PR TITLE
fix listing services, show empty list when no services exist

### DIFF
--- a/.changes/unreleased/Bugfix-20240510-094522.yaml
+++ b/.changes/unreleased/Bugfix-20240510-094522.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix listing services, show empty list when no services exist
+time: 2024-05-10T09:45:22.019688-05:00

--- a/opslevel/datasource_opslevel_services_all.go
+++ b/opslevel/datasource_opslevel_services_all.go
@@ -149,7 +149,11 @@ func (d *ServiceDataSourcesAll) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	stateModel = NewServiceDataSourcesAllModel(services.Nodes)
+	if services == nil {
+		stateModel = NewServiceDataSourcesAllModel([]opslevel.Service{})
+	} else {
+		stateModel = NewServiceDataSourcesAllModel(services.Nodes)
+	}
 	stateModel.Filter = planModel.Filter
 
 	// Save data into Terraform state


### PR DESCRIPTION
## Issues

[nil pointer deference on plural service datasource ](https://github.com/OpsLevel/terraform-provider-opslevel/issues/334)

## Changelog

Fix listing services, show empty list when no services exist.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Using this config:
```tf
data "opslevel_services" "all" {}

output "all_services" {
  value = data.opslevel_services.all.services
}
```

### Run `task plan` against account with no services
```tf
data.opslevel_services.all: Reading...
data.opslevel_services.all: Read complete after 1s

Changes to Outputs:
  + all_services = []

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```