### PR TITLE
update predicate validation, fix tests, one API fix

### DIFF
--- a/.changes/unreleased/Bugfix-20240604-112057.yaml
+++ b/.changes/unreleased/Bugfix-20240604-112057.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: enforce opslevel_check_repository_search.file_extensions is null or non-empty
+  to match API
+time: 2024-06-04T11:20:57.520063-05:00

--- a/.changes/unreleased/Refactor-20240604-112724.yaml
+++ b/.changes/unreleased/Refactor-20240604-112724.yaml
@@ -1,0 +1,4 @@
+kind: Refactor
+body: convert opslevel_check_repository_search.file_extensions to set type from list
+  type
+time: 2024-06-04T11:27:24.309038-05:00

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -104,7 +104,9 @@ func (r *CheckAlertSourceUsageResource) Schema(ctx context.Context, req resource
 func (r *CheckAlertSourceUsageResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckAlertSourceUsageResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() || configModel.AlertNamePredicate == nil {
+	if resp.Diagnostics.HasError() ||
+		configModel.AlertNamePredicate == nil ||
+		configModel.AlertNamePredicate.Type.IsUnknown() {
 		return
 	}
 	if err := configModel.AlertNamePredicate.Validate(); err != nil {

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -112,7 +112,9 @@ func (r *CheckRepositoryFileResource) Schema(ctx context.Context, req resource.S
 func (r *CheckRepositoryFileResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckRepositoryFileResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() || configModel.FileContentsPredicate == nil {
+	if resp.Diagnostics.HasError() ||
+		configModel.FileContentsPredicate == nil ||
+		configModel.FileContentsPredicate.Type.IsUnknown() {
 		return
 	}
 	if err := configModel.FileContentsPredicate.Validate(); err != nil {

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -108,7 +108,7 @@ func (r *CheckRepositoryGrepResource) Schema(ctx context.Context, req resource.S
 func (r *CheckRepositoryGrepResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckRepositoryGrepResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() {
+	if resp.Diagnostics.HasError() || configModel.FileContentsPredicate.Type.IsUnknown() {
 		return
 	}
 	if err := configModel.FileContentsPredicate.Validate(); err != nil {

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -125,7 +125,9 @@ func (r *CheckServiceOwnershipResource) Schema(ctx context.Context, req resource
 func (r *CheckServiceOwnershipResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckServiceOwnershipResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() || configModel.TagPredicate == nil {
+	if resp.Diagnostics.HasError() ||
+		configModel.TagPredicate == nil ||
+		configModel.TagPredicate.Type.IsUnknown() {
 		return
 	}
 	if err := configModel.TagPredicate.Validate(); err != nil {

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -106,7 +106,9 @@ func (r *CheckServicePropertyResource) Schema(ctx context.Context, req resource.
 func (r *CheckServicePropertyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckServicePropertyResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() || configModel.Predicate == nil {
+	if resp.Diagnostics.HasError() ||
+		configModel.Predicate == nil ||
+		configModel.Predicate.Type.IsUnknown() {
 		return
 	}
 	if err := configModel.Predicate.Validate(); err != nil {

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -97,7 +97,9 @@ func (r *CheckTagDefinedResource) Schema(ctx context.Context, req resource.Schem
 func (r *CheckTagDefinedResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckTagDefinedResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() || configModel.TagPredicate == nil {
+	if resp.Diagnostics.HasError() ||
+		configModel.TagPredicate == nil ||
+		configModel.TagPredicate.Type.IsUnknown() {
 		return
 	}
 	if err := configModel.TagPredicate.Validate(); err != nil {

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -118,17 +118,17 @@ func (r *CheckToolUsageResource) ValidateConfig(ctx context.Context, req resourc
 		return
 	}
 
-	if configModel.EnvironmentPredicate != nil {
+	if configModel.EnvironmentPredicate != nil && !configModel.EnvironmentPredicate.Type.IsUnknown() {
 		if err := configModel.EnvironmentPredicate.Validate(); err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
 	}
-	if configModel.ToolNamePredicate != nil {
+	if configModel.ToolNamePredicate != nil && !configModel.ToolNamePredicate.Type.IsUnknown() {
 		if err := configModel.ToolNamePredicate.Validate(); err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
 	}
-	if configModel.ToolUrlPredicate != nil {
+	if configModel.ToolUrlPredicate != nil && !configModel.ToolUrlPredicate.Type.IsUnknown() {
 		if err := configModel.ToolUrlPredicate.Validate(); err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
 		}

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -68,11 +68,10 @@ func newServiceResourceModel(ctx context.Context, service opslevel.Service, give
 	if len(service.ManagedAliases) == 0 && givenModel.Aliases.IsNull() {
 		serviceResourceModel.Aliases = types.SetNull(types.StringType)
 	} else {
-		aliases, diags := types.SetValueFrom(ctx, types.StringType, service.ManagedAliases)
+		serviceResourceModel.Aliases, diags = types.SetValueFrom(ctx, types.StringType, service.ManagedAliases)
 		if diags != nil && diags.HasError() {
 			return ServiceResourceModel{}, diags
 		}
-		serviceResourceModel.Aliases = aliases
 	}
 
 	if givenModel.Tags.IsNull() && (service.Tags != nil || len(service.Tags.Nodes) == 0) {

--- a/tests/local/resource_repository_search.tftest.hcl
+++ b/tests/local/resource_repository_search.tftest.hcl
@@ -14,7 +14,7 @@ run "resource_check_repository_search" {
   }
 
   assert {
-    condition     = opslevel_check_repository_search.example.file_extensions == tolist(["sbt", "py"])
+    condition     = opslevel_check_repository_search.example.file_extensions == toset(["sbt", "py"])
     error_message = "wrong value for file_extensions in opslevel_check_repository_search.example"
   }
 

--- a/tests/remote/check_alert_source_usage.tftest.hcl
+++ b/tests/remote/check_alert_source_usage.tftest.hcl
@@ -6,7 +6,10 @@ variables {
   alert_type = "datadog"
 
   # optional fields
-  alert_name_predicate = null
+  alert_name_predicate = {
+    type  = "exists"
+    value = null
+  }
 
   # -- check base fields --
   # required fields
@@ -79,14 +82,16 @@ run "from_team_get_owner_id" {
 run "resource_check_alert_source_usage_create_with_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    alert_type           = var.alert_type
+    alert_name_predicate = var.alert_name_predicate
+    category             = run.from_rubric_category_get_category_id.first_category.id
+    enable_on            = var.enable_on
+    enabled              = var.enabled
+    filter               = run.from_filter_get_filter_id.first_filter.id
+    level                = run.from_rubric_level_get_level_id.greatest_level.id
+    name                 = var.name
+    notes                = var.notes
+    owner                = run.from_team_get_owner_id.first_team.id
   }
 
   module {
@@ -159,13 +164,14 @@ run "resource_check_alert_source_usage_create_with_all_fields" {
 run "resource_check_alert_source_usage_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
+    # alert_name_predicate = null
+    category             = run.from_rubric_category_get_category_id.first_category.id
+    enable_on            = null
+    enabled              = null
+    filter               = null
+    level                = run.from_rubric_level_get_level_id.greatest_level.id
+    notes                = null
+    owner                = null
   }
 
   module {
@@ -203,14 +209,16 @@ run "resource_check_alert_source_usage_update_unset_optional_fields" {
 run "resource_check_alert_source_usage_update_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    alert_type           = var.alert_type
+    alert_name_predicate = var.alert_name_predicate
+    category             = run.from_rubric_category_get_category_id.first_category.id
+    enable_on            = var.enable_on
+    enabled              = var.enabled
+    filter               = run.from_filter_get_filter_id.first_filter.id
+    level                = run.from_rubric_level_get_level_id.greatest_level.id
+    name                 = var.name
+    notes                = var.notes
+    owner                = run.from_team_get_owner_id.first_team.id
   }
 
   module {

--- a/tests/remote/check_alert_source_usage.tftest.hcl
+++ b/tests/remote/check_alert_source_usage.tftest.hcl
@@ -165,13 +165,13 @@ run "resource_check_alert_source_usage_update_unset_optional_fields" {
 
   variables {
     # alert_name_predicate = null
-    category             = run.from_rubric_category_get_category_id.first_category.id
-    enable_on            = null
-    enabled              = null
-    filter               = null
-    level                = run.from_rubric_level_get_level_id.greatest_level.id
-    notes                = null
-    owner                = null
+    category  = run.from_rubric_category_get_category_id.first_category.id
+    enable_on = null
+    enabled   = null
+    filter    = null
+    level     = run.from_rubric_level_get_level_id.greatest_level.id
+    notes     = null
+    owner     = null
   }
 
   module {

--- a/tests/remote/check_alert_source_usage/main.tf
+++ b/tests/remote/check_alert_source_usage/main.tf
@@ -1,6 +1,9 @@
 resource "opslevel_check_alert_source_usage" "test" {
-  alert_name_predicate = var.alert_name_predicate
-  alert_type           = var.alert_type
+  alert_name_predicate = {
+    type  = var.alert_name_predicate.type
+    value = var.alert_name_predicate.value
+  }
+  alert_type = var.alert_type
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_alert_source_usage/variables.tf
+++ b/tests/remote/check_alert_source_usage/variables.tf
@@ -1,32 +1,9 @@
 variable "alert_name_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = var.alert_name_predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.alert_name_predicate.type)
-    error_message = "invalid predicate type for alert_name_predicate.type"
-  }
 }
 
 variable "alert_type" {

--- a/tests/remote/check_repository_file.tftest.hcl
+++ b/tests/remote/check_repository_file.tftest.hcl
@@ -165,14 +165,14 @@ run "resource_check_repository_file_create_with_all_fields" {
 run "resource_check_repository_file_update_unset_optional_fields" {
 
   variables {
-    category                = run.from_rubric_category_get_category_id.first_category.id
-    enable_on               = null
-    enabled                 = null
+    category  = run.from_rubric_category_get_category_id.first_category.id
+    enable_on = null
+    enabled   = null
     # file_contents_predicate = null
-    filter                  = null
-    level                   = run.from_rubric_level_get_level_id.greatest_level.id
-    notes                   = null
-    owner                   = null
+    filter = null
+    level  = run.from_rubric_level_get_level_id.greatest_level.id
+    notes  = null
+    owner  = null
   }
 
   module {

--- a/tests/remote/check_repository_file.tftest.hcl
+++ b/tests/remote/check_repository_file.tftest.hcl
@@ -8,7 +8,10 @@ variables {
   use_absolute_root = true
 
   # optional fields
-  file_contents_predicate = null
+  file_contents_predicate = {
+    type  = "exists"
+    value = null
+  }
 
   # -- check base fields --
   # required fields
@@ -81,14 +84,15 @@ run "from_team_get_owner_id" {
 run "resource_check_repository_file_create_with_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = var.enable_on
+    enabled                 = var.enabled
+    file_contents_predicate = var.file_contents_predicate
+    filter                  = run.from_filter_get_filter_id.first_filter.id
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    name                    = var.name
+    notes                   = var.notes
+    owner                   = run.from_team_get_owner_id.first_team.id
   }
 
   module {
@@ -161,13 +165,14 @@ run "resource_check_repository_file_create_with_all_fields" {
 run "resource_check_repository_file_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = null
+    enabled                 = null
+    # file_contents_predicate = null
+    filter                  = null
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    notes                   = null
+    owner                   = null
   }
 
   module {
@@ -205,14 +210,15 @@ run "resource_check_repository_file_update_unset_optional_fields" {
 run "resource_check_repository_file_update_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = var.enable_on
+    enabled                 = var.enabled
+    file_contents_predicate = var.file_contents_predicate
+    filter                  = run.from_filter_get_filter_id.first_filter.id
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    name                    = var.name
+    notes                   = var.notes
+    owner                   = run.from_team_get_owner_id.first_team.id
   }
 
   module {

--- a/tests/remote/check_repository_file/main.tf
+++ b/tests/remote/check_repository_file/main.tf
@@ -1,8 +1,11 @@
 resource "opslevel_check_repository_file" "test" {
-  directory_search        = var.directory_search
-  file_contents_predicate = var.file_contents_predicate
-  filepaths               = var.filepaths
-  use_absolute_root       = var.use_absolute_root
+  directory_search = var.directory_search
+  file_contents_predicate = {
+    type  = var.file_contents_predicate.type
+    value = var.file_contents_predicate.value
+  }
+  filepaths         = var.filepaths
+  use_absolute_root = var.use_absolute_root
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_repository_file/variables.tf
+++ b/tests/remote/check_repository_file/variables.tf
@@ -6,32 +6,8 @@ variable "directory_search" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string)
   })
-
-  validation {
-    condition = var.file_contents_predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.file_contents_predicate.type)
-    error_message = "invalid predicate type for file_contents_predicate.type"
-  }
-
   description = "A condition that should be satisfied."
 }
 

--- a/tests/remote/check_repository_grep/main.tf
+++ b/tests/remote/check_repository_grep/main.tf
@@ -1,7 +1,10 @@
 resource "opslevel_check_repository_grep" "test" {
-  directory_search        = var.directory_search
-  file_contents_predicate = var.file_contents_predicate
-  filepaths               = var.filepaths
+  directory_search = var.directory_search
+  file_contents_predicate = {
+    type  = var.file_contents_predicate.type
+    value = var.file_contents_predicate.value
+  }
+  filepaths = var.filepaths
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_repository_grep/variables.tf
+++ b/tests/remote/check_repository_grep/variables.tf
@@ -6,32 +6,9 @@ variable "directory_search" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.file_contents_predicate.type)
-    error_message = "invalid predicate type for file_contents_predicate.type"
-  }
 }
 
 variable "filepaths" {

--- a/tests/remote/check_repository_search.tftest.hcl
+++ b/tests/remote/check_repository_search.tftest.hcl
@@ -4,10 +4,12 @@ variables {
   # -- check_repository_search fields --
   # required fields
   file_contents_predicate = {
-    type  = "does_not_exist",
+    type  = "does_not_contain",
     value = "something_unlikely.txt",
   }
-  file_extensions = tolist([])
+
+  # optional fields
+  file_extensions = toset(["go", "py", "rs"])
 
   # -- check base fields --
   # required fields
@@ -80,14 +82,16 @@ run "from_team_get_owner_id" {
 run "resource_check_repository_search_create_with_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = var.enable_on
+    enabled                 = var.enabled
+    file_contents_predicate = var.file_contents_predicate
+    file_extensions         = var.file_extensions
+    filter                  = run.from_filter_get_filter_id.first_filter.id
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    name                    = var.name
+    notes                   = var.notes
+    owner                   = run.from_team_get_owner_id.first_team.id
   }
 
   module {
@@ -100,6 +104,7 @@ run "resource_check_repository_search_create_with_all_fields" {
       can(opslevel_check_repository_search.test.description),
       can(opslevel_check_repository_search.test.enable_on),
       can(opslevel_check_repository_search.test.enabled),
+      can(opslevel_check_repository_search.test.file_extensions),
       can(opslevel_check_repository_search.test.filter),
       can(opslevel_check_repository_search.test.id),
       can(opslevel_check_repository_search.test.level),
@@ -128,6 +133,11 @@ run "resource_check_repository_search_create_with_all_fields" {
   assert {
     condition     = startswith(opslevel_check_repository_search.test.id, var.id_prefix)
     error_message = replace(var.error_wrong_id, "TYPE", var.check_repository_search)
+  }
+
+  assert {
+    condition     = opslevel_check_repository_search.test.file_extensions == var.file_extensions
+    error_message = "wrong file_extensions of opslevel_check_repository_search resource"
   }
 
   assert {
@@ -160,13 +170,14 @@ run "resource_check_repository_search_create_with_all_fields" {
 run "resource_check_repository_search_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
+    category        = run.from_rubric_category_get_category_id.first_category.id
+    enable_on       = null
+    enabled         = null
+    filter          = null
+    file_extensions = null
+    level           = run.from_rubric_level_get_level_id.greatest_level.id
+    notes           = null
+    owner           = null
   }
 
   module {
@@ -181,6 +192,11 @@ run "resource_check_repository_search_update_unset_optional_fields" {
   assert {
     condition     = opslevel_check_repository_search.test.enabled == false
     error_message = "expected 'false' default for 'enabled' in opslevel_check_repository_search resource"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_search.test.file_extensions == null
+    error_message = var.error_expected_null_field
   }
 
   assert {
@@ -204,14 +220,16 @@ run "resource_check_repository_search_update_unset_optional_fields" {
 run "resource_check_repository_search_update_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = !var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = var.enable_on
+    enabled                 = var.enabled
+    file_contents_predicate = var.file_contents_predicate
+    file_extensions         = setunion(var.file_extensions, ["yaml"])
+    filter                  = run.from_filter_get_filter_id.first_filter.id
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    name                    = var.name
+    notes                   = var.notes
+    owner                   = run.from_team_get_owner_id.first_team.id
   }
 
   module {
@@ -229,8 +247,13 @@ run "resource_check_repository_search_update_all_fields" {
   }
 
   assert {
-    condition     = opslevel_check_repository_search.test.enabled == !var.enabled
+    condition     = opslevel_check_repository_search.test.enabled == var.enabled
     error_message = "wrong enabled of opslevel_check_repository_search resource"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_search.test.file_extensions == var.file_extensions
+    error_message = "wrong file_extensions of opslevel_check_repository_search resource"
   }
 
   assert {

--- a/tests/remote/check_repository_search/main.tf
+++ b/tests/remote/check_repository_search/main.tf
@@ -1,6 +1,9 @@
 resource "opslevel_check_repository_search" "test" {
-  file_contents_predicate = var.file_contents_predicate
-  file_extensions         = var.file_extensions
+  file_contents_predicate = {
+    type  = var.file_contents_predicate.type
+    value = var.file_contents_predicate.value
+  }
+  file_extensions = var.file_extensions
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_repository_search/variables.tf
+++ b/tests/remote/check_repository_search/variables.tf
@@ -1,35 +1,12 @@
 variable "file_extensions" {
-  type        = list(string)
+  type        = set(string)
   description = "Restrict the search to files of given extensions. Extensions should contain only letters and numbers. For example: [\"py\", \"rb\"]."
 }
 
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.file_contents_predicate.type)
-    error_message = "invalid predicate type for file_contents_predicate.type"
-  }
 }

--- a/tests/remote/check_service_ownership.tftest.hcl
+++ b/tests/remote/check_service_ownership.tftest.hcl
@@ -163,13 +163,13 @@ run "resource_check_service_ownership_create_with_all_fields" {
 run "resource_check_service_ownership_update_unset_optional_fields" {
 
   variables {
-    category      = run.from_rubric_category_get_category_id.first_category.id
-    enable_on     = null
-    enabled       = null
-    filter        = null
-    level         = run.from_rubric_level_get_level_id.greatest_level.id
-    notes         = null
-    owner         = null
+    category  = run.from_rubric_category_get_category_id.first_category.id
+    enable_on = null
+    enabled   = null
+    filter    = null
+    level     = run.from_rubric_level_get_level_id.greatest_level.id
+    notes     = null
+    owner     = null
     # tag_predicate = null
   }
 

--- a/tests/remote/check_service_ownership.tftest.hcl
+++ b/tests/remote/check_service_ownership.tftest.hcl
@@ -6,7 +6,10 @@ variables {
   contact_method         = "any"
   require_contact_method = true
   tag_key                = "test-tag-key"
-  tag_predicate          = null
+  tag_predicate = {
+    type  = "does_not_match_regex"
+    value = "abckjasldkfj"
+  }
 
   # -- check base fields --
   # required fields
@@ -79,14 +82,15 @@ run "from_team_get_owner_id" {
 run "resource_check_service_ownership_create_with_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = var.enable_on
+    enabled       = var.enabled
+    filter        = run.from_filter_get_filter_id.first_filter.id
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    name          = var.name
+    notes         = var.notes
+    owner         = run.from_team_get_owner_id.first_team.id
+    tag_predicate = var.tag_predicate
   }
 
   module {
@@ -159,13 +163,14 @@ run "resource_check_service_ownership_create_with_all_fields" {
 run "resource_check_service_ownership_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = null
+    enabled       = null
+    filter        = null
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    notes         = null
+    owner         = null
+    # tag_predicate = null
   }
 
   module {
@@ -203,14 +208,15 @@ run "resource_check_service_ownership_update_unset_optional_fields" {
 run "resource_check_service_ownership_update_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = var.enable_on
+    enabled       = var.enabled
+    filter        = run.from_filter_get_filter_id.first_filter.id
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    name          = var.name
+    notes         = var.notes
+    owner         = run.from_team_get_owner_id.first_team.id
+    tag_predicate = var.tag_predicate
   }
 
   module {

--- a/tests/remote/check_service_ownership/main.tf
+++ b/tests/remote/check_service_ownership/main.tf
@@ -2,7 +2,10 @@ resource "opslevel_check_service_ownership" "test" {
   contact_method         = var.contact_method
   require_contact_method = var.require_contact_method
   tag_key                = var.tag_key
-  tag_predicate          = var.tag_predicate
+  tag_predicate = {
+    type  = var.tag_predicate.type
+    value = var.tag_predicate.value
+  }
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_service_ownership/variables.tf
+++ b/tests/remote/check_service_ownership/variables.tf
@@ -28,30 +28,7 @@ variable "tag_key" {
 variable "tag_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = var.tag_predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.tag_predicate.type)
-    error_message = "invalid predicate type for tag_predicate.type"
-  }
 }

--- a/tests/remote/check_service_property.tftest.hcl
+++ b/tests/remote/check_service_property.tftest.hcl
@@ -6,7 +6,10 @@ variables {
   property = "lifecycle_index"
 
   # optional fields
-  predicate = null
+  predicate = {
+    type  = "exists"
+    value = null
+  }
 
   # -- check base fields --
   # required fields
@@ -87,6 +90,7 @@ run "resource_check_service_property_create_with_all_fields" {
     name      = var.name
     notes     = var.notes
     owner     = run.from_team_get_owner_id.first_team.id
+    predicate = var.predicate
   }
 
   module {
@@ -166,6 +170,7 @@ run "resource_check_service_property_update_unset_optional_fields" {
     level     = run.from_rubric_level_get_level_id.greatest_level.id
     notes     = null
     owner     = null
+    # predicate = null
   }
 
   module {
@@ -211,6 +216,7 @@ run "resource_check_service_property_update_all_fields" {
     name      = var.name
     notes     = var.notes
     owner     = run.from_team_get_owner_id.first_team.id
+    predicate = var.predicate
   }
 
   module {

--- a/tests/remote/check_service_property/main.tf
+++ b/tests/remote/check_service_property/main.tf
@@ -1,6 +1,9 @@
 resource "opslevel_check_service_property" "test" {
-  property  = var.property
-  predicate = var.predicate
+  property = var.property
+  predicate = {
+    type  = var.predicate.type
+    value = var.predicate.value
+  }
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_service_property/variables.tf
+++ b/tests/remote/check_service_property/variables.tf
@@ -22,30 +22,7 @@ variable "property" {
 variable "predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = var.predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.predicate.type)
-    error_message = "invalid predicate type for predicate.type"
-  }
 }

--- a/tests/remote/check_tag_defined.tftest.hcl
+++ b/tests/remote/check_tag_defined.tftest.hcl
@@ -6,7 +6,10 @@ variables {
   tag_key = "test-tag-key"
 
   # optional fields
-  tag_predicate = null
+  tag_predicate = {
+    type  = "exists"
+    value = null
+  }
 
   # -- check base fields --
   # required fields
@@ -79,14 +82,15 @@ run "from_team_get_owner_id" {
 run "resource_check_tag_defined_create_with_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = var.enable_on
+    enabled       = var.enabled
+    filter        = run.from_filter_get_filter_id.first_filter.id
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    name          = var.name
+    notes         = var.notes
+    owner         = run.from_team_get_owner_id.first_team.id
+    tag_predicate = var.tag_predicate
   }
 
   module {
@@ -159,13 +163,14 @@ run "resource_check_tag_defined_create_with_all_fields" {
 run "resource_check_tag_defined_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = null
+    enabled       = null
+    filter        = null
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    notes         = null
+    owner         = null
+    # tag_predicate = null
   }
 
   module {
@@ -203,14 +208,15 @@ run "resource_check_tag_defined_update_unset_optional_fields" {
 run "resource_check_tag_defined_update_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = var.enable_on
+    enabled       = var.enabled
+    filter        = run.from_filter_get_filter_id.first_filter.id
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    name          = var.name
+    notes         = var.notes
+    owner         = run.from_team_get_owner_id.first_team.id
+    tag_predicate = var.tag_predicate
   }
 
   module {

--- a/tests/remote/check_tag_defined.tftest.hcl
+++ b/tests/remote/check_tag_defined.tftest.hcl
@@ -163,13 +163,13 @@ run "resource_check_tag_defined_create_with_all_fields" {
 run "resource_check_tag_defined_update_unset_optional_fields" {
 
   variables {
-    category      = run.from_rubric_category_get_category_id.first_category.id
-    enable_on     = null
-    enabled       = null
-    filter        = null
-    level         = run.from_rubric_level_get_level_id.greatest_level.id
-    notes         = null
-    owner         = null
+    category  = run.from_rubric_category_get_category_id.first_category.id
+    enable_on = null
+    enabled   = null
+    filter    = null
+    level     = run.from_rubric_level_get_level_id.greatest_level.id
+    notes     = null
+    owner     = null
     # tag_predicate = null
   }
 

--- a/tests/remote/check_tag_defined/main.tf
+++ b/tests/remote/check_tag_defined/main.tf
@@ -1,6 +1,9 @@
 resource "opslevel_check_tag_defined" "test" {
-  tag_key       = var.tag_key
-  tag_predicate = var.tag_predicate
+  tag_key = var.tag_key
+  tag_predicate = {
+    type  = var.tag_predicate.type
+    value = var.tag_predicate.value
+  }
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_tag_defined/variables.tf
+++ b/tests/remote/check_tag_defined/variables.tf
@@ -6,30 +6,7 @@ variable "tag_key" {
 variable "tag_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = var.tag_predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.tag_predicate.type)
-    error_message = "invalid predicate type for tag_predicate.type"
-  }
 }

--- a/tests/remote/check_tool_usage.tftest.hcl
+++ b/tests/remote/check_tool_usage.tftest.hcl
@@ -6,9 +6,18 @@ variables {
   tool_category = "api_documentation"
 
   # optional fields
-  tool_name_predicate   = null
-  tool_url_predicate    = null
-  environment_predicate = null
+  environment_predicate = {
+    type  = "exists"
+    value = null
+  }
+  tool_name_predicate = {
+    type  = "exists"
+    value = null
+  }
+  tool_url_predicate = {
+    type  = "exists"
+    value = null
+  }
 
   # -- check base fields --
   # required fields
@@ -81,14 +90,17 @@ run "from_team_get_owner_id" {
 run "resource_check_tool_usage_create_with_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category              = run.from_rubric_category_get_category_id.first_category.id
+    enable_on             = var.enable_on
+    enabled               = var.enabled
+    environment_predicate = var.environment_predicate
+    filter                = run.from_filter_get_filter_id.first_filter.id
+    level                 = run.from_rubric_level_get_level_id.greatest_level.id
+    name                  = var.name
+    notes                 = var.notes
+    owner                 = run.from_team_get_owner_id.first_team.id
+    tool_name_predicate   = var.tool_name_predicate
+    tool_url_predicate    = var.tool_url_predicate
   }
 
   module {
@@ -205,14 +217,17 @@ run "resource_check_tool_usage_update_unset_optional_fields" {
 run "resource_check_tool_usage_update_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category              = run.from_rubric_category_get_category_id.first_category.id
+    enable_on             = var.enable_on
+    enabled               = var.enabled
+    environment_predicate = var.environment_predicate
+    filter                = run.from_filter_get_filter_id.first_filter.id
+    level                 = run.from_rubric_level_get_level_id.greatest_level.id
+    name                  = var.name
+    notes                 = var.notes
+    owner                 = run.from_team_get_owner_id.first_team.id
+    tool_name_predicate   = var.tool_name_predicate
+    tool_url_predicate    = var.tool_url_predicate
   }
 
   module {

--- a/tests/remote/check_tool_usage/main.tf
+++ b/tests/remote/check_tool_usage/main.tf
@@ -1,5 +1,18 @@
 resource "opslevel_check_tool_usage" "test" {
   tool_category = var.tool_category
+  environment_predicate = {
+    type  = var.environment_predicate.type
+    value = var.environment_predicate.value
+  }
+  tool_name_predicate = {
+    type  = var.tool_name_predicate.type
+    value = var.tool_name_predicate.value
+  }
+  tool_url_predicate = {
+    type  = var.tool_url_predicate.type
+    value = var.tool_url_predicate.value
+  }
+
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_tool_usage/variables.tf
+++ b/tests/remote/check_tool_usage/variables.tf
@@ -4,63 +4,11 @@ variable "environment_predicate" {
     value = string
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = var.environment_predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.environment_predicate.type)
-    error_message = "invalid predicate type for environment_predicate.type"
-  }
 }
 
 variable "tool_category" {
   type        = string
   description = "The category that the tool belongs to."
-
-  validation {
-    condition = var.tool_category == null ? true : contains([
-      "admin",
-      "api_documentation",
-      "architecture_diagram",
-      "backlog",
-      "code",
-      "continuous_integration",
-      "deployment",
-      "design_documentation",
-      "errors",
-      "feature_flag",
-      "health_checks",
-      "incidents",
-      "issue_tracking",
-      "logs",
-      "metrics",
-      "observability",
-      "orchestrator",
-      "other",
-      "resiliency",
-      "runbooks",
-      "security_scans",
-      "status_page",
-      "wiki",
-    ], var.tool_category)
-    error_message = "expected level to be a valid ID starting with 'Z2lkOi8v'"
-  }
 }
 
 variable "tool_name_predicate" {
@@ -69,29 +17,6 @@ variable "tool_name_predicate" {
     value = string
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = var.tool_name_predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.tool_name_predicate.type)
-    error_message = "invalid predicate type for tool_name_predicate.type"
-  }
 }
 
 variable "tool_url_predicate" {
@@ -100,27 +25,4 @@ variable "tool_url_predicate" {
     value = string
   })
   description = "A condition that should be satisfied."
-
-  validation {
-    condition = var.tool_url_predicate == null ? true : contains([
-      "contains",
-      "does_not_contain",
-      "does_not_equal",
-      "does_not_exist",
-      "ends_with",
-      "equals",
-      "exists",
-      "greater_than_or_equal_to",
-      "less_than_or_equal_to",
-      "starts_with",
-      "satisfies_version_constraint",
-      "matches_regex",
-      "does_not_match_regex",
-      "belongs_to",
-      "matches",
-      "does_not_match",
-      "satisfies_jq_expression",
-    ], var.tool_url_predicate.type)
-    error_message = "invalid predicate type for tool_url_predicate.type"
-  }
 }

--- a/tests/remote/filter/variables.tf
+++ b/tests/remote/filter/variables.tf
@@ -11,7 +11,6 @@ variable "connective" {
   }
 }
 
-# WIP
 variable "predicate_list" {
   type = list(object({
     case_insensitive = optional(bool)
@@ -23,62 +22,6 @@ variable "predicate_list" {
   }))
   default = []
 }
-
-#variable "predicate" {
-#  type = object({
-#    case_insensitive = optional(bool)
-#    case_sensitive   = optional(bool)
-#    key              = string
-#    key_data         = optional(string)
-#    type             = string
-#    value            = optional(string)
-#  })
-#  description = "The filter's predicate."
-#
-#  validation {
-#    condition = alltrue(
-#      contains([
-#        "aliases",
-#        "creation_source",
-#        "domain_id",
-#        "filter_id",
-#        "framework",
-#        "group_ids",
-#        "language",
-#        "lifecycle_index",
-#        "name",
-#        "owner_id",
-#        "owner_ids",
-#        "product",
-#        "properties",
-#        "repository_ids",
-#        "system_id",
-#        "tags",
-#        "tier_index",
-#      ], var.predicate.key),
-#      contains([
-#        "belongs_to",
-#        "contains",
-#        "does_not_contain",
-#        "does_not_equal",
-#        "does_not_exist",
-#        "does_not_match",
-#        "does_not_match_regex",
-#        "ends_with",
-#        "equals",
-#        "exists",
-#        "greater_than_or_equal_to",
-#        "less_than_or_equal_to",
-#        "matches",
-#        "matches_regex",
-#        "satisfies_jq_expression",
-#        "satisfies_version_constraint",
-#        "starts_with",
-#      ], var.predicate.type),
-#    )
-#    error_message = "invalid predicate key or type given"
-#  }
-#}
 
 variable "name" {
   type        = string


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Add `<Predicate>.IsUnknown()` to config validation of predicates. This is needed for input variables are used to set predicates as we do in integration testing. 
Converted `opslevel_check_repository_search.file_extensions` from list type to set type, added a validator to enforce non-empty sets on this field to match the API.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

`task test-integration`
