### PR TITLE
Update resource.tf

### DIFF
--- a/examples/resources/opslevel_service_repository/resource.tf
+++ b/examples/resources/opslevel_service_repository/resource.tf
@@ -11,7 +11,7 @@ resource "opslevel_service_repository" "foo" {
   repository = data.opslevel_repository.foo.id
 
   name           = "Foo"
-  base_directory = "/"
+  base_directory = "example/"
 }
 
 resource "opslevel_service_repository" "bar" {
@@ -19,5 +19,5 @@ resource "opslevel_service_repository" "bar" {
   repository_alias = "github.com:example/bar"
 
   name           = "Bar"
-  base_directory = "/"
+  base_directory = "example/subdir/"
 }


### PR DESCRIPTION
## Issues

This was reported by a customer that the docs are wrong with the new validation put in for 1.0

```
 Error: Invalid Attribute Value Match
│ 
│   with module.external_services.opslevel_service_repository.example,
│   on external-services/example.tf line 15, in resource "opslevel_service_repository" "example":
│   15:   base_directory = "/external-services/example.tf"
│ 
│ Attribute base_directory path must not start with '/', got:
│ /external-services/example.tf
```
