### PR TITLE
convert service tags to type set from list, skip reorder only updates

### DIFF
--- a/.changes/unreleased/Bugfix-20240603-085824.yaml
+++ b/.changes/unreleased/Bugfix-20240603-085824.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: convert service tags to type set from list, skip reorder only updates
+time: 2024-06-03T08:58:24.439857-05:00

--- a/opslevel/validators.go
+++ b/opslevel/validators.go
@@ -126,7 +126,7 @@ func JsonHasNameKeyValidator() validator.String {
 	return jsonHasNameKeyValidator{}
 }
 
-var _ validator.List = tagFormatValidator{}
+var _ validator.Set = tagFormatValidator{}
 
 // tagFormatValidator validates that list contains items with tag format.
 type tagFormatValidator struct {
@@ -141,7 +141,7 @@ func (v tagFormatValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v tagFormatValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+func (v tagFormatValidator) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
@@ -162,6 +162,6 @@ func (v tagFormatValidator) ValidateList(ctx context.Context, req validator.List
 	}
 }
 
-func TagFormatValidator() validator.List {
+func TagFormatValidator() validator.Set {
 	return tagFormatValidator{}
 }

--- a/tests/local/resource_service.tftest.hcl
+++ b/tests/local/resource_service.tftest.hcl
@@ -62,7 +62,7 @@ run "resource_service_big" {
   }
 
   assert {
-    condition     = opslevel_service.big.tags == tolist(["key1:value1", "key2:value2"])
+    condition     = opslevel_service.big.tags == toset(["key1:value1", "key2:value2"])
     error_message = "wrong tags in opslevel_service.big"
   }
 

--- a/tests/remote/service.tftest.hcl
+++ b/tests/remote/service.tftest.hcl
@@ -15,7 +15,7 @@ variables {
   owner                         = null
   preferred_api_document_source = "PUSH"
   product                       = "widgets"
-  tags                          = tolist(["key1:value1", "key2:value2"])
+  tags                          = toset(["key1:value1", "key2:value2"])
   tier_alias                    = null
 }
 
@@ -242,7 +242,7 @@ run "resource_service_update_set_all_fields" {
     owner                         = run.from_team_get_owner_id.first_team.id
     preferred_api_document_source = var.preferred_api_document_source
     product                       = var.product
-    tags                          = concat(var.tags, ["key3:value3"])
+    tags                          = setunion(var.tags, ["key3:value3"])
     tier_alias                    = run.from_tier_get_tier_alias.first_tier.alias
   }
 

--- a/tests/remote/service/variables.tf
+++ b/tests/remote/service/variables.tf
@@ -71,8 +71,8 @@ variable "product" {
 }
 
 variable "tags" {
-  type        = list(string)
-  description = "A list of tags applied to the service."
+  type        = set(string)
+  description = "A list of unique tags applied to the service."
 }
 
 variable "tier_alias" {


### PR DESCRIPTION
## Issues

[opslevel_serivce tags update errors with the new provider upgrade](https://github.com/OpsLevel/terraform-provider-opslevel/issues/358)

## Changelog

Convert type of service tags from `list` to `set`.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```tf
TODO...
```
