### PR TITLE
add categories field to scorecard data sources

### DIFF
--- a/.changes/unreleased/Feature-20240612-112423.yaml
+++ b/.changes/unreleased/Feature-20240612-112423.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add rubric category data to scorecard data sources
+time: 2024-06-12T11:24:23.055722-05:00

--- a/examples/data-sources/opslevel_scorecard/data-source.tf
+++ b/examples/data-sources/opslevel_scorecard/data-source.tf
@@ -6,3 +6,10 @@ data "opslevel_scorecard" "bar" {
   identifier = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Njcw"
 }
 
+output "foo_category_ids" {
+  value = flatten(data.opslevel_scorecard.foo.categories[*].id)
+}
+
+output "foo_categories" {
+  value = data.opslevel_scorecard.foo.categories
+}

--- a/tests/local/datasource_scorecard.tftest.hcl
+++ b/tests/local/datasource_scorecard.tftest.hcl
@@ -19,6 +19,11 @@ run "datasource_scorecard_mocked_fields" {
   }
 
   assert {
+    condition     = can(data.opslevel_scorecard.mock_scorecard.categories)
+    error_message = "categories attribute missing from opslevel_scorecard.mock_scorecard"
+  }
+
+  assert {
     condition     = data.opslevel_scorecard.mock_scorecard.description == "mock-scorecard-description"
     error_message = "wrong description in opslevel_scorecard mock"
   }

--- a/tests/remote/scorecard.tftest.hcl
+++ b/tests/remote/scorecard.tftest.hcl
@@ -204,6 +204,7 @@ run "datasource_scorecard_first" {
     condition = alltrue([
       can(data.opslevel_scorecard.first_scorecard_by_id.affects_overall_service_levels),
       can(data.opslevel_scorecard.first_scorecard_by_id.aliases),
+      can(data.opslevel_scorecard.first_scorecard_by_id.categories),
       can(data.opslevel_scorecard.first_scorecard_by_id.description),
       can(data.opslevel_scorecard.first_scorecard_by_id.filter_id),
       can(data.opslevel_scorecard.first_scorecard_by_id.id),


### PR DESCRIPTION
## Issues

[Add Categories field to Scorecard datasource](https://github.com/OpsLevel/team-platform/issues/388)

## Changelog

Add categories field to both `opslevel_scorecard` and `opslevel_scorecards` datasources.
Add this field to relevant tests.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this Terraform config
```tf
data "opslevel_scorecards" "all" {}

data "opslevel_scorecard" "one" {
  identifier = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzEzMTg"
}

resource "opslevel_check_has_documentation" "has_docs" {
  name             = "foobarbaz"
  enabled          = true
  category         = data.opslevel_scorecard.one.categories[0].id
  level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
  owner            = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter           = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
  notes            = "Optional additional info on why this check is run or how to fix it"
  document_type    = "api"
  document_subtype = "openapi"
}

output "all_categories" {
  value = data.opslevel_scorecards.all.scorecards[*].categories
}

output "one_categories" {
  value = data.opslevel_scorecard.one.categories
}

output "one_category_ids" {
  value = flatten(data.opslevel_scorecard.one.categories[*].id)
}

output "all_category_ids" {
  value = flatten(data.opslevel_scorecards.all.scorecards[*].categories[*].id)
}

output "one" {
  value = data.opslevel_scorecard.one
}
```

### Run `terraform plan`
```tf
data.opslevel_scorecards.all: Reading...
data.opslevel_scorecard.one: Reading...
data.opslevel_scorecard.one: Read complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzEzMTg]
data.opslevel_scorecards.all: Read complete after 1s

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_check_has_documentation.has_docs will be created
  + resource "opslevel_check_has_documentation" "has_docs" {
      + category         = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODMyMQ"
      + description      = (known after apply)
      + document_subtype = "openapi"
      + document_type    = "api"
      + enabled          = true
      + filter           = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
      + id               = (known after apply)
      + level            = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
      + name             = "foobarbaz"
      + notes            = "Optional additional info on why this check is run or how to fix it"
      + owner            = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + all_categories   = [
      + [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODMyMQ"
              + name = "Test Scorecard"
            },
        ],
    ]
  + all_category_ids = [
      + "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODMyMQ",
    ]
  + one              = {
      + affects_overall_service_levels = false
      + aliases                        = [
          + "test_scorecard",
        ]
      + categories                     = [
          + {
              + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODMyMQ"
              + name = "Test Scorecard"
            },
        ]
      + description                    = "example_description"
      + filter_id                      = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
      + id                             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzEzMTg"
      + identifier                     = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzEzMTg"
      + name                           = "Test Scorecard"
      + owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + passing_checks                 = 0
      + service_count                  = 2
      + total_checks                   = 0
    }
  + one_categories   = [
      + {
          + id   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODMyMQ"
          + name = "Test Scorecard"
        },
    ]
  + one_category_ids = [
      + "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODMyMQ",
    ]
```
