### PR TITLE
convert aliases attribute from list to set

### DIFF
--- a/.changes/unreleased/Refactor-20240530-145934.yaml
+++ b/.changes/unreleased/Refactor-20240530-145934.yaml
@@ -1,0 +1,4 @@
+kind: Refactor
+body: aliases attributes for infrastructure, service, team, converted to set from
+  list
+time: 2024-05-30T14:59:34.12317-05:00

--- a/.changes/unreleased/Refactor-20240530-145934.yaml
+++ b/.changes/unreleased/Refactor-20240530-145934.yaml
@@ -1,4 +1,3 @@
 kind: Refactor
-body: aliases attributes for infrastructure, service, team, converted to set from
-  list
+body: fix unneeded updates to "aliases" field in infrastructure, service, and team when only order is changed. Converted "aliases" from list type to set type
 time: 2024-05-30T14:59:34.12317-05:00

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -83,7 +83,7 @@ func ListValueToStringSlice(ctx context.Context, listValue basetypes.ListValue) 
 	return dataAsSlice, diags
 }
 
-// Converts a basetypes.ListValue to a []string
+// Converts a basetypes.SetValue to a []string
 func SetValueToStringSlice(ctx context.Context, setValue basetypes.SetValue) ([]string, diag.Diagnostics) {
 	dataAsSlice := []string{}
 	if setValue.IsNull() {

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -83,6 +83,16 @@ func ListValueToStringSlice(ctx context.Context, listValue basetypes.ListValue) 
 	return dataAsSlice, diags
 }
 
+// Converts a basetypes.ListValue to a []string
+func SetValueToStringSlice(ctx context.Context, setValue basetypes.SetValue) ([]string, diag.Diagnostics) {
+	dataAsSlice := []string{}
+	if setValue.IsNull() {
+		return dataAsSlice, nil
+	}
+	diags := setValue.ElementsAs(ctx, &dataAsSlice, true)
+	return dataAsSlice, diags
+}
+
 // Converts a basetypes.MapValue to an opslevel.JSON
 func MapValueToOpslevelJson(ctx context.Context, mapValue basetypes.MapValue) (opslevel.JSON, diag.Diagnostics) {
 	mapAsJson := opslevel.JSON{}

--- a/tests/local/resource_infra.tftest.hcl
+++ b/tests/local/resource_infra.tftest.hcl
@@ -38,7 +38,7 @@ run "resource_infra_big" {
   }
 
   assert {
-    condition     = opslevel_infrastructure.big_infra.aliases == tolist(["big-infra"])
+    condition     = contains(opslevel_infrastructure.big_infra.aliases, "big-infra")
     error_message = "wrong aliases in opslevel_infrastructure.big_infra"
   }
 

--- a/tests/local/resource_service.tftest.hcl
+++ b/tests/local/resource_service.tftest.hcl
@@ -9,7 +9,10 @@ run "resource_service_big" {
   }
 
   assert {
-    condition     = opslevel_service.big.aliases == tolist(["service-1", "service-2"])
+    condition = alltrue([
+      contains(opslevel_service.big.aliases, "service-1"),
+      contains(opslevel_service.big.aliases, "service-2"),
+    ])
     error_message = "wrong aliases in opslevel_service.big"
   }
 

--- a/tests/local/resource_team.tftest.hcl
+++ b/tests/local/resource_team.tftest.hcl
@@ -9,7 +9,10 @@ run "resource_team_big" {
   }
 
   assert {
-    condition     = opslevel_team.big.aliases[0] == "the_big_team" && opslevel_team.big.aliases[1] == "big_team"
+    condition = alltrue([
+      contains(opslevel_team.big.aliases, "big_team"),
+      contains(opslevel_team.big.aliases, "the_big_team"),
+    ])
     error_message = "wrong aliases in opslevel_team.big"
   }
 


### PR DESCRIPTION
## Issues

[aliases field has issues](https://github.com/OpsLevel/team-platform/issues/340)

## Changelog

Convert `aliases` field in `opslevel_infrastructure`, `opslevel_service`, and `opslevel_team` from list type to set.
This is a sensible solution to the unordered nature of aliases on return. 

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this config
```tf
# main.tf
resource "opslevel_infrastructure" "example" {
  aliases = []
  owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
  schema  = "Database"
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "frosting-patrol1"
  aliases = []
}

resource "opslevel_team" "example" {
  name             = "bake-off2"
  responsibilities = "Baking cakes"
  aliases          = []
}
```

### Create resources with empty (non-null) aliases, `terraform apply`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be updated in-place
  ~ resource "opslevel_infrastructure" "example" {
      + aliases = []
        id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk"
        # (3 unchanged attributes hidden)
    }

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      + aliases = []
        id      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ"
        name    = "frosting-patrol1"
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      + aliases          = []
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg"
        name             = "bake-off2"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_infrastructure.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]
opslevel_team.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_infrastructure.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]

Apply complete! Resources: 0 added, 3 changed, 0 destroyed.
```

### Update config, populate aliases
```tf
resource "opslevel_infrastructure" "example" {
  aliases = ["lkasjd121fkj12", "b342ufyoiayw12"]
  owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
  schema  = "Database"
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "frosting-patrol1"
  aliases = ["lkasjdfkj12", "bufyoiayw12"]
}

resource "opslevel_team" "example" {
  name             = "bake-off2"
  responsibilities = "Baking cakes"
  aliases          = ["lkasjdfkj", "bufyoiayw"]
}
```

### Update resources to add aliases, `terraform apply`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be updated in-place
  ~ resource "opslevel_infrastructure" "example" {
      ~ aliases = [
          + "b342ufyoiayw12",
          + "lkasjd121fkj12",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk"
        # (3 unchanged attributes hidden)
    }

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      ~ aliases = [
          + "bufyoiayw12",
          + "lkasjdfkj12",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ"
        name    = "frosting-patrol1"
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      ~ aliases          = [
          + "bufyoiayw",
          + "lkasjdfkj",
        ]
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg"
        name             = "bake-off2"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
opslevel_infrastructure.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_team.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_infrastructure.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Modifications complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]

Apply complete! Resources: 0 added, 3 changed, 0 destroyed.
```

### Update config, remove aliases
```tf
resource "opslevel_infrastructure" "example" {
  # aliases = ["lkasjd121fkj12", "b342ufyoiayw12"]
  owner   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
  schema  = "Database"
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "frosting-patrol1"
  # aliases = ["lkasjdfkj12", "bufyoiayw12"]
}

resource "opslevel_team" "example" {
  name             = "bake-off2"
  responsibilities = "Baking cakes"
  # aliases          = ["lkasjdfkj", "bufyoiayw"]
}
```

### Update resources to remove aliases (null - not empty), `terraform apply`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be updated in-place
  ~ resource "opslevel_infrastructure" "example" {
      - aliases = [] -> null
        id      = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk"
        # (3 unchanged attributes hidden)
    }

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      - aliases = [] -> null
        id      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ"
        name    = "frosting-patrol1"
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      - aliases          = [] -> null
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg"
        name             = "bake-off2"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
opslevel_infrastructure.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_team.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_infrastructure.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]

Apply complete! Resources: 0 added, 3 changed, 0 destroyed.
```

### Destroy test resources, `terraform destroy`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be destroyed
  - resource "opslevel_infrastructure" "example" {
      - data   = jsonencode(
            {
              - name = "my-database"
            }
        ) -> null
      - id     = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk" -> null
      - owner  = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg" -> null
      - schema = "Database" -> null
    }

  # opslevel_service.example will be destroyed
  - resource "opslevel_service" "example" {
      - id   = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ" -> null
      - name = "frosting-patrol1" -> null
    }

  # opslevel_team.example will be destroyed
  - resource "opslevel_team" "example" {
      - id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg" -> null
      - name             = "bake-off2" -> null
      - responsibilities = "Baking cakes" -> null
    }

Plan: 0 to add, 0 to change, 3 to destroy.
opslevel_team.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTE2Mg]
opslevel_service.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjQwMDQ]
opslevel_infrastructure.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI0OTgyMTk]
opslevel_infrastructure.example: Destruction complete after 0s
opslevel_team.example: Destruction complete after 0s
opslevel_service.example: Destruction complete after 2s

Destroy complete! Resources: 3 destroyed.
```