### PR TITLE
Db/fix team member keep or delete

### DIFF
--- a/.changes/unreleased/Bugfix-20240529-142603.yaml
+++ b/.changes/unreleased/Bugfix-20240529-142603.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: keep existing Team members when no member blocks used
+time: 2024-05-29T14:26:03.369744-05:00

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -80,7 +79,6 @@ func (teamResource *TeamResource) Metadata(ctx context.Context, req resource.Met
 }
 
 func (teamResource *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	userRoles := []string{"contributor", "manager"}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Team Resource",
 		Attributes: map[string]schema.Attribute{
@@ -126,9 +124,6 @@ func (teamResource *TeamResource) Schema(ctx context.Context, req resource.Schem
 						"role": schema.StringAttribute{
 							Description: "The role of the team member.",
 							Required:    true,
-							Validators: []validator.String{
-								stringvalidator.OneOf(userRoles...),
-							},
 						},
 					},
 				},


### PR DESCRIPTION
## Issues

[Don't remove members assigned to teams in the UI](https://github.com/OpsLevel/terraform-provider-opslevel/issues/183)

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this config file
```tf
# main.tf
resource "opslevel_team" "example" {
  name             = "foo"
  responsibilities = "Responsible for foo frontend and backend"
  aliases          = ["bar1234", "baz3334", "foo3334", "foo3324"]
  # member {
  #   email = "david+pat@opslevel.com"
  #   role  = "contributor"
  # }
}
```

### Create Team (no members)
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_team.example will be created
  + resource "opslevel_team" "example" {
      + aliases          = [
          + "bar1234",
          + "baz3334",
          + "foo3334",
          + "foo3324",
        ]
      + id               = (known after apply)
      + last_updated     = (known after apply)
      + name             = "foo"
      + responsibilities = "Responsible for foo frontend and backend"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_team.example: Creating...
opslevel_team.example: Creation complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Add Members to Team in UI ✅ 

### Run `terraform plan`, no members mentioned
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      ~ aliases          = [
            # (1 unchanged element hidden)
            "baz3334",
          - "foo3324",
            "foo3334",
          + "foo3324",
        ]
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg"
      + last_updated     = (known after apply)
        name             = "foo"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### Add member to config file
```tf
resource "opslevel_team" "example" {
  name             = "foo"
  responsibilities = "Responsible for foo frontend and backend"
  aliases          = ["bar1234", "baz3334", "foo3334", "foo3324"]
  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
}
```

### Run `terraform apply`, all members from UI replaced with members in TF config
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      ~ aliases          = [
            # (1 unchanged element hidden)
            "baz3334",
          - "foo3324",
            "foo3334",
          + "foo3324",
        ]
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg"
      + last_updated     = (known after apply)
        name             = "foo"
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]
opslevel_team.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Remove member from config file
```tf
resource "opslevel_team" "example" {
  name             = "foo"
  responsibilities = "Responsible for foo frontend and backend"
  aliases          = ["bar1234", "baz3334", "foo3334", "foo3324"]
  # member {
  #   email = "david+pat@opslevel.com"
  #   role  = "contributor"
  # }
}
```

### Remove TF added member `terraform apply`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      ~ aliases          = [
            # (1 unchanged element hidden)
            "baz3334",
          - "foo3324",
            "foo3334",
          + "foo3324",
        ]
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg"
      + last_updated     = (known after apply)
        name             = "foo"
        # (1 unchanged attribute hidden)

      - member {
          - email = "david+pat@opslevel.com" -> null
          - role  = "contributor" -> null
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]
opslevel_team.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Add Member back with TF ✅ 

### Destroy Team and members, `terraform destroy`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_team.example will be destroyed
  - resource "opslevel_team" "example" {
      - aliases          = [
          - "bar1234",
          - "baz3334",
          - "foo3324",
          - "foo3334",
        ] -> null
      - id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg" -> null
      - name             = "foo" -> null
      - responsibilities = "Responsible for foo frontend and backend" -> null

      - member {
          - email = "david+pat@opslevel.com" -> null
          - role  = "contributor" -> null
        }
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_team.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTExMg]
opslevel_team.example: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```