### PR TITLE
convert Predicate types to ObjectValue in opslevel_check_tool_usage

### DIFF
--- a/.changes/unreleased/Bugfix-20240607-084851.yaml
+++ b/.changes/unreleased/Bugfix-20240607-084851.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix Value Conversion Error on Predicates in opslevel_check_tool_usage
+time: 2024-06-07T08:48:51.225834-05:00

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -83,6 +84,11 @@ func CheckBaseAttributes(attrs map[string]schema.Attribute) map[string]schema.At
 type PredicateModel struct {
 	Type  types.String `tfsdk:"type"`
 	Value types.String `tfsdk:"value"`
+}
+
+var predicateType = map[string]attr.Type{
+	"type":  types.StringType,
+	"value": types.StringType,
 }
 
 func NewPredicateModel(predicate opslevel.Predicate) *PredicateModel {

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -298,17 +298,19 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 	}
 
 	input.ToolCategory = opslevel.RefOf(opslevel.ToolCategory(planModel.ToolCategory.ValueString()))
+	nullPredicateModel := PredicateModel{}
 
 	// convert environment_predicate object to model from plan
 	predicateModel, diags := PredicateObjectToModel(ctx, planModel.EnvironmentPredicate)
 	resp.Diagnostics.Append(diags...)
-	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
-		if err := predicateModel.Validate(); err == nil {
-			input.EnvironmentPredicate = predicateModel.ToUpdateInput()
-		} else {
-			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
-		}
+	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
+		input.EnvironmentPredicate = nullPredicateModel.ToUpdateInput()
+	} else if err := predicateModel.Validate(); err == nil {
+		input.EnvironmentPredicate = predicateModel.ToUpdateInput()
+	} else {
+		resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -316,12 +318,12 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 	// convert tool_name_predicate object to model from plan
 	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolNamePredicate)
 	resp.Diagnostics.Append(diags...)
-	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
-		if err := predicateModel.Validate(); err == nil {
-			input.ToolNamePredicate = predicateModel.ToUpdateInput()
-		} else {
-			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
-		}
+	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
+		input.ToolNamePredicate = nullPredicateModel.ToUpdateInput()
+	} else if err := predicateModel.Validate(); err == nil {
+		input.ToolNamePredicate = predicateModel.ToUpdateInput()
+	} else {
+		resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 	if resp.Diagnostics.HasError() {
 		return
@@ -330,12 +332,12 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 	// convert tool_url_predicate object to model from plan
 	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolUrlPredicate)
 	resp.Diagnostics.Append(diags...)
-	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
-		if err := predicateModel.Validate(); err == nil {
-			input.ToolUrlPredicate = predicateModel.ToUpdateInput()
-		} else {
-			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
-		}
+	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
+		input.ToolUrlPredicate = nullPredicateModel.ToUpdateInput()
+	} else if err := predicateModel.Validate(); err == nil {
+		input.ToolUrlPredicate = predicateModel.ToUpdateInput()
+	} else {
+		resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 	if resp.Diagnostics.HasError() {
 		return

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -51,7 +51,6 @@ type CheckToolUsageResourceModel struct {
 }
 
 func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check, planModel CheckToolUsageResourceModel) CheckToolUsageResourceModel {
-	var diags diag.Diagnostics
 	var stateModel CheckToolUsageResourceModel
 
 	stateModel.Category = RequiredStringValue(string(check.Category.Id))
@@ -78,25 +77,34 @@ func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check, p
 	if check.ToolNamePredicate == nil {
 		stateModel.ToolNamePredicate = types.ObjectNull(predicateType)
 	} else {
-		toolNamePredicate, toolNamePredicateDiags := types.ObjectValueFrom(ctx, predicateType, *check.ToolNamePredicate)
-		stateModel.ToolNamePredicate = toolNamePredicate
-		diags.Append(toolNamePredicateDiags...)
+		predicate := *check.ToolNamePredicate
+		predicateAttrValues := map[string]attr.Value{
+			"type":  types.StringValue(string(predicate.Type)),
+			"value": types.StringValue(predicate.Value),
+		}
+		stateModel.ToolNamePredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}
 
 	if check.ToolUrlPredicate == nil {
 		stateModel.ToolUrlPredicate = types.ObjectNull(predicateType)
 	} else {
-		toolUrlPredicate, toolUrlPredicateDiags := types.ObjectValueFrom(ctx, predicateType, *check.ToolUrlPredicate)
-		stateModel.ToolUrlPredicate = toolUrlPredicate
-		diags.Append(toolUrlPredicateDiags...)
+		predicate := *check.ToolUrlPredicate
+		predicateAttrValues := map[string]attr.Value{
+			"type":  types.StringValue(string(predicate.Type)),
+			"value": types.StringValue(predicate.Value),
+		}
+		stateModel.ToolUrlPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}
 
 	if check.EnvironmentPredicate == nil {
-		stateModel.ToolUrlPredicate = types.ObjectNull(predicateType)
+		stateModel.EnvironmentPredicate = types.ObjectNull(predicateType)
 	} else {
-		toolUrlPredicate, environmentPredicateDiags := types.ObjectValueFrom(ctx, predicateType, *check.EnvironmentPredicate)
-		stateModel.EnvironmentPredicate = toolUrlPredicate
-		diags.Append(environmentPredicateDiags...)
+		predicate := *check.EnvironmentPredicate
+		predicateAttrValues := map[string]attr.Value{
+			"type":  types.StringValue(string(predicate.Type)),
+			"value": types.StringValue(predicate.Value),
+		}
+		stateModel.EnvironmentPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}
 
 	return stateModel

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -43,13 +44,14 @@ type CheckToolUsageResourceModel struct {
 	Notes       types.String `tfsdk:"notes"`
 	Owner       types.String `tfsdk:"owner"`
 
-	ToolCategory         types.String    `tfsdk:"tool_category"`
-	ToolNamePredicate    *PredicateModel `tfsdk:"tool_name_predicate"`
-	ToolUrlPredicate     *PredicateModel `tfsdk:"tool_url_predicate"`
-	EnvironmentPredicate *PredicateModel `tfsdk:"environment_predicate"`
+	ToolCategory         types.String `tfsdk:"tool_category"`
+	ToolNamePredicate    types.Object `tfsdk:"tool_name_predicate"`
+	ToolUrlPredicate     types.Object `tfsdk:"tool_url_predicate"`
+	EnvironmentPredicate types.Object `tfsdk:"environment_predicate"`
 }
 
 func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check, planModel CheckToolUsageResourceModel) CheckToolUsageResourceModel {
+	var diags diag.Diagnostics
 	var stateModel CheckToolUsageResourceModel
 
 	stateModel.Category = RequiredStringValue(string(check.Category.Id))
@@ -71,16 +73,30 @@ func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check, p
 	stateModel.Name = RequiredStringValue(check.Name)
 	stateModel.Notes = OptionalStringValue(check.Notes)
 	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
-
 	stateModel.ToolCategory = RequiredStringValue(string(check.ToolCategory))
-	if check.ToolNamePredicate != nil {
-		stateModel.ToolNamePredicate = NewPredicateModel(*check.ToolNamePredicate)
+
+	if check.ToolNamePredicate == nil {
+		stateModel.ToolNamePredicate = types.ObjectNull(predicateType)
+	} else {
+		toolNamePredicate, toolNamePredicateDiags := types.ObjectValueFrom(ctx, predicateType, *check.ToolNamePredicate)
+		stateModel.ToolNamePredicate = toolNamePredicate
+		diags.Append(toolNamePredicateDiags...)
 	}
-	if check.ToolUrlPredicate != nil {
-		stateModel.ToolUrlPredicate = NewPredicateModel(*check.ToolUrlPredicate)
+
+	if check.ToolUrlPredicate == nil {
+		stateModel.ToolUrlPredicate = types.ObjectNull(predicateType)
+	} else {
+		toolUrlPredicate, toolUrlPredicateDiags := types.ObjectValueFrom(ctx, predicateType, *check.ToolUrlPredicate)
+		stateModel.ToolUrlPredicate = toolUrlPredicate
+		diags.Append(toolUrlPredicateDiags...)
 	}
-	if check.EnvironmentPredicate != nil {
-		stateModel.EnvironmentPredicate = NewPredicateModel(*check.EnvironmentPredicate)
+
+	if check.EnvironmentPredicate == nil {
+		stateModel.ToolUrlPredicate = types.ObjectNull(predicateType)
+	} else {
+		toolUrlPredicate, environmentPredicateDiags := types.ObjectValueFrom(ctx, predicateType, *check.EnvironmentPredicate)
+		stateModel.EnvironmentPredicate = toolUrlPredicate
+		diags.Append(environmentPredicateDiags...)
 	}
 
 	return stateModel
@@ -118,19 +134,19 @@ func (r *CheckToolUsageResource) ValidateConfig(ctx context.Context, req resourc
 		return
 	}
 
-	if configModel.EnvironmentPredicate != nil && !configModel.EnvironmentPredicate.Type.IsUnknown() {
-		if err := configModel.EnvironmentPredicate.Validate(); err != nil {
-			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
-		}
+	checkToolUsagePredicates := map[string]types.Object{
+		"environment_predicate": configModel.EnvironmentPredicate,
+		"tool_name_predicate":   configModel.ToolNamePredicate,
+		"tool_url_predicate":    configModel.ToolUrlPredicate,
 	}
-	if configModel.ToolNamePredicate != nil && !configModel.ToolNamePredicate.Type.IsUnknown() {
-		if err := configModel.ToolNamePredicate.Validate(); err != nil {
-			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
+	for predicateSchemaName, predicate := range checkToolUsagePredicates {
+		predicateModel, diags := PredicateObjectToModel(ctx, predicate)
+		resp.Diagnostics.Append(diags...)
+		if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
+			continue
 		}
-	}
-	if configModel.ToolUrlPredicate != nil && !configModel.ToolUrlPredicate.Type.IsUnknown() {
-		if err := configModel.ToolUrlPredicate.Validate(); err != nil {
-			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
+		if err := predicateModel.Validate(); err != nil {
+			resp.Diagnostics.AddAttributeError(path.Root(predicateSchemaName), "Invalid Attribute Configuration", err.Error())
 		}
 	}
 }
@@ -163,14 +179,38 @@ func (r *CheckToolUsageResource) Create(ctx context.Context, req resource.Create
 	}
 
 	input.ToolCategory = opslevel.ToolCategory(planModel.ToolCategory.ValueString())
-	if planModel.ToolNamePredicate != nil {
-		input.ToolNamePredicate = planModel.ToolNamePredicate.ToCreateInput()
+
+	// convert environment_predicate object to model from plan
+	predicateModel, diags := PredicateObjectToModel(ctx, planModel.EnvironmentPredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.EnvironmentPredicate = predicateModel.ToCreateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
 	}
-	if planModel.ToolUrlPredicate != nil {
-		input.ToolUrlPredicate = planModel.ToolUrlPredicate.ToCreateInput()
+
+	// convert tool_name_predicate object to model from plan
+	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolNamePredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.ToolNamePredicate = predicateModel.ToCreateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
 	}
-	if planModel.EnvironmentPredicate != nil {
-		input.EnvironmentPredicate = planModel.EnvironmentPredicate.ToCreateInput()
+
+	// convert tool_url_predicate object to model from plan
+	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolUrlPredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.ToolUrlPredicate = predicateModel.ToCreateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
 	}
 
 	data, err := r.client.CreateCheckToolUsage(input)
@@ -235,21 +275,41 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 	}
 
 	input.ToolCategory = opslevel.RefOf(opslevel.ToolCategory(planModel.ToolCategory.ValueString()))
-	if planModel.ToolNamePredicate != nil {
-		input.ToolNamePredicate = planModel.ToolNamePredicate.ToUpdateInput()
-	} else {
-		input.ToolNamePredicate = &opslevel.PredicateUpdateInput{}
+
+	// convert environment_predicate object to model from plan
+	predicateModel, diags := PredicateObjectToModel(ctx, planModel.EnvironmentPredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.EnvironmentPredicate = predicateModel.ToUpdateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
 	}
-	if planModel.ToolUrlPredicate != nil {
-		input.ToolUrlPredicate = planModel.ToolUrlPredicate.ToUpdateInput()
-	} else {
-		input.ToolUrlPredicate = &opslevel.PredicateUpdateInput{}
+
+	// convert tool_name_predicate object to model from plan
+	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolNamePredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.ToolNamePredicate = predicateModel.ToUpdateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
 	}
-	if planModel.EnvironmentPredicate != nil {
-		input.EnvironmentPredicate = planModel.EnvironmentPredicate.ToUpdateInput()
-	} else {
-		input.EnvironmentPredicate = &opslevel.PredicateUpdateInput{}
+
+	// convert tool_url_predicate object to model from plan
+	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolUrlPredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.ToolUrlPredicate = predicateModel.ToUpdateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
 	}
+
+	input.ToolCategory = opslevel.RefOf(opslevel.ToolCategory(planModel.ToolCategory.ValueString()))
 
 	data, err := r.client.UpdateCheckToolUsage(input)
 	if err != nil {

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -185,6 +185,9 @@ func (r *CheckToolUsageResource) Create(ctx context.Context, req resource.Create
 		}
 		input.EnableOn = &iso8601.Time{Time: enabledOn}
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	input.ToolCategory = opslevel.ToolCategory(planModel.ToolCategory.ValueString())
 
@@ -198,6 +201,9 @@ func (r *CheckToolUsageResource) Create(ctx context.Context, req resource.Create
 			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// convert tool_name_predicate object to model from plan
 	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolNamePredicate)
@@ -209,6 +215,9 @@ func (r *CheckToolUsageResource) Create(ctx context.Context, req resource.Create
 			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// convert tool_url_predicate object to model from plan
 	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolUrlPredicate)
@@ -219,6 +228,9 @@ func (r *CheckToolUsageResource) Create(ctx context.Context, req resource.Create
 		} else {
 			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	data, err := r.client.CreateCheckToolUsage(input)
@@ -281,6 +293,9 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 		}
 		input.EnableOn = &iso8601.Time{Time: enabledOn}
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	input.ToolCategory = opslevel.RefOf(opslevel.ToolCategory(planModel.ToolCategory.ValueString()))
 
@@ -294,6 +309,9 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 			resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// convert tool_name_predicate object to model from plan
 	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolNamePredicate)
@@ -305,6 +323,9 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 			resp.Diagnostics.AddAttributeError(path.Root("tool_name_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// convert tool_url_predicate object to model from plan
 	predicateModel, diags = PredicateObjectToModel(ctx, planModel.ToolUrlPredicate)
@@ -315,6 +336,9 @@ func (r *CheckToolUsageResource) Update(ctx context.Context, req resource.Update
 		} else {
 			resp.Diagnostics.AddAttributeError(path.Root("tool_url_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	input.ToolCategory = opslevel.RefOf(opslevel.ToolCategory(planModel.ToolCategory.ValueString()))

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -105,6 +105,15 @@ func MapValueToOpslevelJson(ctx context.Context, mapValue basetypes.MapValue) (o
 	return mapAsJson, diags
 }
 
+// Converts a basetypes.ObjectValue to a PredicateModel
+func PredicateObjectToModel(ctx context.Context, predicateObj basetypes.ObjectValue) (PredicateModel, diag.Diagnostics) {
+	var predicateModel PredicateModel
+
+	objOptions := basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true}
+	diags := predicateObj.As(ctx, &predicateModel, objOptions)
+	return predicateModel, diags
+}
+
 // asID converts a types.String to an opslevel.ID
 func asID(input types.String) opslevel.ID {
 	return opslevel.ID(input.ValueString())

--- a/tests/remote/check_tool_usage.tftest.hcl
+++ b/tests/remote/check_tool_usage.tftest.hcl
@@ -99,6 +99,7 @@ run "resource_check_tool_usage_create_with_all_fields" {
     name                  = var.name
     notes                 = var.notes
     owner                 = run.from_team_get_owner_id.first_team.id
+    tool_category         = var.tool_category
     tool_name_predicate   = var.tool_name_predicate
     tool_url_predicate    = var.tool_url_predicate
   }
@@ -226,6 +227,7 @@ run "resource_check_tool_usage_update_all_fields" {
     name                  = var.name
     notes                 = var.notes
     owner                 = run.from_team_get_owner_id.first_team.id
+    tool_category         = var.tool_category
     tool_name_predicate   = var.tool_name_predicate
     tool_url_predicate    = var.tool_url_predicate
   }


### PR DESCRIPTION
## Issues

Fix this:
```tf
│ Error: Value Conversion Error
│ 
│ An unexpected error was encountered trying to build a value. This is always an error in the provider. Please report the following to the provider developer:
│ 
│ Received null value, however the target type cannot handle null values. Use the corresponding `types` package type, a pointer type or a custom type that handles null values.
│ 
│ Path: tool_url_predicate
│ Target Type: opslevel.PredicateModel
│ Suggested `types` Type: basetypes.ObjectValue
│ Suggested Pointer Type: *opslevel.PredicateModel
```

## Changelog

PredicateModel has useful functions that remain. The schema now accepts ObjectValues instead and Terraform understands how to interpret these better than a custom struct with tfsdk tags.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this Terraform config (note `*_predicate` blocks):
```tf
resource "opslevel_check_tool_usage" "example" {
  name          = "foo the barz"
  enabled       = true
  category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  tool_category = "metrics"
  environment_predicate = {
    type  = "ends_with"
    value = "the sea"
  }
  tool_name_predicate = {
    type  = "exists"
    value = ""
  }
  tool_url_predicate = {
    type  = "starts_with"
    value = "https"
  }
  notes = "Optional additional info on why this check is run or how to fix it"
}
```

### Create `opslevel_check_tool_usage` with predicates. `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_check_tool_usage.example will be created
  + resource "opslevel_check_tool_usage" "example" {
      + category              = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description           = (known after apply)
      + enabled               = true
      + environment_predicate = {
          + type  = "ends_with"
          + value = "the sea"
        }
      + filter                = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                    = (known after apply)
      + level                 = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                  = "foo the barz"
      + notes                 = "Optional additional info on why this check is run or how to fix it"
      + owner                 = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + tool_category         = "metrics"
      + tool_name_predicate   = {
          + type  = "exists"
          + value = ""
        }
      + tool_url_predicate    = {
          + type  = "starts_with"
          + value = "https"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_check_tool_usage.example: Creating...
opslevel_check_tool_usage.example: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTE]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Destroy `opslevel_check_tool_usage` with predicates. `terraform destroy`
```tf
opslevel_check_tool_usage.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_check_tool_usage.example will be destroyed
  - resource "opslevel_check_tool_usage" "example" {
      - category              = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description           = "The service has a metrics tool whose name exists in an environment which ends with 'the sea' with a url which starts with 'https'." -> null
      - enabled               = true -> null
      - environment_predicate = {
          - type  = "ends_with" -> null
          - value = "the sea" -> null
        } -> null
      - filter                = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id                    = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTE" -> null
      - level                 = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name                  = "foo the barz" -> null
      - notes                 = "Optional additional info on why this check is run or how to fix it" -> null
      - owner                 = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
      - tool_category         = "metrics" -> null
      - tool_name_predicate   = {
          - type  = "exists" -> null
          - value = "" -> null
        } -> null
      - tool_url_predicate    = {
          - type  = "starts_with" -> null
          - value = "https" -> null
        } -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_check_tool_usage.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTE]
opslevel_check_tool_usage.example: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```

### Update Terraform config. `*_predicate` blocks commented out:
```tf
resource "opslevel_check_tool_usage" "example" {
  name          = "foo the barz"
  enabled       = true
  category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  tool_category = "metrics"
  # environment_predicate = {
  #   type  = "ends_with"
  #   value = "the sea"
  # }
  # tool_name_predicate = {
  #   type  = "exists"
  #   value = ""
  # }
  # tool_url_predicate = {
  #   type  = "starts_with"
  #   value = "https"
  # }
  notes = "Optional additional info on why this check is run or how to fix it"
}
```

### Create `opslevel_check_tool_usage` with no predicates. `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_check_tool_usage.example will be created
  + resource "opslevel_check_tool_usage" "example" {
      + category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description   = (known after apply)
      + enabled       = true
      + filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id            = (known after apply)
      + level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name          = "foo the barz"
      + notes         = "Optional additional info on why this check is run or how to fix it"
      + owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + tool_category = "metrics"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_check_tool_usage.example: Creating...
opslevel_check_tool_usage.example: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTI]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Update Terraform config. Add `*_predicate` blocks:
```tf
resource "opslevel_check_tool_usage" "example" {
  name          = "foo the barz"
  enabled       = true
  category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  tool_category = "metrics"
  environment_predicate = {
    type  = "ends_with"
    value = "the sea"
  }
  tool_name_predicate = {
    type  = "exists"
    value = ""
  }
  tool_url_predicate = {
    type  = "starts_with"
    value = "https"
  }
  notes = "Optional additional info on why this check is run or how to fix it"
}
```

### Update `opslevel_check_tool_usage`, add predicates. `terraform apply`:
```tf
opslevel_check_tool_usage.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTI]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_check_tool_usage.example will be updated in-place
  ~ resource "opslevel_check_tool_usage" "example" {
      ~ description           = "The service has a metrics tool." -> (known after apply)
      + environment_predicate = {
          + type  = "ends_with"
          + value = "the sea"
        }
        id                    = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTI"
        name                  = "foo the barz"
      + tool_name_predicate   = {
          + type  = "exists"
          + value = ""
        }
      + tool_url_predicate    = {
          + type  = "starts_with"
          + value = "https"
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_check_tool_usage.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTI]
opslevel_check_tool_usage.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjYwNTI]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```