### PR TITLE
add manual test integration workflow to CI

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,0 +1,24 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Tests
+        run: task test-integration
+        env:
+          OPSLEVEL_API_TOKEN: ${{ secrets.OPSLEVEL_PAT_API_TOKEN }}


### PR DESCRIPTION
## Issues

[Setup Integration Testing](https://github.com/OpsLevel/team-platform/issues/346)

## Changelog

Add manually triggered CI workflow that runs integration tests against the PAT account.
This runs `task test-integration` which:
- builds the latest Go code on `main`
- runs `terraform init`
- runs `test -var-file=test.tfvars -var="api_token=$OPSLEVEL_API_TOKEN"` from `tests/remote`

---

- [X] List your changes here
- [ ] Make a `changie` entry, N/A CI only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->
