### PR TITLE
Db/patch api token provider arg

### DIFF
--- a/.changes/unreleased/Bugfix-20240606-112819.yaml
+++ b/.changes/unreleased/Bugfix-20240606-112819.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: provider arg 'api_token' is optional, defaults to env var token instead of raising
+  error
+time: 2024-06-06T11:28:19.279859-05:00

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -40,7 +40,7 @@ func (p *OpslevelProvider) Schema(ctx context.Context, req provider.SchemaReques
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"api_token": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "The API authorization token. It can also be sourced from the OPSLEVEL_API_TOKEN environment variable.",
 				Sensitive:   true,
 			},


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Terraform configs
```tf
# backend.tf
terraform {
  required_providers {
    opslevel = {
      source  = "OpsLevel/opslevel"
      version = "> 0.0.1"
    }
  }
}

# no args provided to provider block, env var set
provider "opslevel" {}
```
and
```tf
# main.tf
data "opslevel_domain" "example" {
  identifier = "sample_web"
}

output "example" {
  value = data.opslevel_domain.example
}
```

### Run `terraform plan`, env var `OPSLEVEL_API_TOKEN` is set
```tf
data.opslevel_domain.example: Reading...
data.opslevel_domain.example: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzEwOTk2NjU]

Changes to Outputs:
  + example = {
      + aliases     = [
          + "sample_web",
        ]
      + description = null
      + id          = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzEwOTk2NjU"
      + identifier  = "sample_web"
      + name        = "(Sample) Web"
      + owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDQwNg"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```

### Unset env var `OPSLEVEL_API_TOKEN`, then run `terraform plan`
```bash
OPSLEVEL_API_TOKEN=
terraform plan
```
Output:
```tf
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Provider Config Error
│ 
│   with provider["registry.terraform.io/opslevel/opslevel"],
│   on backend.tf line 10, in provider "opslevel":
│   10: provider "opslevel" {}
│ 
│ An OPSLEVEL_API_TOKEN is needed to authenticate with the opslevel client. This can be set as an 'OPSLEVEL_API_TOKEN' environment variable or in the provider configuration block as 'api_token'.

```

### `OPSLEVEL_API_TOKEN` still unset, provided as env arg
```bash
export TMP_TOKEN=the-api-token-value
TF_VAR_OPSLEVEL_API_TOKEN=$TMP_TOKEN terraform plan
```
output
```tf
data.opslevel_domain.example: Reading...
data.opslevel_domain.example: Read complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzEwOTk2NjU]

Changes to Outputs:
  + example = {
      + aliases     = [
          + "sample_web",
        ]
      + description = null
      + id          = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzEwOTk2NjU"
      + identifier  = "sample_web"
      + name        = "(Sample) Web"
      + owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDQwNg"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```

## Update configs to take input variable
```tf
terraform {
  required_providers {
    opslevel = {
      source  = "OpsLevel/opslevel"
      version = "> 0.0.1"
    }
  }
}

provider "opslevel" {
  api_token = var.OPSLEVEL_API_TOKEN
}

# no default set, will prompt for value
variable "OPSLEVEL_API_TOKEN" {
  type      = string
  sensitive = true
}
```

### OPSLEVEL_API_TOKEN still unset, `terraform plan`, enter blank value
```tf
var.OPSLEVEL_API_TOKEN
  Enter a value: 

data.opslevel_domain.example: Reading...

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Client Error
│ 
│   with data.opslevel_domain.example,
│   on main.tf line 1, in data "opslevel_domain" "example":
│    1: data "opslevel_domain" "example" {
│ 
│ Unable to read domain, got error: Message: 401 Unauthorized; body: "{\"errors\":[{\"status\":401,\"title\":\"Bad credentials\"}]}", Locations: [], Extensions: map[code:request_error], Path: []
```

### set OPSLEVEL_API_TOKEN env var, `terraform plan`, enter (sourced automatically)
```tf
var.OPSLEVEL_API_TOKEN
  Enter a value: 

data.opslevel_domain.example: Reading...
data.opslevel_domain.example: Read complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzEwOTk2NjU]

Changes to Outputs:
  + example = {
      + aliases     = [
          + "sample_web",
        ]
      + description = null
      + id          = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzEwOTk2NjU"
      + identifier  = "sample_web"
      + name        = "(Sample) Web"
      + owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNDQwNg"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```