### PR TITLE
fix terraform import opslevel_team_tag resources

### DIFF
--- a/.changes/unreleased/Bugfix-20240606-135829.yaml
+++ b/.changes/unreleased/Bugfix-20240606-135829.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: terraform import opslevel_team_tag resources fixed
+time: 2024-06-06T13:58:29.609926-05:00

--- a/opslevel/resource_opslevel_team_tag.go
+++ b/opslevel/resource_opslevel_team_tag.go
@@ -252,7 +252,6 @@ func (teamTagResource *TeamTagResource) ImportState(ctx context.Context, req res
 			fmt.Sprintf("Id expected to be formatted as '<team-id>:<tag-id>'. Given '%s'", req.ID),
 		)
 	}
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 
 	ids := strings.Split(req.ID, ":")
 	teamId := ids[0]


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this config, and empty Terraform state file
```tf
resource "opslevel_team_tag" "team_tag_1" {
  key        = "key2"
  value      = "value"
  team       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  team_alias = "team_platform_3_a"
}
```

### Import `opslevel_team_tag` instance
```bash
terraform import opslevel_team_tag.team_tag_1 'Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA:Z2lkOi8vb3BzbGV2ZWwvVGFnLzgyNjU0OTMw'
```
outputs
```tf
opslevel_team_tag.team_tag_1: Importing from ID "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA:Z2lkOi8vb3BzbGV2ZWwvVGFnLzgyNjU0OTMw"...
opslevel_team_tag.team_tag_1: Import prepared!
  Prepared opslevel_team_tag for import
opslevel_team_tag.team_tag_1: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA:Z2lkOi8vb3BzbGV2ZWwvVGFnLzgyNjU0OTMw]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```