### PR TITLE
fix unwanted update to trigger_definition.entity_type when specified

### DIFF
--- a/.changes/unreleased/Bugfix-20240603-103816.yaml
+++ b/.changes/unreleased/Bugfix-20240603-103816.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix unwanted update to trigger_definition.entity_type when specified
+time: 2024-06-03T10:38:16.67209-05:00


### PR DESCRIPTION
## Issues

Fix unwanted update to optional field `opslevel_ trigger_definition.entity_type` when not specified in Terraform config.

## Changelog

If `entity_type` is not specified in the Terraform config, default to what is returned by the API.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this Terraform config
```tf
resource "opslevel_trigger_definition" "example" {
  access_control = "everyone"
  action         = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi81ODk"
  # entity_type    = "GLOBAL"
  name           = "Page The On Call"
  owner          = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  published      = false
}
```

### Create a Trigger Definition (without optional `entity_type` field, defaults to `SERVICE`). `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_trigger_definition.example will be created
  + resource "opslevel_trigger_definition" "example" {
      + access_control = "everyone"
      + action         = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi81ODk"
      + entity_type    = (known after apply)
      + id             = (known after apply)
      + name           = "Page The On Call"
      + owner          = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + published      = false
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_trigger_definition.example: Creating...
opslevel_trigger_definition.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Update the Terraform config, set `entity_type`
```tf
resource "opslevel_trigger_definition" "example" {
  access_control = "everyone"
  action         = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi81ODk"
  entity_type    = "GLOBAL"
  name           = "Page The On Call"
  owner          = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  published      = false
}
```

### Update the Trigger Definition's `entity_type`. `terraform apply`
```tf
opslevel_trigger_definition.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_trigger_definition.example will be updated in-place
  ~ resource "opslevel_trigger_definition" "example" {
      ~ entity_type    = "SERVICE" -> "GLOBAL"
        id             = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3"
        name           = "Page The On Call"
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_trigger_definition.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3]
opslevel_trigger_definition.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Update Terraform config to omit `entity_type`
```tf
resource "opslevel_trigger_definition" "example" {
  access_control = "everyone"
  action         = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi81ODk"
  # entity_type    = "GLOBAL"
  name      = "Page The On Call"
  owner     = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  published = false
}
```

### Running `terraform plan` shows no changes
```tf
opslevel_trigger_definition.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

### Destroy Trigger Definition. `terraform destroy`
```tf
opslevel_trigger_definition.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_trigger_definition.example will be destroyed
  - resource "opslevel_trigger_definition" "example" {
      - access_control = "everyone" -> null
      - action         = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6V2ViaG9va0FjdGlvbi81ODk" -> null
      - entity_type    = "GLOBAL" -> null
      - id             = "Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3" -> null
      - name           = "Page The On Call" -> null
      - owner          = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
      - published      = false -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_trigger_definition.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ3VzdG9tQWN0aW9uczo6VHJpZ2dlckRlZmluaXRpb24vNTE3]
opslevel_trigger_definition.example: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```