### PR TITLE
add listSortStringModifier custom PlanModifier

### DIFF
--- a/.changes/unreleased/Feature-20240530-110257.yaml
+++ b/.changes/unreleased/Feature-20240530-110257.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add listSortStringModifier custom PlanModifier
+time: 2024-05-30T11:02:57.495845-05:00

--- a/opslevel/plan_modifiers.go
+++ b/opslevel/plan_modifiers.go
@@ -1,0 +1,42 @@
+package opslevel
+
+import (
+	"context"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+var _ planmodifier.List = listSortStringModifier{}
+
+type listSortStringModifier struct{}
+
+// Description returns a plain text description of the validator's behavior,
+// suitable for a practitioner to understand its impact.
+func (m listSortStringModifier) Description(_ context.Context) string {
+	return "Sorts a given list of strings"
+}
+
+// MarkdownDescription returns a markdown formatted description of the
+// validator's behavior, suitable for a practitioner to understand its impact.
+func (m listSortStringModifier) MarkdownDescription(_ context.Context) string {
+	return "Sorts list of strings when returned order of strings may vary"
+}
+
+// PlanModifyList updates the planned value with the default if its not null.
+func (m listSortStringModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	planStrings, diags := ListValueToStringSlice(ctx, req.PlanValue)
+	resp.Diagnostics.Append(diags...)
+
+	stateStrings, diags := ListValueToStringSlice(ctx, req.StateValue)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	slices.Sort(planStrings)
+	slices.Sort(stateStrings)
+	if slices.Equal(planStrings, stateStrings) {
+		resp.PlanValue = req.StateValue
+	}
+}

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -94,6 +95,9 @@ func (r *InfrastructureResource) Schema(ctx context.Context, req resource.Schema
 				ElementType: types.StringType,
 				Description: "The aliases for the infrastructure resource.",
 				Optional:    true,
+				Validators: []validator.List{
+					listvalidator.UniqueValues(),
+				},
 			},
 			"data": schema.StringAttribute{
 				Description: "The data of the infrastructure resource in JSON format.",

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -95,6 +95,9 @@ func (r *InfrastructureResource) Schema(ctx context.Context, req resource.Schema
 				ElementType: types.StringType,
 				Description: "The aliases for the infrastructure resource.",
 				Optional:    true,
+				PlanModifiers: []planmodifier.List{
+					listSortStringModifier{},
+				},
 				Validators: []validator.List{
 					listvalidator.UniqueValues(),
 				},

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -124,6 +124,9 @@ func (r *ServiceResource) Schema(ctx context.Context, req resource.SchemaRequest
 				ElementType: types.StringType,
 				Description: "A list of human-friendly, unique identifiers for the service.",
 				Optional:    true,
+				PlanModifiers: []planmodifier.List{
+					listSortStringModifier{},
+				},
 				Validators: []validator.List{
 					listvalidator.UniqueValues(),
 				},

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -64,6 +64,9 @@ func NewTeamResourceModel(ctx context.Context, team opslevel.Team, givenModel Te
 		Name:             RequiredStringValue(team.Name),
 		Responsibilities: OptionalStringValue(team.Responsibilities),
 	}
+	if ListValueStringsAreEqual(ctx, givenModel.Aliases, teamResourceModel.Aliases) {
+		teamResourceModel.Aliases = givenModel.Aliases
+	}
 
 	if len(givenModel.Member) > 0 && team.Memberships != nil {
 		for _, mem := range team.Memberships.Nodes {

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -86,6 +86,9 @@ func (teamResource *TeamResource) Schema(ctx context.Context, req resource.Schem
 				ElementType: types.StringType,
 				Description: "A list of human-friendly, unique identifiers for the team.",
 				Optional:    true,
+				PlanModifiers: []planmodifier.List{
+					listSortStringModifier{},
+				},
 				Validators: []validator.List{
 					listvalidator.UniqueValues(),
 				},


### PR DESCRIPTION
## Issues

[fix aliases](https://github.com/OpsLevel/team-platform/issues/340)

## Changelog

Add `listSortStringModifier` custom PlanModifier. During the plan, if the proposed changes to a list of strings differs from the current state only by order, then continue using the state's list of strings.
This avoids unneeded updates to lists of strings that only serve to shuffle the order of strings

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this config file:
```tf
# main.tf
resource "opslevel_infrastructure" "example" {
  aliases = ["123", "bbb", "DDD", "aaa"]
  owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
  schema  = "Database"
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "frosting-patrol"
  aliases = ["yellow", "blue", "red"]
}

resource "opslevel_team" "example" {
  name             = "bake-off"
  responsibilities = "Baking cakes"
  aliases          = ["ZZZ", "XXXX", "yyyyy", "4321"]
}
```

### Create infra, service, and team resources with aliases. `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be created
  + resource "opslevel_infrastructure" "example" {
      + aliases      = [
          + "123",
          + "DDD",
          + "aaa",
          + "bbb",
        ]
      + data         = jsonencode(
            {
              + name = "my-database"
            }
        )
      + id           = (known after apply)
      + last_updated = (known after apply)
      + owner        = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
      + schema       = "Database"
    }

  # opslevel_service.example will be created
  + resource "opslevel_service" "example" {
      + aliases      = [
          + "blue",
          + "red",
          + "yellow",
        ]
      + id           = (known after apply)
      + last_updated = (known after apply)
      + name         = "frosting-patrol"
    }

  # opslevel_team.example will be created
  + resource "opslevel_team" "example" {
      + aliases          = [
          + "4321",
          + "XXXX",
          + "ZZZ",
          + "yyyyy",
        ]
      + id               = (known after apply)
      + last_updated     = (known after apply)
      + name             = "bake-off"
      + responsibilities = "Baking cakes"
    }

Plan: 3 to add, 0 to change, 0 to destroy.
opslevel_service.example: Creating...
opslevel_team.example: Creating...
opslevel_infrastructure.example: Creating...
opslevel_team.example: Creation complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA]
opslevel_service.example: Creation complete after 3s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI]
opslevel_infrastructure.example: Creation complete after 4s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

### Update the config file, sort all aliases:
```tf
# main.tf
resource "opslevel_infrastructure" "example" {
  aliases = sort(["123", "bbb", "DDD", "aaa"])
  owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
  schema  = "Database"
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "frosting-patrol"
  aliases = sort(["yellow", "blue", "red"])
}

resource "opslevel_team" "example" {
  name             = "bake-off"
  responsibilities = "Baking cakes"
  aliases          = sort(["ZZZ", "XXXX", "yyyyy", "4321"])
}
```

### `task plan` shows no change

### Update the config file, change contents of aliases:
```tf
resource "opslevel_infrastructure" "example" {
  aliases = sort(["123", "bbb", "DDD"])
  owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
  schema  = "Database"
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "frosting-patrol"
  aliases = sort(["yellow", "blue", "red", "green"])
}

resource "opslevel_team" "example" {
  name             = "bake-off"
  responsibilities = "Baking cakes"
  aliases          = sort(["ZZZ", "4321", "asdf"])
}
```

### Update aliases. `terraform apply`
```tf
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY]
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be updated in-place
  ~ resource "opslevel_infrastructure" "example" {
      ~ aliases      = [
            # (1 unchanged element hidden)
            "DDD",
          - "aaa",
            "bbb",
        ]
        id           = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY"
      + last_updated = (known after apply)
        # (3 unchanged attributes hidden)
    }

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      ~ aliases      = [
            "blue",
          + "green",
            "red",
            # (1 unchanged element hidden)
        ]
        id           = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI"
      + last_updated = (known after apply)
        name         = "frosting-patrol"
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      ~ aliases          = [
            "4321",
          - "XXXX",
            "ZZZ",
          - "yyyyy",
          + "asdf",
        ]
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA"
      + last_updated     = (known after apply)
        name             = "bake-off"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA]
opslevel_infrastructure.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY]
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI]
opslevel_infrastructure.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY]
opslevel_team.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA]
opslevel_service.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI]

Apply complete! Resources: 0 added, 3 changed, 0 destroyed.
```

### Tear down resources, `terraform destroy`
```tf
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY]
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be destroyed
  - resource "opslevel_infrastructure" "example" {
      - aliases = [
          - "123",
          - "DDD",
          - "bbb",
        ] -> null
      - data    = jsonencode(
            {
              - name = "my-database"
            }
        ) -> null
      - id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY" -> null
      - owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg" -> null
      - schema  = "Database" -> null
    }

  # opslevel_service.example will be destroyed
  - resource "opslevel_service" "example" {
      - aliases = [
          - "blue",
          - "green",
          - "red",
          - "yellow",
        ] -> null
      - id      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI" -> null
      - name    = "frosting-patrol" -> null
    }

  # opslevel_team.example will be destroyed
  - resource "opslevel_team" "example" {
      - aliases          = [
          - "4321",
          - "ZZZ",
          - "asdf",
        ] -> null
      - id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA" -> null
      - name             = "bake-off" -> null
      - responsibilities = "Baking cakes" -> null
    }

Plan: 0 to add, 0 to change, 3 to destroy.
opslevel_service.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjM5ODI]
opslevel_infrastructure.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTc4NDY]
opslevel_team.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE0OA]
opslevel_infrastructure.example: Destruction complete after 1s
opslevel_team.example: Destruction complete after 1s
opslevel_service.example: Destruction complete after 2s

Destroy complete! Resources: 3 destroyed.
```