### PR TITLE
Db/team members order

### DIFF
--- a/.changes/unreleased/Bugfix-20240607-154253.yaml
+++ b/.changes/unreleased/Bugfix-20240607-154253.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: ensure order of team members alone does not trigger update
+time: 2024-06-07T15:42:53.967301-05:00

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -111,7 +111,7 @@ func (teamResource *TeamResource) Schema(ctx context.Context, req resource.Schem
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"member": schema.ListNestedBlock{
+			"member": schema.SetNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"email": schema.StringAttribute{

--- a/tests/local/resource_team.tftest.hcl
+++ b/tests/local/resource_team.tftest.hcl
@@ -37,7 +37,7 @@ run "resource_team_big" {
   }
 
   assert {
-    condition     = opslevel_team.big.member[0].email == "alice@opslevel.com" && opslevel_team.big.member[0].role == "manager" && opslevel_team.big.member[1].email == "bob@opslevel.com" && opslevel_team.big.member[1].role == "contributor"
+    condition     = contains(opslevel_team.big.member[*].email, "alice@opslevel.com") && contains(opslevel_team.big.member[*].role, "manager") && contains(opslevel_team.big.member[*].email, "bob@opslevel.com") && contains(opslevel_team.big.member[*].role, "contributor")
     error_message = "wrong members in opslevel_team.big"
   }
 }


### PR DESCRIPTION
## Issues

[Ensure the "sort order" of team members and that we can properly reconcile them](https://github.com/OpsLevel/team-platform/issues/384)

## Changelog

Order of members erroneously triggered updates to Terraform state. Changing the schema from a ListNestedBlock to a SetNestedBlock keeps the same functionality and ignores the order of member blocks.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting


### With this config:
```tf
resource "opslevel_team" "example" {
  name             = "foo foo foo"
  responsibilities = "Stuff"
  parent           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"

  member {
    email = "kyle+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "taimoor+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
}
```

### Create team with three members
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_team.example will be created
  + resource "opslevel_team" "example" {
      + id               = (known after apply)
      + name             = "foo foo foo"
      + parent           = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzMg"
      + responsibilities = "Stuff"

      + member {
          + email = "david+pat@opslevel.com"
          + role  = "contributor"
        }
      + member {
          + email = "kyle+pat@opslevel.com"
          + role  = "contributor"
        }
      + member {
          + email = "taimoor+pat@opslevel.com"
          + role  = "contributor"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_team.example: Creating...
opslevel_team.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTI0Nw]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```