### PR TITLE
convert predicates to ObjectModels, needs testing

### DIFF
--- a/.changes/unreleased/Bugfix-20240611-090028.yaml
+++ b/.changes/unreleased/Bugfix-20240611-090028.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: created opslevel_check_service_ownership use new defaults instead of crashing. Optional fields require_contact_method and contact_method now have default values.
+time: 2024-06-11T09:00:28.77618-05:00

--- a/.changes/unreleased/Feature-20240611-091721.yaml
+++ b/.changes/unreleased/Feature-20240611-091721.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add predicate type validation to opslevel_check_repository_search
+time: 2024-06-11T09:17:21.917195-05:00

--- a/.changes/unreleased/Refactor-20240611-085420.yaml
+++ b/.changes/unreleased/Refactor-20240611-085420.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: fix unsetting opslevel_check_alert_source_usage.alert_name_predicate. Type of field AlertNamePredicate was PredicateModel is now types.Object
+time: 2024-06-11T08:54:20.876041-05:00

--- a/.changes/unreleased/Refactor-20240611-085611.yaml
+++ b/.changes/unreleased/Refactor-20240611-085611.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: fix unsetting opslevel_check_repository_file.file_contents_predicate. Type of field FileContentsPredicate was PredicateModel is now types.Object
+time: 2024-06-11T08:56:11.805923-05:00

--- a/.changes/unreleased/Refactor-20240611-085618.yaml
+++ b/.changes/unreleased/Refactor-20240611-085618.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: fix unsetting opslevel_check_service_ownership.tag_predicate. Type of field TagPredicate was PredicateModel is now types.Object
+time: 2024-06-11T08:56:18.154783-05:00

--- a/.changes/unreleased/Refactor-20240611-085621.yaml
+++ b/.changes/unreleased/Refactor-20240611-085621.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: fix unsetting opslevel_check_repository_search.file_contents_predicate. Type of field FileContentsPredicate was PredicateModel is now types.Object
+time: 2024-06-11T08:56:21.459287-05:00

--- a/.changes/unreleased/Refactor-20240611-085625.yaml
+++ b/.changes/unreleased/Refactor-20240611-085625.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: fix unsetting opslevel_check_repository_grep.file_contents_predicate. Type of field FileContentsPredicate was PredicateModel is now types.Object
+time: 2024-06-11T08:56:25.468086-05:00

--- a/.changes/unreleased/Refactor-20240611-085844.yaml
+++ b/.changes/unreleased/Refactor-20240611-085844.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: fix unsetting opslevel_check_service_property.predicate. Type of field Predicate was PredicateModel is now types.Object
+time: 2024-06-11T08:58:44.173408-05:00

--- a/.changes/unreleased/Refactor-20240611-085846.yaml
+++ b/.changes/unreleased/Refactor-20240611-085846.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: fix unsetting opslevel_check_tag_model.tag_predicate. Type of field TagPredicate was PredicateModel is now types.Object
+time: 2024-06-11T08:58:46.861239-05:00

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -163,6 +163,9 @@ func (r *CheckAlertSourceUsageResource) Create(ctx context.Context, req resource
 			resp.Diagnostics.AddAttributeError(path.Root("alert_name_predicate"), "Invalid Attribute Configuration", err.Error())
 		}
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	data, err := r.client.CreateCheckAlertSourceUsage(input)
 	if err != nil {
@@ -235,6 +238,9 @@ func (r *CheckAlertSourceUsageResource) Update(ctx context.Context, req resource
 		input.AlertSourceNamePredicate = predicateModel.ToUpdateInput()
 	} else {
 		resp.Diagnostics.AddAttributeError(path.Root("alert_name_predicate"), "Invalid Attribute Configuration", err.Error())
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	data, err := r.client.UpdateCheckAlertSourceUsage(input)

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -256,6 +256,9 @@ func (r *CheckRepositoryFileResource) Update(ctx context.Context, req resource.U
 	} else {
 		resp.Diagnostics.AddAttributeError(path.Root("environment_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	input.UseAbsoluteRoot = planModel.UseAbsoluteRoot.ValueBoolPointer()
 
 	data, err := r.client.UpdateCheckRepositoryFile(input)

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -157,6 +157,7 @@ func (r *CheckRepositoryGrepResource) Create(ctx context.Context, req resource.C
 	resp.Diagnostics.Append(planModel.Filepaths.ElementsAs(ctx, &input.FilePaths, false)...)
 
 	predicateModel, diags := PredicateObjectToModel(ctx, planModel.FileContentsPredicate)
+	resp.Diagnostics.Append(diags...)
 	input.FileContentsPredicate = *predicateModel.ToCreateInput()
 
 	data, err := r.client.CreateCheckRepositoryGrep(input)
@@ -226,6 +227,7 @@ func (r *CheckRepositoryGrepResource) Update(ctx context.Context, req resource.U
 	resp.Diagnostics.Append(planModel.Filepaths.ElementsAs(ctx, &input.FilePaths, false)...)
 
 	predicateModel, diags := PredicateObjectToModel(ctx, planModel.FileContentsPredicate)
+	resp.Diagnostics.Append(diags...)
 	input.FileContentsPredicate = predicateModel.ToUpdateInput()
 
 	data, err := r.client.UpdateCheckRepositoryGrep(input)

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -3,6 +3,7 @@ package opslevel
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -122,13 +123,8 @@ func (r *CheckRepositoryGrepResource) ValidateConfig(ctx context.Context, req re
 	predicateModel, diags := PredicateObjectToModel(ctx, configModel.FileContentsPredicate)
 	resp.Diagnostics.Append(diags...)
 
-	if configModel.DirectorySearch.ValueBool() {
-		switch predicateModel.Type.ValueString() {
-		case "does_not_exist", "exists":
-			return
-		default:
-			resp.Diagnostics.AddError("Config Error", "When 'directory_search' is true, file_contents_predicate type must be 'exists' or 'does_not_exist'")
-		}
+	if configModel.DirectorySearch.ValueBool() && !slices.Contains([]string{"exists", "does_not_exist"}, predicateModel.Type.ValueString()) {
+		resp.Diagnostics.AddError("Config Error", "When 'directory_search' is true, file_contents_predicate type must be 'exists' or 'does_not_exist'")
 	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -121,6 +121,15 @@ func (r *CheckRepositoryGrepResource) ValidateConfig(ctx context.Context, req re
 
 	predicateModel, diags := PredicateObjectToModel(ctx, configModel.FileContentsPredicate)
 	resp.Diagnostics.Append(diags...)
+
+	if configModel.DirectorySearch.ValueBool() {
+		switch predicateModel.Type.ValueString() {
+		case "does_not_exist", "exists":
+			return
+		default:
+			resp.Diagnostics.AddError("Config Error", "When 'directory_search' is true, file_contents_predicate type must be 'exists' or 'does_not_exist'")
+		}
+	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -124,8 +124,12 @@ func (r *CheckRepositorySearchResource) ValidateConfig(ctx context.Context, req 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	predicateModel, diags := PredicateObjectToModel(ctx, configModel.FileContentsPredicate)
 	resp.Diagnostics.Append(diags...)
+	if predicateModel.Type.ValueString() == "exists" || predicateModel.Type.ValueString() == "does_not_exist" {
+		resp.Diagnostics.AddError("Config Error", "file_contents_predicate type must not be 'exists' or 'does_not_exist'")
+	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -142,6 +142,7 @@ func (r *CheckRepositorySearchResource) Create(ctx context.Context, req resource
 	}
 
 	predicateModel, diags := PredicateObjectToModel(ctx, planModel.FileContentsPredicate)
+	resp.Diagnostics.Append(diags...)
 	input := opslevel.CheckRepositorySearchCreateInput{
 		CategoryId:            asID(planModel.Category),
 		Enabled:               planModel.Enabled.ValueBoolPointer(),

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -275,6 +275,9 @@ func (r *CheckServiceOwnershipResource) Update(ctx context.Context, req resource
 	} else {
 		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	data, err := r.client.UpdateCheckServiceOwnership(input)
 	if err != nil {

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -43,10 +44,10 @@ type CheckServiceOwnershipResourceModel struct {
 	Notes       types.String `tfsdk:"notes"`
 	Owner       types.String `tfsdk:"owner"`
 
-	RequireContactMethod types.Bool      `tfsdk:"require_contact_method"`
-	ContactMethod        types.String    `tfsdk:"contact_method"`
-	TagKey               types.String    `tfsdk:"tag_key"`
-	TagPredicate         *PredicateModel `tfsdk:"tag_predicate"`
+	RequireContactMethod types.Bool   `tfsdk:"require_contact_method"`
+	ContactMethod        types.String `tfsdk:"contact_method"`
+	TagKey               types.String `tfsdk:"tag_key"`
+	TagPredicate         types.Object `tfsdk:"tag_predicate"`
 }
 
 func NewCheckServiceOwnershipResourceModel(ctx context.Context, check opslevel.Check, planModel CheckServiceOwnershipResourceModel) CheckServiceOwnershipResourceModel {
@@ -81,10 +82,17 @@ func NewCheckServiceOwnershipResourceModel(ctx context.Context, check opslevel.C
 			stateModel.ContactMethod = OptionalStringValue(contactMethod)
 		}
 	}
-
 	stateModel.TagKey = OptionalStringValue(check.ServiceOwnershipCheckFragment.TeamTagKey)
-	if check.ServiceOwnershipCheckFragment.TeamTagPredicate != nil {
-		stateModel.TagPredicate = NewPredicateModel(*check.ServiceOwnershipCheckFragment.TeamTagPredicate)
+
+	if check.ServiceOwnershipCheckFragment.TeamTagPredicate == nil {
+		stateModel.TagPredicate = types.ObjectNull(predicateType)
+	} else {
+		predicate := *&check.ServiceOwnershipCheckFragment.TeamTagPredicate
+		predicateAttrValues := map[string]attr.Value{
+			"type":  types.StringValue(string(predicate.Type)),
+			"value": types.StringValue(predicate.Value),
+		}
+		stateModel.TagPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}
 
 	return stateModel
@@ -125,12 +133,16 @@ func (r *CheckServiceOwnershipResource) Schema(ctx context.Context, req resource
 func (r *CheckServiceOwnershipResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckServiceOwnershipResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() ||
-		configModel.TagPredicate == nil ||
-		configModel.TagPredicate.Type.IsUnknown() {
+	if resp.Diagnostics.HasError() {
 		return
 	}
-	if err := configModel.TagPredicate.Validate(); err != nil {
+
+	predicateModel, diags := PredicateObjectToModel(ctx, configModel.TagPredicate)
+	resp.Diagnostics.Append(diags...)
+	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
+		return
+	}
+	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
@@ -165,8 +177,19 @@ func (r *CheckServiceOwnershipResource) Create(ctx context.Context, req resource
 	input.RequireContactMethod = planModel.RequireContactMethod.ValueBoolPointer()
 	input.ContactMethod = opslevel.RefOf(strings.ToUpper(planModel.ContactMethod.ValueString()))
 	input.TagKey = planModel.TagKey.ValueStringPointer()
-	if planModel.TagPredicate != nil {
-		input.TagPredicate = planModel.TagPredicate.ToCreateInput()
+
+	// convert tool_name_predicate object to model from plan
+	predicateModel, diags := PredicateObjectToModel(ctx, planModel.TagPredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.TagPredicate = predicateModel.ToCreateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	data, err := r.client.CreateCheckServiceOwnership(input)
@@ -233,10 +256,16 @@ func (r *CheckServiceOwnershipResource) Update(ctx context.Context, req resource
 	input.RequireContactMethod = planModel.RequireContactMethod.ValueBoolPointer()
 	input.ContactMethod = opslevel.RefOf(strings.ToUpper(planModel.ContactMethod.ValueString()))
 	input.TagKey = planModel.TagKey.ValueStringPointer()
-	if planModel.TagPredicate != nil {
-		input.TagPredicate = planModel.TagPredicate.ToUpdateInput()
-	} else {
+
+	// convert tool_name_predicate object to model from plan
+	predicateModel, diags := PredicateObjectToModel(ctx, planModel.TagPredicate)
+	resp.Diagnostics.Append(diags...)
+	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
 		input.TagPredicate = &opslevel.PredicateUpdateInput{}
+	} else if err := predicateModel.Validate(); err == nil {
+		input.TagPredicate = predicateModel.ToUpdateInput()
+	} else {
+		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 
 	data, err := r.client.UpdateCheckServiceOwnership(input)

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -244,6 +244,9 @@ func (r *CheckServicePropertyResource) Update(ctx context.Context, req resource.
 	} else {
 		resp.Diagnostics.AddAttributeError(path.Root("predicate"), "Invalid Attribute Configuration", err.Error())
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	data, err := r.client.UpdateCheckServiceProperty(input)
 	if err != nil {

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -40,8 +41,8 @@ type CheckTagDefinedResourceModel struct {
 	Notes       types.String `tfsdk:"notes"`
 	Owner       types.String `tfsdk:"owner"`
 
-	TagKey       types.String    `tfsdk:"tag_key"`
-	TagPredicate *PredicateModel `tfsdk:"tag_predicate"`
+	TagKey       types.String `tfsdk:"tag_key"`
+	TagPredicate types.Object `tfsdk:"tag_predicate"`
 }
 
 func NewCheckTagDefinedResourceModel(ctx context.Context, check opslevel.Check, planModel CheckTagDefinedResourceModel) CheckTagDefinedResourceModel {
@@ -68,8 +69,16 @@ func NewCheckTagDefinedResourceModel(ctx context.Context, check opslevel.Check, 
 	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
 
 	stateModel.TagKey = RequiredStringValue(check.TagKey)
-	if check.TagPredicate != nil {
-		stateModel.TagPredicate = NewPredicateModel(*check.TagPredicate)
+
+	if check.TagPredicate == nil {
+		stateModel.TagPredicate = types.ObjectNull(predicateType)
+	} else {
+		predicate := *check.TagPredicate
+		predicateAttrValues := map[string]attr.Value{
+			"type":  types.StringValue(string(predicate.Type)),
+			"value": types.StringValue(predicate.Value),
+		}
+		stateModel.TagPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}
 
 	return stateModel
@@ -97,12 +106,15 @@ func (r *CheckTagDefinedResource) Schema(ctx context.Context, req resource.Schem
 func (r *CheckTagDefinedResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckTagDefinedResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() ||
-		configModel.TagPredicate == nil ||
-		configModel.TagPredicate.Type.IsUnknown() {
+	if resp.Diagnostics.HasError() {
 		return
 	}
-	if err := configModel.TagPredicate.Validate(); err != nil {
+	predicateModel, diags := PredicateObjectToModel(ctx, configModel.TagPredicate)
+	resp.Diagnostics.Append(diags...)
+	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
+		return
+	}
+	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
@@ -135,8 +147,19 @@ func (r *CheckTagDefinedResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	input.TagKey = planModel.TagKey.ValueString()
-	if planModel.TagPredicate != nil {
-		input.TagPredicate = planModel.TagPredicate.ToCreateInput()
+
+	// convert environment_predicate object to model from plan
+	predicateModel, diags := PredicateObjectToModel(ctx, planModel.TagPredicate)
+	resp.Diagnostics.Append(diags...)
+	if !predicateModel.Type.IsUnknown() && !predicateModel.Type.IsNull() {
+		if err := predicateModel.Validate(); err == nil {
+			input.TagPredicate = predicateModel.ToCreateInput()
+		} else {
+			resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
+		}
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	data, err := r.client.CreateCheckTagDefined(input)
@@ -201,10 +224,16 @@ func (r *CheckTagDefinedResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	input.TagKey = planModel.TagKey.ValueStringPointer()
-	if planModel.TagPredicate != nil {
-		input.TagPredicate = planModel.TagPredicate.ToUpdateInput()
-	} else {
+
+	// convert environment_predicate object to model from plan
+	predicateModel, diags := PredicateObjectToModel(ctx, planModel.TagPredicate)
+	resp.Diagnostics.Append(diags...)
+	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
 		input.TagPredicate = &opslevel.PredicateUpdateInput{}
+	} else if err := predicateModel.Validate(); err == nil {
+		input.TagPredicate = predicateModel.ToUpdateInput()
+	} else {
+		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 
 	data, err := r.client.UpdateCheckTagDefined(input)

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -235,6 +235,9 @@ func (r *CheckTagDefinedResource) Update(ctx context.Context, req resource.Updat
 	} else {
 		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	data, err := r.client.UpdateCheckTagDefined(input)
 	if err != nil {

--- a/tests/remote/check_alert_source_usage.tftest.hcl
+++ b/tests/remote/check_alert_source_usage.tftest.hcl
@@ -8,7 +8,7 @@ variables {
   # optional fields
   alert_name_predicate = {
     type  = "exists"
-    value = null
+    value = ""
   }
 
   # -- check base fields --

--- a/tests/remote/check_alert_source_usage.tftest.hcl
+++ b/tests/remote/check_alert_source_usage.tftest.hcl
@@ -164,18 +164,23 @@ run "resource_check_alert_source_usage_create_with_all_fields" {
 run "resource_check_alert_source_usage_update_unset_optional_fields" {
 
   variables {
-    # alert_name_predicate = null
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
+    alert_name_predicate = null
+    category             = run.from_rubric_category_get_category_id.first_category.id
+    enable_on            = null
+    enabled              = null
+    filter               = null
+    level                = run.from_rubric_level_get_level_id.greatest_level.id
+    notes                = null
+    owner                = null
   }
 
   module {
     source = "./check_alert_source_usage"
+  }
+
+  assert {
+    condition     = opslevel_check_alert_source_usage.test.alert_name_predicate == null
+    error_message = var.error_expected_null_field
   }
 
   assert {

--- a/tests/remote/check_alert_source_usage/main.tf
+++ b/tests/remote/check_alert_source_usage/main.tf
@@ -1,9 +1,6 @@
 resource "opslevel_check_alert_source_usage" "test" {
-  alert_name_predicate = {
-    type  = var.alert_name_predicate.type
-    value = var.alert_name_predicate.value
-  }
-  alert_type = var.alert_type
+  alert_name_predicate = var.alert_name_predicate
+  alert_type           = var.alert_type
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_alert_source_usage/variables.tf
+++ b/tests/remote/check_alert_source_usage/variables.tf
@@ -1,7 +1,7 @@
 variable "alert_name_predicate" {
   type = object({
     type  = string
-    value = optional(string)
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_repository_file.tftest.hcl
+++ b/tests/remote/check_repository_file.tftest.hcl
@@ -105,6 +105,7 @@ run "resource_check_repository_file_create_with_all_fields" {
       can(opslevel_check_repository_file.test.description),
       can(opslevel_check_repository_file.test.enable_on),
       can(opslevel_check_repository_file.test.enabled),
+      can(opslevel_check_repository_file.test.file_contents_predicate),
       can(opslevel_check_repository_file.test.filter),
       can(opslevel_check_repository_file.test.id),
       can(opslevel_check_repository_file.test.level),
@@ -133,6 +134,11 @@ run "resource_check_repository_file_create_with_all_fields" {
   assert {
     condition     = startswith(opslevel_check_repository_file.test.id, var.id_prefix)
     error_message = replace(var.error_wrong_id, "TYPE", var.check_repository_file)
+  }
+
+  assert {
+    condition     = opslevel_check_repository_file.test.file_contents_predicate == var.file_contents_predicate
+    error_message = "wrong file_contents_predicate of opslevel_check_repository_file resource"
   }
 
   assert {
@@ -165,14 +171,14 @@ run "resource_check_repository_file_create_with_all_fields" {
 run "resource_check_repository_file_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    # file_contents_predicate = null
-    filter = null
-    level  = run.from_rubric_level_get_level_id.greatest_level.id
-    notes  = null
-    owner  = null
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = null
+    enabled                 = null
+    file_contents_predicate = null
+    filter                  = null
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    notes                   = null
+    owner                   = null
   }
 
   module {
@@ -187,6 +193,11 @@ run "resource_check_repository_file_update_unset_optional_fields" {
   assert {
     condition     = opslevel_check_repository_file.test.enabled == false
     error_message = "expected 'false' default for 'enabled' in opslevel_check_repository_file resource"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_file.test.file_contents_predicate == null
+    error_message = var.error_expected_null_field
   }
 
   assert {
@@ -238,6 +249,11 @@ run "resource_check_repository_file_update_all_fields" {
   assert {
     condition     = opslevel_check_repository_file.test.enabled == var.enabled
     error_message = "wrong enabled of opslevel_check_repository_file resource"
+  }
+
+  assert {
+    condition     = opslevel_check_repository_file.test.file_contents_predicate == var.file_contents_predicate
+    error_message = "wrong file_contents_predicate of opslevel_check_repository_file resource"
   }
 
   assert {

--- a/tests/remote/check_repository_file/main.tf
+++ b/tests/remote/check_repository_file/main.tf
@@ -1,11 +1,8 @@
 resource "opslevel_check_repository_file" "test" {
-  directory_search = var.directory_search
-  file_contents_predicate = {
-    type  = var.file_contents_predicate.type
-    value = var.file_contents_predicate.value
-  }
-  filepaths         = var.filepaths
-  use_absolute_root = var.use_absolute_root
+  directory_search        = var.directory_search
+  file_contents_predicate = var.file_contents_predicate
+  filepaths               = var.filepaths
+  use_absolute_root       = var.use_absolute_root
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_repository_file/variables.tf
+++ b/tests/remote/check_repository_file/variables.tf
@@ -6,7 +6,7 @@ variable "directory_search" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = optional(string)
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_repository_grep.tftest.hcl
+++ b/tests/remote/check_repository_grep.tftest.hcl
@@ -4,9 +4,10 @@ variables {
   # -- check_repository_grep fields --
   # required fields
   directory_search = true
+  # NOTE: baffled here, this is not being passed in
   file_contents_predicate = {
-    type  = "does_not_exist",
-    value = null,
+    type  = "exists"
+    value = ""
   }
   filepaths = tolist(["one/two.py", "three/four.rs"])
 
@@ -81,14 +82,15 @@ run "from_team_get_owner_id" {
 run "resource_check_repository_grep_create_with_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = var.enable_on
+    enabled                 = var.enabled
+    file_contents_predicate = var.file_contents_predicate
+    filter                  = run.from_filter_get_filter_id.first_filter.id
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    name                    = var.name
+    notes                   = var.notes
+    owner                   = run.from_team_get_owner_id.first_team.id
   }
 
   module {
@@ -101,6 +103,7 @@ run "resource_check_repository_grep_create_with_all_fields" {
       can(opslevel_check_repository_grep.test.description),
       can(opslevel_check_repository_grep.test.enable_on),
       can(opslevel_check_repository_grep.test.enabled),
+      can(opslevel_check_repository_grep.test.file_contents_predicate),
       can(opslevel_check_repository_grep.test.filter),
       can(opslevel_check_repository_grep.test.id),
       can(opslevel_check_repository_grep.test.level),
@@ -205,14 +208,15 @@ run "resource_check_repository_grep_update_unset_optional_fields" {
 run "resource_check_repository_grep_update_all_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = var.enable_on
-    enabled   = var.enabled
-    filter    = run.from_filter_get_filter_id.first_filter.id
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    name      = var.name
-    notes     = var.notes
-    owner     = run.from_team_get_owner_id.first_team.id
+    category                = run.from_rubric_category_get_category_id.first_category.id
+    enable_on               = var.enable_on
+    enabled                 = var.enabled
+    file_contents_predicate = var.file_contents_predicate
+    filter                  = run.from_filter_get_filter_id.first_filter.id
+    level                   = run.from_rubric_level_get_level_id.greatest_level.id
+    name                    = var.name
+    notes                   = var.notes
+    owner                   = run.from_team_get_owner_id.first_team.id
   }
 
   module {

--- a/tests/remote/check_repository_grep/main.tf
+++ b/tests/remote/check_repository_grep/main.tf
@@ -1,7 +1,11 @@
 resource "opslevel_check_repository_grep" "test" {
-  directory_search        = var.directory_search
-  file_contents_predicate = var.file_contents_predicate
-  filepaths               = var.filepaths
+  directory_search = var.directory_search
+  # file_contents_predicate = var.file_contents_predicate
+  file_contents_predicate = {
+    type  = "exists"
+    value = ""
+  }
+  filepaths = var.filepaths
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_repository_grep/main.tf
+++ b/tests/remote/check_repository_grep/main.tf
@@ -1,10 +1,7 @@
 resource "opslevel_check_repository_grep" "test" {
-  directory_search = var.directory_search
-  file_contents_predicate = {
-    type  = var.file_contents_predicate.type
-    value = var.file_contents_predicate.value
-  }
-  filepaths = var.filepaths
+  directory_search        = var.directory_search
+  file_contents_predicate = var.file_contents_predicate
+  filepaths               = var.filepaths
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_repository_grep/variables.tf
+++ b/tests/remote/check_repository_grep/variables.tf
@@ -6,7 +6,7 @@ variable "directory_search" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = optional(string)
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_repository_grep/variables.tf
+++ b/tests/remote/check_repository_grep/variables.tf
@@ -1,3 +1,4 @@
+# NOTE: if directory_search is true, file_contents_predicate can only be "exists" or "does_not_exist"
 variable "directory_search" {
   type        = bool
   description = "Whether the check looks for the existence of a directory instead of a file."

--- a/tests/remote/check_repository_search.tftest.hcl
+++ b/tests/remote/check_repository_search.tftest.hcl
@@ -104,6 +104,7 @@ run "resource_check_repository_search_create_with_all_fields" {
       can(opslevel_check_repository_search.test.description),
       can(opslevel_check_repository_search.test.enable_on),
       can(opslevel_check_repository_search.test.enabled),
+      can(opslevel_check_repository_search.test.file_contents_predicate),
       can(opslevel_check_repository_search.test.file_extensions),
       can(opslevel_check_repository_search.test.filter),
       can(opslevel_check_repository_search.test.id),

--- a/tests/remote/check_repository_search/main.tf
+++ b/tests/remote/check_repository_search/main.tf
@@ -1,7 +1,8 @@
 resource "opslevel_check_repository_search" "test" {
+  # file_contents_predicate = var.file_contents_predicate
   file_contents_predicate = {
-    type  = var.file_contents_predicate.type
-    value = var.file_contents_predicate.value
+    type  = "contains"
+    value = "dev"
   }
   file_extensions = var.file_extensions
 

--- a/tests/remote/check_repository_search/variables.tf
+++ b/tests/remote/check_repository_search/variables.tf
@@ -6,7 +6,7 @@ variable "file_extensions" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = optional(string)
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_service_ownership.tftest.hcl
+++ b/tests/remote/check_service_ownership.tftest.hcl
@@ -82,15 +82,16 @@ run "from_team_get_owner_id" {
 run "resource_check_service_ownership_create_with_all_fields" {
 
   variables {
-    category      = run.from_rubric_category_get_category_id.first_category.id
-    enable_on     = var.enable_on
-    enabled       = var.enabled
-    filter        = run.from_filter_get_filter_id.first_filter.id
-    level         = run.from_rubric_level_get_level_id.greatest_level.id
-    name          = var.name
-    notes         = var.notes
-    owner         = run.from_team_get_owner_id.first_team.id
-    tag_predicate = var.tag_predicate
+    category       = run.from_rubric_category_get_category_id.first_category.id
+    contact_method = var.contact_method
+    enable_on      = var.enable_on
+    enabled        = var.enabled
+    filter         = run.from_filter_get_filter_id.first_filter.id
+    level          = run.from_rubric_level_get_level_id.greatest_level.id
+    name           = var.name
+    notes          = var.notes
+    owner          = run.from_team_get_owner_id.first_team.id
+    tag_predicate  = var.tag_predicate
   }
 
   module {
@@ -100,6 +101,7 @@ run "resource_check_service_ownership_create_with_all_fields" {
   assert {
     condition = alltrue([
       can(opslevel_check_service_ownership.test.category),
+      can(opslevel_check_service_ownership.test.contact_method),
       can(opslevel_check_service_ownership.test.description),
       can(opslevel_check_service_ownership.test.enable_on),
       can(opslevel_check_service_ownership.test.enabled),
@@ -109,6 +111,9 @@ run "resource_check_service_ownership_create_with_all_fields" {
       can(opslevel_check_service_ownership.test.name),
       can(opslevel_check_service_ownership.test.notes),
       can(opslevel_check_service_ownership.test.owner),
+      can(opslevel_check_service_ownership.test.require_contact_method),
+      can(opslevel_check_service_ownership.test.tag_key),
+      can(opslevel_check_service_ownership.test.tag_predicate),
     ])
     error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.check_service_ownership)
   }
@@ -116,6 +121,11 @@ run "resource_check_service_ownership_create_with_all_fields" {
   assert {
     condition     = opslevel_check_service_ownership.test.category == var.category
     error_message = "wrong category of opslevel_check_service_ownership resource"
+  }
+
+  assert {
+    condition     = lower(opslevel_check_service_ownership.test.contact_method) == lower(var.contact_method)
+    error_message = "wrong contact_method of opslevel_check_service_ownership resource"
   }
 
   assert {
@@ -163,14 +173,14 @@ run "resource_check_service_ownership_create_with_all_fields" {
 run "resource_check_service_ownership_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
-    # tag_predicate = null
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = null
+    enabled       = null
+    filter        = null
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    notes         = null
+    owner         = null
+    tag_predicate = null
   }
 
   module {
@@ -202,21 +212,26 @@ run "resource_check_service_ownership_update_unset_optional_fields" {
     error_message = var.error_expected_null_field
   }
 
+  assert {
+    condition     = opslevel_check_service_ownership.test.tag_predicate == null
+    error_message = var.error_expected_null_field
+  }
 
 }
 
 run "resource_check_service_ownership_update_all_fields" {
 
   variables {
-    category      = run.from_rubric_category_get_category_id.first_category.id
-    enable_on     = var.enable_on
-    enabled       = var.enabled
-    filter        = run.from_filter_get_filter_id.first_filter.id
-    level         = run.from_rubric_level_get_level_id.greatest_level.id
-    name          = var.name
-    notes         = var.notes
-    owner         = run.from_team_get_owner_id.first_team.id
-    tag_predicate = var.tag_predicate
+    category       = run.from_rubric_category_get_category_id.first_category.id
+    contact_method = var.contact_method
+    enable_on      = var.enable_on
+    enabled        = var.enabled
+    filter         = run.from_filter_get_filter_id.first_filter.id
+    level          = run.from_rubric_level_get_level_id.greatest_level.id
+    name           = var.name
+    notes          = var.notes
+    owner          = run.from_team_get_owner_id.first_team.id
+    tag_predicate  = var.tag_predicate
   }
 
   module {
@@ -226,6 +241,11 @@ run "resource_check_service_ownership_update_all_fields" {
   assert {
     condition     = opslevel_check_service_ownership.test.category == var.category
     error_message = "wrong category of opslevel_check_service_ownership resource"
+  }
+
+  assert {
+    condition     = lower(opslevel_check_service_ownership.test.contact_method) == lower(var.contact_method)
+    error_message = "wrong contact_method of opslevel_check_service_ownership resource"
   }
 
   assert {

--- a/tests/remote/check_service_ownership/main.tf
+++ b/tests/remote/check_service_ownership/main.tf
@@ -2,10 +2,7 @@ resource "opslevel_check_service_ownership" "test" {
   contact_method         = var.contact_method
   require_contact_method = var.require_contact_method
   tag_key                = var.tag_key
-  tag_predicate = {
-    type  = var.tag_predicate.type
-    value = var.tag_predicate.value
-  }
+  tag_predicate          = var.tag_predicate
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_service_ownership/variables.tf
+++ b/tests/remote/check_service_ownership/variables.tf
@@ -28,7 +28,7 @@ variable "tag_key" {
 variable "tag_predicate" {
   type = object({
     type  = string
-    value = optional(string)
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_service_property/main.tf
+++ b/tests/remote/check_service_property/main.tf
@@ -1,9 +1,6 @@
 resource "opslevel_check_service_property" "test" {
-  property = var.property
-  predicate = {
-    type  = var.predicate.type
-    value = var.predicate.value
-  }
+  property  = var.property
+  predicate = var.predicate
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_service_property/variables.tf
+++ b/tests/remote/check_service_property/variables.tf
@@ -22,7 +22,7 @@ variable "property" {
 variable "predicate" {
   type = object({
     type  = string
-    value = optional(string)
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_tag_defined.tftest.hcl
+++ b/tests/remote/check_tag_defined.tftest.hcl
@@ -163,14 +163,14 @@ run "resource_check_tag_defined_create_with_all_fields" {
 run "resource_check_tag_defined_update_unset_optional_fields" {
 
   variables {
-    category  = run.from_rubric_category_get_category_id.first_category.id
-    enable_on = null
-    enabled   = null
-    filter    = null
-    level     = run.from_rubric_level_get_level_id.greatest_level.id
-    notes     = null
-    owner     = null
-    # tag_predicate = null
+    category      = run.from_rubric_category_get_category_id.first_category.id
+    enable_on     = null
+    enabled       = null
+    filter        = null
+    level         = run.from_rubric_level_get_level_id.greatest_level.id
+    notes         = null
+    owner         = null
+    tag_predicate = null
   }
 
   module {
@@ -202,6 +202,10 @@ run "resource_check_tag_defined_update_unset_optional_fields" {
     error_message = var.error_expected_null_field
   }
 
+  assert {
+    condition     = opslevel_check_tag_defined.test.tag_predicate == null
+    error_message = var.error_expected_null_field
+  }
 
 }
 

--- a/tests/remote/check_tag_defined/main.tf
+++ b/tests/remote/check_tag_defined/main.tf
@@ -1,9 +1,6 @@
 resource "opslevel_check_tag_defined" "test" {
-  tag_key = var.tag_key
-  tag_predicate = {
-    type  = var.tag_predicate.type
-    value = var.tag_predicate.value
-  }
+  tag_key       = var.tag_key
+  tag_predicate = var.tag_predicate
 
   # -- check base fields --
   category  = var.category

--- a/tests/remote/check_tag_defined/variables.tf
+++ b/tests/remote/check_tag_defined/variables.tf
@@ -6,7 +6,7 @@ variable "tag_key" {
 variable "tag_predicate" {
   type = object({
     type  = string
-    value = optional(string)
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_tool_usage/main.tf
+++ b/tests/remote/check_tool_usage/main.tf
@@ -1,17 +1,8 @@
 resource "opslevel_check_tool_usage" "test" {
-  tool_category = var.tool_category
-  environment_predicate = {
-    type  = var.environment_predicate.type
-    value = var.environment_predicate.value
-  }
-  tool_name_predicate = {
-    type  = var.tool_name_predicate.type
-    value = var.tool_name_predicate.value
-  }
-  tool_url_predicate = {
-    type  = var.tool_url_predicate.type
-    value = var.tool_url_predicate.value
-  }
+  tool_category         = var.tool_category
+  environment_predicate = var.environment_predicate
+  tool_name_predicate   = var.tool_name_predicate
+  tool_url_predicate    = var.tool_url_predicate
 
 
   # -- check base fields --

--- a/tests/remote/check_tool_usage/variables.tf
+++ b/tests/remote/check_tool_usage/variables.tf
@@ -1,7 +1,7 @@
 variable "environment_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }
@@ -14,7 +14,7 @@ variable "tool_category" {
 variable "tool_name_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }
@@ -22,7 +22,7 @@ variable "tool_name_predicate" {
 variable "tool_url_predicate" {
   type = object({
     type  = string
-    value = string
+    value = optional(string, "")
   })
   description = "A condition that should be satisfied."
 }


### PR DESCRIPTION
## Issues

[Fix Terraform Predicate types across resources](https://github.com/OpsLevel/team-platform/issues/387)

## Changelog

Convert `PredicateModel` to `types.Object` - Terraform handles this better
Add some Predicate type validation. Saves HOURS of guesswork due to opaque API error messages 😞 
Update tests

- [X] List your changes here
- [X] Make a `changie` entry, 

## Tophatting

### With this config:
```tf
resource "opslevel_check_alert_source_usage" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"

  alert_type = "pagerduty"
  alert_name_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_file" "example" {
  name              = "foo"
  enabled           = true
  filepaths         = ["tbd"]
  directory_search  = false
  use_absolute_root = false
  category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner             = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter            = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_grep" "example" {
  name             = "foo"
  enabled          = true
  filepaths        = ["here", "there"]
  directory_search = false
  category         = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner            = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter           = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_search" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_service_ownership" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
}

resource "opslevel_check_service_property" "example" {
  name     = "foo"
  enabled  = true
  property = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_tag_defined" "example" {
  name     = "foo"
  enabled  = true
  tag_key  = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  tag_predicate = {
    type  = "contains"
    value = "dev"
  }
}
```

### Create resources with predicates. `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_check_alert_source_usage.example will be created
  + resource "opslevel_check_alert_source_usage" "example" {
      + alert_name_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      + alert_type           = "pagerduty"
      + category             = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description          = (known after apply)
      + enabled              = true
      + filter               = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                   = (known after apply)
      + level                = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                 = "foo"
      + owner                = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    }

  # opslevel_check_repository_file.example will be created
  + resource "opslevel_check_repository_file" "example" {
      + category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description             = (known after apply)
      + directory_search        = false
      + enabled                 = true
      + file_contents_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      + filepaths               = [
          + "tbd",
        ]
      + filter                  = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                      = (known after apply)
      + level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                    = "foo"
      + owner                   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + use_absolute_root       = false
    }

  # opslevel_check_repository_grep.example will be created
  + resource "opslevel_check_repository_grep" "example" {
      + category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description             = (known after apply)
      + directory_search        = false
      + enabled                 = true
      + file_contents_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      + filepaths               = [
          + "here",
          + "there",
        ]
      + filter                  = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                      = (known after apply)
      + level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                    = "foo"
      + owner                   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    }

  # opslevel_check_repository_search.example will be created
  + resource "opslevel_check_repository_search" "example" {
      + category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description             = (known after apply)
      + enabled                 = true
      + file_contents_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      + filter                  = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                      = (known after apply)
      + level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                    = "foo"
      + owner                   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    }

  # opslevel_check_service_ownership.example will be created
  + resource "opslevel_check_service_ownership" "example" {
      + category               = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + contact_method         = "ANY"
      + description            = (known after apply)
      + enabled                = true
      + filter                 = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                     = (known after apply)
      + level                  = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                   = "foo"
      + owner                  = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + require_contact_method = false
    }

  # opslevel_check_service_property.example will be created
  + resource "opslevel_check_service_property" "example" {
      + category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description = (known after apply)
      + enabled     = true
      + filter      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id          = (known after apply)
      + level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name        = "foo"
      + owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + predicate   = {
          + type  = "contains"
          + value = "dev"
        }
      + property    = "product"
    }

  # opslevel_check_tag_defined.example will be created
  + resource "opslevel_check_tag_defined" "example" {
      + category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description   = (known after apply)
      + enabled       = true
      + filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id            = (known after apply)
      + level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name          = "foo"
      + owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + tag_key       = "product"
      + tag_predicate = {
          + type  = "contains"
          + value = "dev"
        }
    }

Plan: 7 to add, 0 to change, 0 to destroy.
opslevel_check_tag_defined.example: Creating...
opslevel_check_service_property.example: Creating...
opslevel_check_alert_source_usage.example: Creating...
opslevel_check_repository_search.example: Creating...
opslevel_check_repository_file.example: Creating...
opslevel_check_repository_grep.example: Creating...
opslevel_check_service_ownership.example: Creating...
opslevel_check_repository_file.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM1Mw]
opslevel_check_alert_source_usage.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzU2]
opslevel_check_repository_grep.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNjM1NQ]
opslevel_check_tag_defined.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzU0]
opslevel_check_service_property.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNTg]
opslevel_check_service_ownership.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNjM1OQ]
opslevel_check_repository_search.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI2MzU3]

Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
```

### Destroy resources then, update config:
```tf
resource "opslevel_check_alert_source_usage" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"

  alert_type = "pagerduty"
  # alert_name_predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}

resource "opslevel_check_repository_file" "example" {
  name              = "foo"
  enabled           = true
  filepaths         = ["tbd"]
  directory_search  = false
  use_absolute_root = false
  category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner             = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter            = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  # file_contents_predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}

resource "opslevel_check_repository_grep" "example" {
  name             = "foo"
  enabled          = true
  filepaths        = ["here", "there"]
  directory_search = false
  category         = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner            = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter           = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_search" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_service_ownership" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
}

resource "opslevel_check_service_property" "example" {
  name     = "foo"
  enabled  = true
  property = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  # predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}

resource "opslevel_check_tag_defined" "example" {
  name     = "foo"
  enabled  = true
  tag_key  = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  # tag_predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}
```

### Create resources without optional predicates. `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_check_alert_source_usage.example will be created
  + resource "opslevel_check_alert_source_usage" "example" {
      + alert_type  = "pagerduty"
      + category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description = (known after apply)
      + enabled     = true
      + filter      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id          = (known after apply)
      + level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name        = "foo"
      + owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    }

  # opslevel_check_repository_file.example will be created
  + resource "opslevel_check_repository_file" "example" {
      + category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description       = (known after apply)
      + directory_search  = false
      + enabled           = true
      + filepaths         = [
          + "tbd",
        ]
      + filter            = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                = (known after apply)
      + level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name              = "foo"
      + owner             = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + use_absolute_root = false
    }

  # opslevel_check_repository_grep.example will be created
  + resource "opslevel_check_repository_grep" "example" {
      + category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description             = (known after apply)
      + directory_search        = false
      + enabled                 = true
      + file_contents_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      + filepaths               = [
          + "here",
          + "there",
        ]
      + filter                  = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                      = (known after apply)
      + level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                    = "foo"
      + owner                   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    }

  # opslevel_check_repository_search.example will be created
  + resource "opslevel_check_repository_search" "example" {
      + category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description             = (known after apply)
      + enabled                 = true
      + file_contents_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      + filter                  = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                      = (known after apply)
      + level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                    = "foo"
      + owner                   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    }

  # opslevel_check_service_ownership.example will be created
  + resource "opslevel_check_service_ownership" "example" {
      + category               = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + contact_method         = "ANY"
      + description            = (known after apply)
      + enabled                = true
      + filter                 = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id                     = (known after apply)
      + level                  = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name                   = "foo"
      + owner                  = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + require_contact_method = false
    }

  # opslevel_check_service_property.example will be created
  + resource "opslevel_check_service_property" "example" {
      + category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description = (known after apply)
      + enabled     = true
      + filter      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id          = (known after apply)
      + level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name        = "foo"
      + owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + property    = "product"
    }

  # opslevel_check_tag_defined.example will be created
  + resource "opslevel_check_tag_defined" "example" {
      + category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description = (known after apply)
      + enabled     = true
      + filter      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
      + id          = (known after apply)
      + level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
      + name        = "foo"
      + owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + tag_key     = "product"
    }

Plan: 7 to add, 0 to change, 0 to destroy.
opslevel_check_alert_source_usage.example: Creating...
opslevel_check_tag_defined.example: Creating...
opslevel_check_service_property.example: Creating...
opslevel_check_repository_search.example: Creating...
opslevel_check_service_ownership.example: Creating...
opslevel_check_repository_grep.example: Creating...
opslevel_check_repository_file.example: Creating...
opslevel_check_service_property.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_service_ownership.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNjM2Mg]
opslevel_check_alert_source_usage.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_repository_grep.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNjM2NA]
opslevel_check_repository_search.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI2MzYx]
opslevel_check_tag_defined.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]
opslevel_check_repository_file.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]

Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
```

### Update config, (add optional predicates)
```tf
resource "opslevel_check_alert_source_usage" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"

  alert_type = "pagerduty"
  alert_name_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_file" "example" {
  name              = "foo"
  enabled           = true
  filepaths         = ["tbd"]
  directory_search  = false
  use_absolute_root = false
  category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner             = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter            = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_grep" "example" {
  name             = "foo"
  enabled          = true
  filepaths        = ["here", "there"]
  directory_search = false
  category         = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner            = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter           = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_search" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_service_ownership" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
}

resource "opslevel_check_service_property" "example" {
  name     = "foo"
  enabled  = true
  property = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_tag_defined" "example" {
  name     = "foo"
  enabled  = true
  tag_key  = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  tag_predicate = {
    type  = "contains"
    value = "dev"
  }
}
```

### Update resources, add optional predicates. `terraform apply`
```tf
opslevel_check_repository_search.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI2MzYx]
opslevel_check_tag_defined.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]
opslevel_check_service_property.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_service_ownership.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNjM2Mg]
opslevel_check_alert_source_usage.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_repository_file.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_repository_grep.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNjM2NA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_check_alert_source_usage.example will be updated in-place
  ~ resource "opslevel_check_alert_source_usage" "example" {
      + alert_name_predicate = {
          + type  = "contains"
          + value = "dev"
        }
      ~ description          = "The service is using a PagerDuty alert source." -> (known after apply)
        id                   = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz"
        name                 = "foo"
        # (6 unchanged attributes hidden)
    }

  # opslevel_check_repository_file.example will be updated in-place
  ~ resource "opslevel_check_repository_file" "example" {
      ~ description             = "Repo file 'tbd' exists." -> (known after apply)
      + file_contents_predicate = {
          + type  = "contains"
          + value = "dev"
        }
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng"
        name                    = "foo"
        # (8 unchanged attributes hidden)
    }

  # opslevel_check_service_property.example will be updated in-place
  ~ resource "opslevel_check_service_property" "example" {
      ~ description = "The service has a product." -> (known after apply)
        id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA"
        name        = "foo"
      + predicate   = {
          + type  = "contains"
          + value = "dev"
        }
        # (6 unchanged attributes hidden)
    }

  # opslevel_check_tag_defined.example will be updated in-place
  ~ resource "opslevel_check_tag_defined" "example" {
      ~ description   = "Verifies that the service has the specified tag defined." -> (known after apply)
        id            = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1"
        name          = "foo"
      + tag_predicate = {
          + type  = "contains"
          + value = "dev"
        }
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 4 to change, 0 to destroy.
opslevel_check_tag_defined.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]
opslevel_check_service_property.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_repository_file.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_alert_source_usage.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_repository_file.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_alert_source_usage.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_service_property.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_tag_defined.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]

Apply complete! Resources: 0 added, 4 changed, 0 destroyed.
```

### Update config (remove optional predicates)
```tf
resource "opslevel_check_alert_source_usage" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"

  alert_type = "pagerduty"
  # alert_name_predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}

resource "opslevel_check_repository_file" "example" {
  name              = "foo"
  enabled           = true
  filepaths         = ["tbd"]
  directory_search  = false
  use_absolute_root = false
  category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner             = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter            = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  # file_contents_predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}

resource "opslevel_check_repository_grep" "example" {
  name             = "foo"
  enabled          = true
  filepaths        = ["here", "there"]
  directory_search = false
  category         = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner            = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter           = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_repository_search" "example" {
  name    = "foo"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  file_contents_predicate = {
    type  = "contains"
    value = "dev"
  }
}

resource "opslevel_check_service_ownership" "example" {
  name     = "foo"
  enabled  = true
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
}

resource "opslevel_check_service_property" "example" {
  name     = "foo"
  enabled  = true
  property = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  # predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}

resource "opslevel_check_tag_defined" "example" {
  name     = "foo"
  enabled  = true
  tag_key  = "product"
  category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA"
  owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk"
  # tag_predicate = {
  #   type  = "contains"
  #   value = "dev"
  # }
}
```

### Update resources, remove optional predicates. `terraform apply`
```tf
opslevel_check_repository_search.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI2MzYx]
opslevel_check_repository_file.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_tag_defined.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]
opslevel_check_service_ownership.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNjM2Mg]
opslevel_check_alert_source_usage.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_service_property.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_repository_grep.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNjM2NA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_check_alert_source_usage.example will be updated in-place
  ~ resource "opslevel_check_alert_source_usage" "example" {
      - alert_name_predicate = {
          - type  = "contains" -> null
          - value = "dev" -> null
        } -> null
      ~ description          = "The service is using a PagerDuty alert source whose name contains 'dev'." -> (known after apply)
        id                   = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz"
        name                 = "foo"
        # (6 unchanged attributes hidden)
    }

  # opslevel_check_repository_file.example will be updated in-place
  ~ resource "opslevel_check_repository_file" "example" {
      ~ description             = "Repo file 'tbd' contains 'dev'." -> (known after apply)
      - file_contents_predicate = {
          - type  = "contains" -> null
          - value = "dev" -> null
        } -> null
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng"
        name                    = "foo"
        # (8 unchanged attributes hidden)
    }

  # opslevel_check_service_property.example will be updated in-place
  ~ resource "opslevel_check_service_property" "example" {
      ~ description = "The service has a product that contains <code>dev</code>" -> (known after apply)
        id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA"
        name        = "foo"
      - predicate   = {
          - type  = "contains" -> null
          - value = "dev" -> null
        } -> null
        # (6 unchanged attributes hidden)
    }

  # opslevel_check_tag_defined.example will be updated in-place
  ~ resource "opslevel_check_tag_defined" "example" {
      ~ description   = "Verifies that the service has the specified tag defined." -> (known after apply)
        id            = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1"
        name          = "foo"
      - tag_predicate = {
          - type  = "contains" -> null
          - value = "dev" -> null
        } -> null
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 4 to change, 0 to destroy.
opslevel_check_tag_defined.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]
opslevel_check_alert_source_usage.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_service_property.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_repository_file.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_alert_source_usage.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_repository_file.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_service_property.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_tag_defined.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]

Apply complete! Resources: 0 added, 4 changed, 0 destroyed.
```

### Destroy resources `terraform destroy`
```tf
opslevel_check_service_property.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_service_ownership.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNjM2Mg]
opslevel_check_repository_file.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_alert_source_usage.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_tag_defined.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]
opslevel_check_repository_search.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI2MzYx]
opslevel_check_repository_grep.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNjM2NA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_check_alert_source_usage.example will be destroyed
  - resource "opslevel_check_alert_source_usage" "example" {
      - alert_type  = "pagerduty" -> null
      - category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description = "The service is using a PagerDuty alert source." -> null
      - enabled     = true -> null
      - filter      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz" -> null
      - level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name        = "foo" -> null
      - owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
    }

  # opslevel_check_repository_file.example will be destroyed
  - resource "opslevel_check_repository_file" "example" {
      - category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description       = "Repo file 'tbd' exists." -> null
      - directory_search  = false -> null
      - enabled           = true -> null
      - filepaths         = [
          - "tbd",
        ] -> null
      - filter            = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id                = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng" -> null
      - level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name              = "foo" -> null
      - owner             = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
      - use_absolute_root = false -> null
    }

  # opslevel_check_repository_grep.example will be destroyed
  - resource "opslevel_check_repository_grep" "example" {
      - category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description             = "Verifies the existence and/or contents of files in a service's attached Git repositories." -> null
      - directory_search        = false -> null
      - enabled                 = true -> null
      - file_contents_predicate = {
          - type  = "contains" -> null
          - value = "dev" -> null
        } -> null
      - filepaths               = [
          - "here",
          - "there",
        ] -> null
      - filter                  = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNjM2NA" -> null
      - level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name                    = "foo" -> null
      - owner                   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
    }

  # opslevel_check_repository_search.example will be destroyed
  - resource "opslevel_check_repository_search" "example" {
      - category                = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description             = "Repo contains search term 'dev' in at least one file." -> null
      - enabled                 = true -> null
      - file_contents_predicate = {
          - type  = "contains" -> null
          - value = "dev" -> null
        } -> null
      - filter                  = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI2MzYx" -> null
      - level                   = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name                    = "foo" -> null
      - owner                   = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
    }

  # opslevel_check_service_ownership.example will be destroyed
  - resource "opslevel_check_service_ownership" "example" {
      - category               = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - contact_method         = "ANY" -> null
      - description            = "Verifies that the service has an owner defined and with an optional requirement for a contact method and/or tag to be associated with that owner." -> null
      - enabled                = true -> null
      - filter                 = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id                     = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNjM2Mg" -> null
      - level                  = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name                   = "foo" -> null
      - owner                  = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
      - require_contact_method = false -> null
    }

  # opslevel_check_service_property.example will be destroyed
  - resource "opslevel_check_service_property" "example" {
      - category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description = "The service has a product." -> null
      - enabled     = true -> null
      - filter      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA" -> null
      - level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name        = "foo" -> null
      - owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
      - property    = "product" -> null
    }

  # opslevel_check_tag_defined.example will be destroyed
  - resource "opslevel_check_tag_defined" "example" {
      - category    = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description = "Verifies that the service has the specified tag defined." -> null
      - enabled     = true -> null
      - filter      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1Njk" -> null
      - id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1" -> null
      - level       = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcwOA" -> null
      - name        = "foo" -> null
      - owner       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
      - tag_key     = "product" -> null
    }

Plan: 0 to add, 0 to change, 7 to destroy.
opslevel_check_repository_search.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvU2VhcmNoLzI2MzYx]
opslevel_check_alert_source_usage.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI2MzYz]
opslevel_check_service_property.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjYzNjA]
opslevel_check_repository_grep.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvR3JlcC8yNjM2NA]
opslevel_check_repository_file.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNjM2Ng]
opslevel_check_tag_defined.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI2MzY1]
opslevel_check_service_ownership.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNjM2Mg]
opslevel_check_service_ownership.example: Destruction complete after 1s
opslevel_check_repository_file.example: Destruction complete after 1s
opslevel_check_service_property.example: Destruction complete after 1s
opslevel_check_repository_grep.example: Destruction complete after 1s
opslevel_check_repository_search.example: Destruction complete after 1s
opslevel_check_tag_defined.example: Destruction complete after 1s
opslevel_check_alert_source_usage.example: Destruction complete after 1s

Destroy complete! Resources: 7 destroyed.
```