### PR TITLE
add Terraform config validation to filter predicates

### DIFF
--- a/.changes/unreleased/Feature-20240531-112947.yaml
+++ b/.changes/unreleased/Feature-20240531-112947.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add Terraform config validation to filter predicates
+time: 2024-05-31T11:29:47.949371-05:00

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckAlertSourceUsageResource{}
-	_ resource.ResourceWithImportState = &CheckAlertSourceUsageResource{}
+	_ resource.ResourceWithConfigure      = &CheckAlertSourceUsageResource{}
+	_ resource.ResourceWithImportState    = &CheckAlertSourceUsageResource{}
+	_ resource.ResourceWithValidateConfig = &CheckAlertSourceUsageResource{}
 )
 
 func NewCheckAlertSourceUsageResource() resource.Resource {
@@ -97,6 +98,17 @@ func (r *CheckAlertSourceUsageResource) Schema(ctx context.Context, req resource
 			},
 			"alert_name_predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckAlertSourceUsageResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckAlertSourceUsageResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() || configModel.AlertNamePredicate == nil {
+		return
+	}
+	if err := configModel.AlertNamePredicate.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("alert_name_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -92,10 +92,18 @@ func NewPredicateModel(predicate opslevel.Predicate) *PredicateModel {
 	}
 }
 
-func (s PredicateModel) ToCreateInput() *opslevel.PredicateInput {
+func (p PredicateModel) Validate() error {
+	predicate := opslevel.Predicate{
+		Type:  opslevel.PredicateTypeEnum(p.Type.ValueString()),
+		Value: p.Value.ValueString(),
+	}
+	return predicate.Validate()
+}
+
+func (p PredicateModel) ToCreateInput() *opslevel.PredicateInput {
 	return &opslevel.PredicateInput{
-		Type:  opslevel.PredicateTypeEnum(s.Type.ValueString()),
-		Value: opslevel.RefOf(s.Value.ValueString()),
+		Type:  opslevel.PredicateTypeEnum(p.Type.ValueString()),
+		Value: opslevel.RefOf(p.Value.ValueString()),
 	}
 }
 

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckRepositoryFileResource{}
-	_ resource.ResourceWithImportState = &CheckRepositoryFileResource{}
+	_ resource.ResourceWithConfigure      = &CheckRepositoryFileResource{}
+	_ resource.ResourceWithImportState    = &CheckRepositoryFileResource{}
+	_ resource.ResourceWithValidateConfig = &CheckRepositoryFileResource{}
 )
 
 func NewCheckRepositoryFileResource() resource.Resource {
@@ -105,6 +106,17 @@ func (r *CheckRepositoryFileResource) Schema(ctx context.Context, req resource.S
 				Required:    true,
 			},
 		}),
+	}
+}
+
+func (r *CheckRepositoryFileResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckRepositoryFileResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() || configModel.FileContentsPredicate == nil {
+		return
+	}
+	if err := configModel.FileContentsPredicate.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckRepositoryGrepResource{}
-	_ resource.ResourceWithImportState = &CheckRepositoryGrepResource{}
+	_ resource.ResourceWithConfigure      = &CheckRepositoryGrepResource{}
+	_ resource.ResourceWithImportState    = &CheckRepositoryGrepResource{}
+	_ resource.ResourceWithValidateConfig = &CheckRepositoryGrepResource{}
 )
 
 func NewCheckRepositoryGrepResource() resource.Resource {
@@ -101,6 +102,17 @@ func (r *CheckRepositoryGrepResource) Schema(ctx context.Context, req resource.S
 			},
 			"file_contents_predicate": predicateSchema,
 		}),
+	}
+}
+
+func (r *CheckRepositoryGrepResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckRepositoryGrepResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := configModel.FileContentsPredicate.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckRepositorySearchResource{}
-	_ resource.ResourceWithImportState = &CheckRepositorySearchResource{}
+	_ resource.ResourceWithConfigure      = &CheckRepositorySearchResource{}
+	_ resource.ResourceWithImportState    = &CheckRepositorySearchResource{}
+	_ resource.ResourceWithValidateConfig = &CheckRepositorySearchResource{}
 )
 
 func NewCheckRepositorySearchResource() resource.Resource {
@@ -95,6 +96,17 @@ func (r *CheckRepositorySearchResource) Schema(ctx context.Context, req resource
 			},
 			"file_contents_predicate": predicateSchema,
 		}),
+	}
+}
+
+func (r *CheckRepositorySearchResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckRepositorySearchResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := configModel.FileContentsPredicate.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckServiceOwnershipResource{}
-	_ resource.ResourceWithImportState = &CheckServiceOwnershipResource{}
+	_ resource.ResourceWithConfigure      = &CheckServiceOwnershipResource{}
+	_ resource.ResourceWithImportState    = &CheckServiceOwnershipResource{}
+	_ resource.ResourceWithValidateConfig = &CheckServiceOwnershipResource{}
 )
 
 func NewCheckServiceOwnershipResource() resource.Resource {
@@ -118,6 +119,17 @@ func (r *CheckServiceOwnershipResource) Schema(ctx context.Context, req resource
 			},
 			"tag_predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckServiceOwnershipResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckServiceOwnershipResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() || configModel.TagPredicate == nil {
+		return
+	}
+	if err := configModel.TagPredicate.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckServicePropertyResource{}
-	_ resource.ResourceWithImportState = &CheckServicePropertyResource{}
+	_ resource.ResourceWithConfigure      = &CheckServicePropertyResource{}
+	_ resource.ResourceWithImportState    = &CheckServicePropertyResource{}
+	_ resource.ResourceWithValidateConfig = &CheckServicePropertyResource{}
 )
 
 func NewCheckServicePropertyResource() resource.Resource {
@@ -99,6 +100,17 @@ func (r *CheckServicePropertyResource) Schema(ctx context.Context, req resource.
 			},
 			"predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckServicePropertyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckServicePropertyResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() || configModel.Predicate == nil {
+		return
+	}
+	if err := configModel.Predicate.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckTagDefinedResource{}
-	_ resource.ResourceWithImportState = &CheckTagDefinedResource{}
+	_ resource.ResourceWithConfigure      = &CheckTagDefinedResource{}
+	_ resource.ResourceWithImportState    = &CheckTagDefinedResource{}
+	_ resource.ResourceWithValidateConfig = &CheckTagDefinedResource{}
 )
 
 func NewCheckTagDefinedResource() resource.Resource {
@@ -90,6 +91,17 @@ func (r *CheckTagDefinedResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"tag_predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckTagDefinedResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckTagDefinedResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() || configModel.TagPredicate == nil {
+		return
+	}
+	if err := configModel.TagPredicate.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	_ resource.ResourceWithConfigure   = &CheckToolUsageResource{}
-	_ resource.ResourceWithImportState = &CheckToolUsageResource{}
+	_ resource.ResourceWithConfigure      = &CheckToolUsageResource{}
+	_ resource.ResourceWithImportState    = &CheckToolUsageResource{}
+	_ resource.ResourceWithValidateConfig = &CheckToolUsageResource{}
 )
 
 func NewCheckToolUsageResource() resource.Resource {
@@ -103,10 +104,34 @@ func (r *CheckToolUsageResource) Schema(ctx context.Context, req resource.Schema
 				Required:   true,
 				Validators: []validator.String{stringvalidator.OneOf(opslevel.AllToolCategory...)},
 			},
+			"environment_predicate": PredicateSchema(),
 			"tool_name_predicate":   PredicateSchema(),
 			"tool_url_predicate":    PredicateSchema(),
-			"environment_predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckToolUsageResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var configModel CheckToolUsageResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if configModel.EnvironmentPredicate != nil {
+		if err := configModel.EnvironmentPredicate.Validate(); err != nil {
+			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
+	}
+	if configModel.ToolNamePredicate != nil {
+		if err := configModel.ToolNamePredicate.Validate(); err != nil {
+			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
+	}
+	if configModel.ToolUrlPredicate != nil {
+		if err := configModel.ToolUrlPredicate.Validate(); err != nil {
+			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
## Issues

[Add filter predicate validation for Terraform configs](https://github.com/OpsLevel/team-platform/issues/376)

## Changelog

Add predicate validation at config time, i.e. `terraform validate` (pre-plan).

NOTE: predicated on update in this [opslevel-go PR](https://github.com/OpsLevel/opslevel-go/pull/410) 

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Using this config
```tf
resource "opslevel_check_alert_source_usage" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  alert_type = "pagerduty" # one of: "pagerduty", "datadog", "opsgenie"
  alert_name_predicate = {
    type  = "exists"
    value = null
  }
}

resource "opslevel_check_repository_grep" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  filepaths        = ["kjsd"]
  directory_search = false
  file_contents_predicate = {
    type  = "does_not_exist"
    value = null
  }
}


resource "opslevel_check_repository_file" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  filepaths         = ["kjsd"]
  use_absolute_root = false
  directory_search  = false
  file_contents_predicate = {
    type  = "contains"
    value = "asdf"
  }
}

resource "opslevel_check_repository_search" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  file_contents_predicate = {
    type  = "contains"
    value = "asdf"
  }
}

resource "opslevel_check_service_ownership" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  tag_predicate = {
    type  = "contains"
    value = "asdf"
  }
}

resource "opslevel_check_service_property" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  property = "name"
  predicate = {
    type  = "contains"
    value = "asdf"
  }
}


resource "opslevel_check_tag_defined" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  tag_key = "name"
  tag_predicate = {
    type  = "contains"
    value = "asdf"
  }
}


resource "opslevel_check_tool_usage" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3OQ"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ3NDM"
  notes    = "Optional additional info on why this check is run or how to fix it"

  tool_category = "runbooks"
  environment_predicate = {
    type  = "contains"
    value = "asdf"
  }
  tool_name_predicate = {
    type  = "contains"
    value = "asdf"
  }
  tool_url_predicate = {
    type  = "contains"
    value = "asdf"
  }
}
```

### Modify the `type` and `value` of each
- `type = "exists"` and `type = "does_not_exist"` should not have a value. `terraform validate` prints an error otherwise
- All other `type = "<valid type>"` requires a value. `terraform validate` guides the dev along