### PR TITLE
fix setting of opslevel_filter fields, add config validation

### DIFF
--- a/.changes/unreleased/Bugfix-20240613-102557.yaml
+++ b/.changes/unreleased/Bugfix-20240613-102557.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix opslevel_filter predicate fields 'case_sensitive', 'case_insensitive' - they were set incorrectly
+time: 2024-06-13T10:25:57.450254-05:00

--- a/.changes/unreleased/Bugfix-20240614-122130.yaml
+++ b/.changes/unreleased/Bugfix-20240614-122130.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix unsetting case sensitive fields in opslevel_filter predicate list
+time: 2024-06-14T12:21:30.22545-05:00

--- a/.changes/unreleased/Bugfix-20240614-151336.yaml
+++ b/.changes/unreleased/Bugfix-20240614-151336.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix predicate value fields. may be set or null, but not empty string
+time: 2024-06-14T15:13:36.192194-05:00

--- a/.changes/unreleased/Deprecated-20240614-151143.yaml
+++ b/.changes/unreleased/Deprecated-20240614-151143.yaml
@@ -1,0 +1,3 @@
+kind: Deprecated
+body: the case_insensitive field in opslevel_filter is marked for removal
+time: 2024-06-14T15:11:43.133723-05:00

--- a/.changes/unreleased/Feature-20240613-102821.yaml
+++ b/.changes/unreleased/Feature-20240613-102821.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add filter predicate config validation
+time: 2024-06-13T10:28:21.215672-05:00

--- a/.changes/unreleased/Refactor-20240614-121951.yaml
+++ b/.changes/unreleased/Refactor-20240614-121951.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: change opslevel_filter predicate field to Terraform List from []filterPredicate
+time: 2024-06-14T12:19:51.916004-05:00

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -78,7 +78,7 @@ func NewCheckAlertSourceUsageResourceModel(ctx context.Context, check opslevel.C
 		predicate := *check.AlertSourceNamePredicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.AlertNamePredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -129,6 +129,9 @@ func PredicateSchema() schema.SingleNestedAttribute {
 			"value": schema.StringAttribute{
 				Description: "The condition value used by the predicate.",
 				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.NoneOf(""),
+				},
 			},
 		},
 	}

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -91,13 +91,6 @@ var predicateType = map[string]attr.Type{
 	"value": types.StringType,
 }
 
-func NewPredicateModel(predicate opslevel.Predicate) *PredicateModel {
-	return &PredicateModel{
-		Type:  RequiredStringValue(string(predicate.Type)),
-		Value: OptionalStringValue(predicate.Value),
-	}
-}
-
 func (p PredicateModel) Validate() error {
 	predicate := opslevel.Predicate{
 		Type:  opslevel.PredicateTypeEnum(p.Type.ValueString()),

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -81,7 +81,7 @@ func NewCheckRepositoryFileResourceModel(ctx context.Context, check opslevel.Che
 		predicate := *check.RepositoryFileCheckFragment.FileContentsPredicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.FileContentsPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -78,7 +78,7 @@ func NewCheckRepositoryGrepResourceModel(ctx context.Context, check opslevel.Che
 	predicate := check.RepositoryGrepCheckFragment.FileContentsPredicate
 	predicateAttrValues := map[string]attr.Value{
 		"type":  types.StringValue(string(predicate.Type)),
-		"value": types.StringValue(predicate.Value),
+		"value": OptionalStringValue(predicate.Value),
 	}
 	stateModel.FileContentsPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -84,7 +84,7 @@ func NewCheckRepositorySearchResourceModel(ctx context.Context, check opslevel.C
 	predicate := check.RepositorySearchCheckFragment.FileContentsPredicate
 	predicateAttrValues := map[string]attr.Value{
 		"type":  types.StringValue(string(predicate.Type)),
-		"value": types.StringValue(predicate.Value),
+		"value": OptionalStringValue(predicate.Value),
 	}
 	stateModel.FileContentsPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -92,7 +92,7 @@ func NewCheckServiceOwnershipResourceModel(ctx context.Context, check opslevel.C
 		predicate := *&check.ServiceOwnershipCheckFragment.TeamTagPredicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.TagPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -79,7 +79,7 @@ func NewCheckServicePropertyResourceModel(ctx context.Context, check opslevel.Ch
 		predicate := *check.ServicePropertyCheckFragment.Predicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.Predicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -76,7 +76,7 @@ func NewCheckTagDefinedResourceModel(ctx context.Context, check opslevel.Check, 
 		predicate := *check.TagPredicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.TagPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -80,7 +80,7 @@ func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check, p
 		predicate := *check.ToolNamePredicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.ToolNamePredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}
@@ -91,7 +91,7 @@ func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check, p
 		predicate := *check.ToolUrlPredicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.ToolUrlPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}
@@ -102,7 +102,7 @@ func NewCheckToolUsageResourceModel(ctx context.Context, check opslevel.Check, p
 		predicate := *check.EnvironmentPredicate
 		predicateAttrValues := map[string]attr.Value{
 			"type":  types.StringValue(string(predicate.Type)),
-			"value": types.StringValue(predicate.Value),
+			"value": OptionalStringValue(predicate.Value),
 		}
 		stateModel.EnvironmentPredicate = types.ObjectValueMust(predicateType, predicateAttrValues)
 	}

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -138,13 +138,13 @@ func (r *FilterResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							Description: "Option for determining whether to compare strings case-sensitively. Not settable for all predicate types.",
 							Optional:    true,
 							Computed:    true,
-							Validators:  []validator.Bool{boolvalidator.ConflictsWith(path.MatchRoot("case_sensitive"))},
+							Validators:  []validator.Bool{boolvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("case_sensitive"))},
 						},
 						"case_sensitive": schema.BoolAttribute{
 							Description: "Option for determining whether to compare strings case-sensitively. Not settable for all predicate types.",
 							Optional:    true,
 							Computed:    true,
-							Validators:  []validator.Bool{boolvalidator.ConflictsWith(path.MatchRoot("case_insensitive"))},
+							Validators:  []validator.Bool{boolvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("case_insensitive"))},
 						},
 						"key": schema.StringAttribute{
 							Description: fmt.Sprintf(

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -7,12 +7,15 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -36,13 +39,13 @@ type FilterResource struct {
 
 // FilterResourceModel describes the Filter managed resource.
 type FilterResourceModel struct {
-	Connective types.String      `tfsdk:"connective"`
-	Id         types.String      `tfsdk:"id"`
-	Name       types.String      `tfsdk:"name"`
-	Predicate  []filterPredicate `tfsdk:"predicate"`
+	Connective types.String `tfsdk:"connective"`
+	Id         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	Predicate  types.List   `tfsdk:"predicate"`
 }
 
-type filterPredicate struct {
+type filterPredicateModel struct {
 	CaseInsensitive types.Bool   `tfsdk:"case_insensitive"`
 	CaseSensitive   types.Bool   `tfsdk:"case_sensitive"`
 	Key             types.String `tfsdk:"key"`
@@ -51,7 +54,16 @@ type filterPredicate struct {
 	Value           types.String `tfsdk:"value"`
 }
 
-func (fp filterPredicate) Validate() error {
+var filterPredicateType = map[string]attr.Type{
+	"case_insensitive": types.BoolType,
+	"case_sensitive":   types.BoolType,
+	"key":              types.StringType,
+	"key_data":         types.StringType,
+	"type":             types.StringType,
+	"value":            types.StringType,
+}
+
+func (fp filterPredicateModel) Validate() error {
 	opslevelFilterPredicate := opslevel.FilterPredicate{
 		CaseSensitive: fp.CaseSensitive.ValueBoolPointer(),
 		Key:           opslevel.PredicateKeyEnum(fp.Key.ValueString()),
@@ -65,37 +77,52 @@ func (fp filterPredicate) Validate() error {
 	return opslevelFilterPredicate.Validate()
 }
 
-func convertPredicate(predicate opslevel.FilterPredicate) filterPredicate {
-	convertedFilterPredicate := filterPredicate{
-		CaseSensitive:   types.BoolNull(),
-		CaseInsensitive: types.BoolNull(),
-		Key:             RequiredStringValue(string(predicate.Key)),
-		KeyData:         OptionalStringValue(predicate.KeyData),
-		Type:            RequiredStringValue(string(predicate.Type)),
-		Value:           OptionalStringValue(predicate.Value),
-	}
-	if predicate.CaseSensitive != nil {
-		isCaseSensitive := *predicate.CaseSensitive
-		if isCaseSensitive {
-			convertedFilterPredicate.CaseSensitive = types.BoolValue(true)
-		} else {
-			convertedFilterPredicate.CaseSensitive = types.BoolValue(false)
-		}
-	}
-	return convertedFilterPredicate
-}
+func NewFilterResourceModel(ctx context.Context, filter opslevel.Filter, givenModel FilterResourceModel) (FilterResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var filterPredicateAttrs []attr.Value
+	var filterPredicatesListValue basetypes.ListValue
+	var givenPredicateModels []filterPredicateModel
 
-func NewFilterResourceModel(filter opslevel.Filter) FilterResourceModel {
-	filterPredicates := []filterPredicate{}
-	for _, predicate := range filter.Predicates {
-		filterPredicates = append(filterPredicates, convertPredicate(predicate))
+	// Convert predicates from plan to slice of models
+	givenModel.Predicate.ElementsAs(ctx, &givenPredicateModels, false)
+
+	for _, opslevelPredicate := range filter.Predicates {
+		predicateObj := OpslevelFilterPredicateToObjectValue(nil, &opslevelPredicate)
+		attrs := predicateObj.Attributes()
+
+		// find predicate from plan that matches predicateObj from API
+		foundPlanPredModel, extractDiags := ExtractFilterPredicateModel(ctx, attrs, givenPredicateModels)
+		diags.Append(extractDiags...)
+		if diags.HasError() {
+			return FilterResourceModel{}, diags
+		}
+
+		if !foundPlanPredModel.CaseSensitive.IsNull() && !foundPlanPredModel.CaseSensitive.IsUnknown() {
+			attrs["case_sensitive"] = types.BoolValue(*opslevelPredicate.CaseSensitive)
+		} else {
+			attrs["case_sensitive"] = types.BoolNull()
+		}
+		if !foundPlanPredModel.CaseInsensitive.IsNull() && !foundPlanPredModel.CaseInsensitive.IsUnknown() {
+			attrs["case_insensitive"] = types.BoolValue(*opslevelPredicate.CaseSensitive)
+		} else {
+			attrs["case_insensitive"] = types.BoolNull()
+		}
+
+		predicateObj = types.ObjectValueMust(filterPredicateType, attrs)
+		filterPredicateAttrs = append(filterPredicateAttrs, predicateObj)
 	}
+	if len(filterPredicateAttrs) == 0 {
+		filterPredicatesListValue = types.ListNull(types.ObjectType{AttrTypes: filterPredicateType})
+	} else {
+		filterPredicatesListValue = types.ListValueMust(types.ObjectType{AttrTypes: filterPredicateType}, filterPredicateAttrs)
+	}
+
 	return FilterResourceModel{
-		Connective: OptionalStringValue(string(filter.Connective)),
+		Connective: givenModel.Connective,
 		Id:         ComputedStringValue(string(filter.Id)),
 		Name:       RequiredStringValue(filter.Name),
-		Predicate:  filterPredicates,
-	}
+		Predicate:  filterPredicatesListValue,
+	}, diags
 }
 
 func (r *FilterResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -183,12 +210,18 @@ func (r *FilterResource) Schema(ctx context.Context, req resource.SchemaRequest,
 
 func (r *FilterResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel FilterResourceModel
+	var predicateModels []filterPredicateModel
+
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(configModel.Predicate.ElementsAs(ctx, &predicateModels, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	for _, filterPredicate := range configModel.Predicate {
+	for _, filterPredicate := range predicateModels {
 		if err := filterPredicate.Validate(); err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("predicate"), "Invalid Attribute Configuration", err.Error())
 		}
@@ -197,14 +230,18 @@ func (r *FilterResource) ValidateConfig(ctx context.Context, req resource.Valida
 
 func (r *FilterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var planModel FilterResourceModel
+	var predicateModels []filterPredicateModel
 
-	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	predicates, err := getFilterPredicates(planModel.Predicate)
+
+	resp.Diagnostics.Append(planModel.Predicate.ElementsAs(ctx, &predicateModels, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	predicates, err := getFilterPredicates(predicateModels)
 	if err != nil {
 		resp.Diagnostics.AddError("Config error", fmt.Sprintf("misconfigured filter predicate, got error: %s", err))
 		return
@@ -219,45 +256,55 @@ func (r *FilterResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create filter, got error: %s", err))
 		return
 	}
-	stateModel := NewFilterResourceModel(*filter)
-	stateModel.Connective = planModel.Connective
+	stateModel, diags := NewFilterResourceModel(ctx, *filter, planModel)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "created a filter resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
 }
 
 func (r *FilterResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var planModel FilterResourceModel
+	var stateModel FilterResourceModel
 
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateModel)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	filter, err := r.client.GetFilter(opslevel.ID(planModel.Id.ValueString()))
+	filter, err := r.client.GetFilter(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read filter, got error: %s", err))
 		return
 	}
-	stateModel := NewFilterResourceModel(*filter)
-	stateModel.Connective = planModel.Connective
+	verifiedStateModel, diags := NewFilterResourceModel(ctx, *filter, stateModel)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &verifiedStateModel)...)
 }
 
 func (r *FilterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var planModel FilterResourceModel
+	var predicateModels []filterPredicateModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(planModel.Predicate.ElementsAs(ctx, &predicateModels, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	predicates, err := getFilterPredicates(planModel.Predicate)
+	predicates, err := getFilterPredicates(predicateModels)
 	if err != nil {
 		resp.Diagnostics.AddError("Config error", fmt.Sprintf("misconfigured filter predicate, got error: %s", err))
 		return
@@ -278,8 +325,11 @@ func (r *FilterResource) Update(ctx context.Context, req resource.UpdateRequest,
 		updatedFilter.Connective = *connectiveEnum
 	}
 
-	stateModel := NewFilterResourceModel(*updatedFilter)
-	stateModel.Connective = planModel.Connective
+	stateModel, diags := NewFilterResourceModel(ctx, *updatedFilter, planModel)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	tflog.Trace(ctx, "updated a filter resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
@@ -317,8 +367,9 @@ func getConnectiveEnum(connective string) *opslevel.ConnectiveEnum {
 	}
 }
 
-func getFilterPredicates(predicates []filterPredicate) (*[]opslevel.FilterPredicateInput, error) {
+func getFilterPredicates(predicates []filterPredicateModel) (*[]opslevel.FilterPredicateInput, error) {
 	filterPredicateInputs := []opslevel.FilterPredicateInput{}
+
 	for _, predicate := range predicates {
 		tmpPredicateInput := opslevel.FilterPredicateInput{
 			Key:     opslevel.PredicateKeyEnum(predicate.Key.ValueString()),
@@ -326,19 +377,20 @@ func getFilterPredicates(predicates []filterPredicate) (*[]opslevel.FilterPredic
 			Type:    opslevel.PredicateTypeEnum(predicate.Type.ValueString()),
 			Value:   predicate.Value.ValueStringPointer(),
 		}
+		isCaseSensitiveSet := !predicate.CaseSensitive.IsNull() && !predicate.CaseSensitive.IsUnknown()
+		isCaseInsensitiveSet := !predicate.CaseInsensitive.IsNull() && !predicate.CaseInsensitive.IsUnknown()
 
-		if predicate.CaseSensitive.ValueBool() && predicate.CaseInsensitive.ValueBool() {
+		if isCaseSensitiveSet && isCaseInsensitiveSet {
 			return nil, fmt.Errorf("a predicate should not have 'case_sensitive' and 'case_insensitive' set at the same time")
-		} else if predicate.CaseSensitive.ValueBool() {
-			tmpPredicateInput.CaseSensitive = opslevel.RefOf(true)
-		} else if predicate.CaseInsensitive.ValueBool() {
-			tmpPredicateInput.CaseSensitive = opslevel.RefOf(false)
+		}
+		if isCaseSensitiveSet {
+			tmpPredicateInput.CaseSensitive = opslevel.RefOf(predicate.CaseSensitive.ValueBool())
+		} else if isCaseInsensitiveSet {
+			tmpPredicateInput.CaseSensitive = opslevel.RefOf(predicate.CaseInsensitive.ValueBool())
 		}
 
 		filterPredicateInputs = append(filterPredicateInputs, tmpPredicateInput)
 	}
-	if len(filterPredicateInputs) > 0 {
-		return &filterPredicateInputs, nil
-	}
-	return nil, nil
+
+	return &filterPredicateInputs, nil
 }

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -162,10 +162,11 @@ func (r *FilterResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"case_insensitive": schema.BoolAttribute{
-							Description: "Option for determining whether to compare strings case-sensitively. Not settable for all predicate types.",
-							Optional:    true,
-							Computed:    true,
-							Validators:  []validator.Bool{boolvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("case_sensitive"))},
+							Description:        "Option for determining whether to compare strings case-sensitively. Not settable for all predicate types.",
+							DeprecationMessage: "The 'case_insensitive' field is deprecated. Please use 'case_sensitive' only.",
+							Optional:           true,
+							Computed:           true,
+							Validators:         []validator.Bool{boolvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("case_sensitive"))},
 						},
 						"case_sensitive": schema.BoolAttribute{
 							Description: "Option for determining whether to compare strings case-sensitively. Not settable for all predicate types.",
@@ -200,6 +201,9 @@ func (r *FilterResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						"value": schema.StringAttribute{
 							Description: "The condition value used by the predicate.",
 							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.NoneOf(""),
+							},
 						},
 					},
 				},

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -162,6 +162,9 @@ func PredicateObjectToModel(ctx context.Context, predicateObj basetypes.ObjectVa
 
 	objOptions := basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true}
 	diags := predicateObj.As(ctx, &predicateModel, objOptions)
+	if predicateModel.Value.ValueString() == "" {
+		predicateModel.Value = types.StringNull()
+	}
 	return predicateModel, diags
 }
 

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -103,6 +104,56 @@ func MapValueToOpslevelJson(ctx context.Context, mapValue basetypes.MapValue) (o
 		mapAsJson[k] = v
 	}
 	return mapAsJson, diags
+}
+
+// Converts an opslevel.FilterPredicate to a basetypes.ObjectValue
+// - both case sensitive fields need to be set by calling function
+func OpslevelFilterPredicateToObjectValue(ctx context.Context, filterPredicate *opslevel.FilterPredicate) basetypes.ObjectValue {
+	if filterPredicate == nil {
+		return types.ObjectNull(filterPredicateType)
+	}
+	predicateAttrValues := map[string]attr.Value{
+		"case_insensitive": types.BoolNull(),
+		"case_sensitive":   types.BoolNull(),
+		"key":              RequiredStringValue(string(filterPredicate.Key)),
+		"key_data":         OptionalStringValue(filterPredicate.KeyData),
+		"type":             RequiredStringValue(string(filterPredicate.Type)),
+		"value":            OptionalStringValue(filterPredicate.Value),
+	}
+	return types.ObjectValueMust(filterPredicateType, predicateAttrValues)
+}
+
+func FilterPredicateObjectToModel(ctx context.Context, filterPredicateObj basetypes.ObjectValue) (filterPredicateModel, diag.Diagnostics) {
+	var predicateModel filterPredicateModel
+
+	objOptions := basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true}
+	diags := filterPredicateObj.As(ctx, &predicateModel, objOptions)
+	return predicateModel, diags
+}
+
+func ExtractFilterPredicateModel(ctx context.Context, predicateWantedAttrs map[string]attr.Value, givenModels []filterPredicateModel) (filterPredicateModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	for _, givenPredicateModel := range givenModels {
+		if predicateWantedAttrs["key"] == givenPredicateModel.Key &&
+			predicateWantedAttrs["key_data"] == givenPredicateModel.KeyData &&
+			predicateWantedAttrs["type"] == givenPredicateModel.Type &&
+			predicateWantedAttrs["value"] == givenPredicateModel.Value {
+			return givenPredicateModel, diags
+		}
+	}
+	diags.AddError("Internal Error", "Could not find matching filter predicate")
+	return filterPredicateModel{}, diags
+}
+
+func OpslevelPredicateToObjectValue(ctx context.Context, predicate *opslevel.Predicate) basetypes.ObjectValue {
+	if predicate == nil {
+		return types.ObjectNull(predicateType)
+	}
+	predicateAttrValues := map[string]attr.Value{
+		"type":  types.StringValue(string(predicate.Type)),
+		"value": types.StringValue(predicate.Value),
+	}
+	return types.ObjectValueMust(predicateType, predicateAttrValues)
 }
 
 // Converts a basetypes.ObjectValue to a PredicateModel

--- a/tests/local/data_sources.tf
+++ b/tests/local/data_sources.tf
@@ -173,7 +173,7 @@ data "opslevel_team" "mock_team_with_alias" {
 data "opslevel_tier" "mock_tier" {
   filter {
     field = "alias"
-    value = ""
+    value = "thing"
   }
 }
 

--- a/tests/local/resource_filter.tftest.hcl
+++ b/tests/local/resource_filter.tftest.hcl
@@ -39,11 +39,6 @@ run "resource_filter_big_predicate_one" {
   }
 
   assert {
-    condition     = opslevel_filter.big.predicate[0].case_insensitive == null
-    error_message = "expected 'case_insensitive' to be null for opslevel_filter.big.predicate[0]"
-  }
-
-  assert {
     condition     = opslevel_filter.big.predicate[0].case_sensitive == null
     error_message = "expected 'case_sensitive' to be null for opslevel_filter.big.predicate[0]"
   }
@@ -64,7 +59,7 @@ run "resource_filter_big_predicate_one" {
   }
 
   assert {
-    condition     = opslevel_filter.big.predicate[0].value == null
+    condition     = opslevel_filter.big.predicate[0].value == "1"
     error_message = "expected 'value' to be null for opslevel_filter.big.predicate[0]"
   }
 

--- a/tests/local/resource_filter.tftest.hcl
+++ b/tests/local/resource_filter.tftest.hcl
@@ -39,6 +39,16 @@ run "resource_filter_big_predicate_one" {
   }
 
   assert {
+    condition     = opslevel_filter.big.predicate[0].case_insensitive == null
+    error_message = "expected 'case_insensitive' to be null for opslevel_filter.big.predicate[0]"
+  }
+
+  assert {
+    condition     = opslevel_filter.big.predicate[0].case_sensitive == null
+    error_message = "expected 'case_sensitive' to be null for opslevel_filter.big.predicate[0]"
+  }
+
+  assert {
     condition     = opslevel_filter.big.predicate[0].key == var.predicate_key_enum
     error_message = "invalid predicate key enum for opslevel_filter.big.predicate[0]"
   }
@@ -63,6 +73,11 @@ run "resource_filter_big_predicate_one" {
 run "resource_filter_big_predicate_two" {
   providers = {
     opslevel = opslevel.fake
+  }
+
+  assert {
+    condition     = opslevel_filter.big.predicate[1].case_sensitive == true
+    error_message = "expected case_sensitive to be true for opslevel_filter.big.predicate[1]"
   }
 
   assert {

--- a/tests/local/resource_filter.tftest.hcl
+++ b/tests/local/resource_filter.tftest.hcl
@@ -39,16 +39,6 @@ run "resource_filter_big_predicate_one" {
   }
 
   assert {
-    condition     = opslevel_filter.big.predicate[0].case_insensitive == null
-    error_message = "expected 'case_insensitive' to be null for opslevel_filter.big.predicate[0]"
-  }
-
-  assert {
-    condition     = opslevel_filter.big.predicate[0].case_sensitive == null
-    error_message = "expected 'case_sensitive' to be null for opslevel_filter.big.predicate[0]"
-  }
-
-  assert {
     condition     = opslevel_filter.big.predicate[0].key == var.predicate_key_enum
     error_message = "invalid predicate key enum for opslevel_filter.big.predicate[0]"
   }
@@ -73,11 +63,6 @@ run "resource_filter_big_predicate_one" {
 run "resource_filter_big_predicate_two" {
   providers = {
     opslevel = opslevel.fake
-  }
-
-  assert {
-    condition     = opslevel_filter.big.predicate[1].case_sensitive == true
-    error_message = "expected case_sensitive to be true for opslevel_filter.big.predicate[1]"
   }
 
   assert {

--- a/tests/local/resources.tf
+++ b/tests/local/resources.tf
@@ -21,12 +21,10 @@ resource "opslevel_filter" "big" {
     type = var.predicate_type_enum
   }
   predicate {
-    case_insensitive = false
-    case_sensitive   = true
-    key              = "lifecycle_index"
-    key_data         = "big_predicate"
-    type             = "ends_with"
-    value            = "1"
+    key      = "lifecycle_index"
+    key_data = "big_predicate"
+    type     = "ends_with"
+    value    = "1"
   }
 }
 

--- a/tests/local/resources.tf
+++ b/tests/local/resources.tf
@@ -21,10 +21,12 @@ resource "opslevel_filter" "big" {
     type = var.predicate_type_enum
   }
   predicate {
-    key      = "lifecycle_index"
-    key_data = "big_predicate"
-    type     = "ends_with"
-    value    = "1"
+    case_insensitive = null
+    case_sensitive   = true
+    key              = "lifecycle_index"
+    key_data         = "big_predicate"
+    type             = "ends_with"
+    value            = "1"
   }
 }
 

--- a/tests/local/resources.tf
+++ b/tests/local/resources.tf
@@ -17,16 +17,16 @@ resource "opslevel_filter" "big" {
   connective = var.connective_enum
   name       = "Big Filter"
   predicate {
-    key  = var.predicate_key_enum
-    type = var.predicate_type_enum
+    key   = var.predicate_key_enum
+    type  = var.predicate_type_enum
+    value = "1"
   }
   predicate {
-    case_insensitive = null
-    case_sensitive   = true
-    key              = "lifecycle_index"
-    key_data         = "big_predicate"
-    type             = "ends_with"
-    value            = "1"
+    case_sensitive = true
+    key            = "lifecycle_index"
+    key_data       = "big_predicate"
+    type           = "ends_with"
+    value          = "1"
   }
 }
 

--- a/tests/remote/check_alert_source_usage.tftest.hcl
+++ b/tests/remote/check_alert_source_usage.tftest.hcl
@@ -8,7 +8,7 @@ variables {
   # optional fields
   alert_name_predicate = {
     type  = "exists"
-    value = ""
+    value = null
   }
 
   # -- check base fields --

--- a/tests/remote/check_alert_source_usage/variables.tf
+++ b/tests/remote/check_alert_source_usage/variables.tf
@@ -1,7 +1,7 @@
 variable "alert_name_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_repository_file/variables.tf
+++ b/tests/remote/check_repository_file/variables.tf
@@ -6,7 +6,7 @@ variable "directory_search" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_repository_grep.tftest.hcl
+++ b/tests/remote/check_repository_grep.tftest.hcl
@@ -7,7 +7,7 @@ variables {
   # NOTE: baffled here, this is not being passed in
   file_contents_predicate = {
     type  = "exists"
-    value = ""
+    value = null
   }
   filepaths = tolist(["one/two.py", "three/four.rs"])
 

--- a/tests/remote/check_repository_grep/main.tf
+++ b/tests/remote/check_repository_grep/main.tf
@@ -3,7 +3,7 @@ resource "opslevel_check_repository_grep" "test" {
   # file_contents_predicate = var.file_contents_predicate
   file_contents_predicate = {
     type  = "exists"
-    value = ""
+    value = null
   }
   filepaths = var.filepaths
 

--- a/tests/remote/check_repository_grep/variables.tf
+++ b/tests/remote/check_repository_grep/variables.tf
@@ -7,7 +7,7 @@ variable "directory_search" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_repository_search/variables.tf
+++ b/tests/remote/check_repository_search/variables.tf
@@ -6,7 +6,7 @@ variable "file_extensions" {
 variable "file_contents_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_service_ownership/variables.tf
+++ b/tests/remote/check_service_ownership/variables.tf
@@ -28,7 +28,7 @@ variable "tag_key" {
 variable "tag_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_service_property/variables.tf
+++ b/tests/remote/check_service_property/variables.tf
@@ -22,7 +22,7 @@ variable "property" {
 variable "predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_tag_defined/variables.tf
+++ b/tests/remote/check_tag_defined/variables.tf
@@ -6,7 +6,7 @@ variable "tag_key" {
 variable "tag_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/check_tool_usage/variables.tf
+++ b/tests/remote/check_tool_usage/variables.tf
@@ -1,7 +1,7 @@
 variable "environment_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }
@@ -14,7 +14,7 @@ variable "tool_category" {
 variable "tool_name_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }
@@ -22,7 +22,7 @@ variable "tool_name_predicate" {
 variable "tool_url_predicate" {
   type = object({
     type  = string
-    value = optional(string, "")
+    value = optional(string)
   })
   description = "A condition that should be satisfied."
 }

--- a/tests/remote/filter.tftest.hcl
+++ b/tests/remote/filter.tftest.hcl
@@ -7,7 +7,7 @@ variables {
   name = "TF Test Filter"
 
   # optional fields
-  connective = "and"
+  connective     = "and"
   predicate_list = []
 }
 

--- a/tests/remote/filter.tftest.hcl
+++ b/tests/remote/filter.tftest.hcl
@@ -8,7 +8,7 @@ variables {
 
   # optional fields
   connective = "and"
-  # predicate_list = null
+  predicate_list = []
 }
 
 run "resource_filter_create_with_all_fields" {

--- a/tests/remote/filter/variables.tf
+++ b/tests/remote/filter/variables.tf
@@ -20,7 +20,6 @@ variable "predicate_list" {
     type             = string
     value            = optional(string)
   }))
-  default = []
 }
 
 variable "name" {


### PR DESCRIPTION
## Issues

[https://github.com/OpsLevel/team-platform/issues/391](https://github.com/OpsLevel/team-platform/issues/391)

## Changelog

✅  - relies on updates in [this opslevel-go PR](https://github.com/OpsLevel/opslevel-go/pull/417)

Fix the where `case_insensitive` and `case_sensitive` were being set - they should be left null by default. 
- see `convertedFilterPredicate.CaseInsensitive = types.BoolValue(false)` below
Remove `NewPredicateModel` it is unused.
Add validation to FilterPredicates.
Add Terraform Config validation to enforce `case_sensitive` and `case_insensitive` are not both set.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this Terraform config (invalid):
```tf
resource "opslevel_filter" "example" {
  name       = "foobarbaz"
  connective = "and"
  predicate {
    key              = "language"
    type             = "contains"
    value            = "bar"
    case_sensitive   = true
    case_insensitive = true
  }
}
```

### Run `terraform validate`
```tf
│ Error: Invalid Attribute Combination
│ 
│   with opslevel_filter.example,
│   on main.tf line 8, in resource "opslevel_filter" "example":
│    8:     case_sensitive   = true
│ 
│ Attribute "predicate[0].case_insensitive" cannot be specified when "predicate[0].case_sensitive" is specified
╵
╷
│ Error: Invalid Attribute Combination
│ 
│   with opslevel_filter.example,
│   on main.tf line 9, in resource "opslevel_filter" "example":
│    9:     case_insensitive = true
│ 
│ Attribute "predicate[0].case_sensitive" cannot be specified when "predicate[0].case_insensitive" is specified
```

### Update Terraform config (valid):
```tf
resource "opslevel_filter" "example" {
  name       = "foobarbaz"
  connective = "and"
  predicate {
    key              = "language"
    type             = "contains"
    value            = "bar"
    case_sensitive   = true
    case_insensitive = null
  }
}
```

### Run `terraform validate`
```tf
Success! The configuration is valid.
```

------------

### With this Terraform config
```tf
resource "opslevel_filter" "example" {
  name       = "foobarbaz1"
  connective = "and"
  predicate {
    key              = "language"
    type             = "contains"
    value            = "barbaz"
    case_sensitive   = true
    case_insensitive = null
  }
  predicate {
    key   = "tier_index"
    type  = "less_than_or_equal_to"
    value = 3
  }
  predicate {
    key   = "language"
    type  = "exists"
    value = null
  }
}

resource "opslevel_check_tool_usage" "example" {
  name          = "TF V1 Upgrade part deux"
  enabled       = true
  category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
  owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTI0Nw"
  filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
  tool_category = "metrics"
  tool_name_predicate = {
    type  = "equals"
    value = "datadog"
  }
  environment_predicate = {
    type  = "exists"
    value = null
  }
  notes = "Optional additional info on why this check is run or how to fix it"
}
```

### Create Resources with Predicates `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_check_tool_usage.example will be created
  + resource "opslevel_check_tool_usage" "example" {
      + category              = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
      + description           = (known after apply)
      + enabled               = true
      + environment_predicate = {
          + type = "exists"
        }
      + filter                = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
      + id                    = (known after apply)
      + level                 = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
      + name                  = "TF V1 Upgrade part deux"
      + notes                 = "Optional additional info on why this check is run or how to fix it"
      + owner                 = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTI0Nw"
      + tool_category         = "metrics"
      + tool_name_predicate   = {
          + type  = "equals"
          + value = "datadog"
        }
    }

  # opslevel_filter.example will be created
  + resource "opslevel_filter" "example" {
      + connective = "and"
      + id         = (known after apply)
      + name       = "foobarbaz1"

      + predicate {
          + case_insensitive = (known after apply)
          + case_sensitive   = true
          + key              = "language"
          + type             = "contains"
          + value            = "barbaz"
        }
      + predicate {
          + case_insensitive = (known after apply)
          + case_sensitive   = (known after apply)
          + key              = "tier_index"
          + type             = "less_than_or_equal_to"
          + value            = "3"
        }
      + predicate {
          + case_insensitive = (known after apply)
          + case_sensitive   = (known after apply)
          + key              = "language"
          + type             = "exists"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
opslevel_check_tool_usage.example: Creating...
opslevel_filter.example: Creating...
opslevel_check_tool_usage.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY]
opslevel_filter.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

### Update Terraform config:
```tf
resource "opslevel_filter" "example" {
  name       = "foobarbaz1"
  connective = "and"
  predicate {
    key              = "language"
    type             = "contains"
    value            = "barbaz"
    case_sensitive   = true
    case_insensitive = null
  }
  # predicate {
  #   key   = "tier_index"
  #   type  = "less_than_or_equal_to"
  #   value = 3
  # }
  predicate {
    key   = "language"
    type  = "exists"
    value = null
  }
}

resource "opslevel_check_tool_usage" "example" {
  name          = "TF V1 Upgrade part deux"
  enabled       = true
  category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
  owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTI0Nw"
  filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
  tool_category = "metrics"
  tool_name_predicate = {
    type  = "does_not_equal"
    value = "datadog"
  }
  environment_predicate = {
    type  = "starts_with"
    value = "water"
  }
  notes = "Optional additional info on why this check is run or how to fix it"
}
```

### Update the Resource's predicates, `terraform apply`
```tf
opslevel_filter.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI]
opslevel_check_tool_usage.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_check_tool_usage.example will be updated in-place
  ~ resource "opslevel_check_tool_usage" "example" {
      ~ description           = "The service is using 'datadog' as a metrics tool in an environment which exists ''." -> (known after apply)
      ~ environment_predicate = {
          ~ type  = "exists" -> "starts_with"
          + value = "water"
        }
        id                    = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY"
        name                  = "TF V1 Upgrade part deux"
      ~ tool_name_predicate   = {
          ~ type  = "equals" -> "does_not_equal"
            # (1 unchanged attribute hidden)
        }
        # (7 unchanged attributes hidden)
    }

  # opslevel_filter.example will be updated in-place
  ~ resource "opslevel_filter" "example" {
        id         = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI"
        name       = "foobarbaz1"
        # (1 unchanged attribute hidden)

      ~ predicate {
          + case_insensitive = (known after apply)
            # (4 unchanged attributes hidden)
        }
      ~ predicate {
          + case_insensitive = (known after apply)
          + case_sensitive   = (known after apply)
          ~ key              = "tier_index" -> "language"
          ~ type             = "less_than_or_equal_to" -> "exists"
          - value            = "3" -> null
        }
      - predicate {
          - key  = "language" -> null
          - type = "exists" -> null
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.
opslevel_filter.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI]
opslevel_check_tool_usage.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY]
opslevel_filter.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI]
opslevel_check_tool_usage.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
```

### Destroy Resources, `terraform destroy`
```tf
opslevel_filter.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI]
opslevel_check_tool_usage.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_check_tool_usage.example will be destroyed
  - resource "opslevel_check_tool_usage" "example" {
      - category              = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw" -> null
      - description           = "The service has a metrics tool whose name does not equal 'datadog' in an environment which starts with 'water'." -> null
      - enabled               = true -> null
      - environment_predicate = {
          - type  = "starts_with" -> null
          - value = "water" -> null
        } -> null
      - filter                = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA" -> null
      - id                    = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY" -> null
      - level                 = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA" -> null
      - name                  = "TF V1 Upgrade part deux" -> null
      - notes                 = "Optional additional info on why this check is run or how to fix it" -> null
      - owner                 = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTI0Nw" -> null
      - tool_category         = "metrics" -> null
      - tool_name_predicate   = {
          - type  = "does_not_equal" -> null
          - value = "datadog" -> null
        } -> null
    }

  # opslevel_filter.example will be destroyed
  - resource "opslevel_filter" "example" {
      - connective = "and" -> null
      - id         = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI" -> null
      - name       = "foobarbaz1" -> null

      - predicate {
          - case_sensitive = true -> null
          - key            = "language" -> null
          - type           = "contains" -> null
          - value          = "barbaz" -> null
        }
      - predicate {
          - key  = "language" -> null
          - type = "exists" -> null
        }
    }

Plan: 0 to add, 0 to change, 2 to destroy.
opslevel_filter.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzQ4NzI]
opslevel_check_tool_usage.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjY0NzY]
opslevel_filter.example: Destruction complete after 1s
opslevel_check_tool_usage.example: Destruction complete after 1s

Destroy complete! Resources: 2 destroyed.
```