### PR TITLE
update reconcileAliases to use opslevel-go implementation

### DIFF
--- a/.changes/unreleased/Bugfix-20240626-140311.yaml
+++ b/.changes/unreleased/Bugfix-20240626-140311.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix management of aliases on Teams and Services. NOTE - aliases in Terraform config now require aliases generated from API. Missing aliases will be displayed by warning messages
+time: 2024-06-26T14:03:11.435544-05:00

--- a/.changes/unreleased/Feature-20240624-160020.yaml
+++ b/.changes/unreleased/Feature-20240624-160020.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add TagSetValueToTagSlice to convert tags as strings to slice of opslevel.Tag
+time: 2024-06-24T16:00:20.808257-05:00

--- a/examples/resources/opslevel_infrastructure/resource.tf
+++ b/examples/resources/opslevel_infrastructure/resource.tf
@@ -16,8 +16,9 @@ resource "opslevel_infrastructure" "example_1" {
 
 // Detailed example
 resource "opslevel_infrastructure" "example_2" {
-  schema = "Database"
-  owner  = data.opslevel_team.foo.id
+  aliases = ["foo", "bar", "baz"]
+  schema  = "Database"
+  owner   = data.opslevel_team.foo.id
   provider_data = {
     account = "dev"
     name    = "google cloud"

--- a/examples/resources/opslevel_service/resource.tf
+++ b/examples/resources/opslevel_service/resource.tf
@@ -15,7 +15,7 @@ data "opslevel_tier" "tier3" {
 resource "opslevel_team" "foo" {
   name             = "foo"
   responsibilities = "Responsible for foo frontend and backend"
-  aliases          = ["foo", "bar", "baz"] # NOTE: if set, value of "name" must be included
+  aliases          = ["foo", "bar", "baz"] # NOTE: if set, slugified value of "name" must be included
 
   member {
     email = "john.doe@example.com"

--- a/examples/resources/opslevel_service/resource.tf
+++ b/examples/resources/opslevel_service/resource.tf
@@ -15,7 +15,7 @@ data "opslevel_tier" "tier3" {
 resource "opslevel_team" "foo" {
   name             = "foo"
   responsibilities = "Responsible for foo frontend and backend"
-  aliases          = ["bar", "baz"]
+  aliases          = ["foo", "bar", "baz"] # NOTE: if set, value of "name" must be included
 
   member {
     email = "john.doe@example.com"
@@ -37,7 +37,7 @@ resource "opslevel_service" "foo" {
   api_document_path             = "/swagger.json"
   preferred_api_document_source = "PULL" //or "PUSH"
 
-  aliases = ["bar", "baz"]
+  aliases = ["foo", "bar", "baz"] # NOTE: if set, value of "name" must be included
   tags    = ["foo:bar"]
 }
 

--- a/examples/resources/opslevel_team/resource.tf
+++ b/examples/resources/opslevel_team/resource.tf
@@ -5,7 +5,7 @@ data "opslevel_team" "parent" {
 resource "opslevel_team" "example" {
   name             = "foo"
   responsibilities = "Responsible for foo frontend and backend"
-  aliases          = ["foo", "bar", "baz"] # NOTE: if set, value of "name" must be included
+  aliases          = ["foo", "bar", "baz"] # NOTE: if set, slugified value of "name" must be included
   parent           = data.opslevel_team.parent.id
 
   member {

--- a/examples/resources/opslevel_team/resource.tf
+++ b/examples/resources/opslevel_team/resource.tf
@@ -5,7 +5,7 @@ data "opslevel_team" "parent" {
 resource "opslevel_team" "example" {
   name             = "foo"
   responsibilities = "Responsible for foo frontend and backend"
-  aliases          = ["bar", "baz"]
+  aliases          = ["foo", "bar", "baz"] # NOTE: if set, value of "name" must be included
   parent           = data.opslevel_team.parent.id
 
   member {

--- a/opslevel/import_utils.go
+++ b/opslevel/import_utils.go
@@ -53,6 +53,13 @@ func getTagsFromResource(client *opslevel.Client, resource opslevel.TaggableReso
 	return tags, diags
 }
 
+// hasTagFormat returns true if the given tag is formatted as '<key>:<value>'
+func hasTagFormat(tag string) bool {
+	parts := strings.Split(tag, ":")
+	return len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0
+}
+
+// isTagValid returns true if the given tag is formatted as '<resource-id>:<tag-id>'
 func isTagValid(tag string) bool {
 	ids := strings.Split(tag, ":")
 	return len(ids) == 2 && opslevel.IsID(ids[0]) && opslevel.IsID(ids[1])

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -178,7 +178,7 @@ func (r *InfrastructureResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.AddError("Config error", fmt.Sprintf("Unable to handle given infrastructure aliases: '%s'", planModel.Aliases))
 		return
 	}
-	if err = reconcileInfraAliases(*r.client, givenAliases, infrastructure); err != nil {
+	if err = infrastructure.ReconcileAliases(r.client, givenAliases); err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to reconcile infrastructure aliases: '%s', got error: %s", givenAliases, err))
 		return
 	}
@@ -239,7 +239,7 @@ func (r *InfrastructureResource) Update(ctx context.Context, req resource.Update
 		resp.Diagnostics.AddError("Config error", fmt.Sprintf("Unable to handle given infrastructure aliases: '%s'", planModel.Aliases))
 		return
 	}
-	if err = reconcileInfraAliases(*r.client, givenAliases, updatedInfrastructure); err != nil {
+	if err = updatedInfrastructure.ReconcileAliases(r.client, givenAliases); err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to reconcile infrastructure aliases: '%s', got error: %s", givenAliases, err))
 		return
 	}

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -224,6 +224,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	if len(givenAliases) > 0 {
 		if err = service.ReconcileAliases(r.client, givenAliases); err != nil {
 			resp.Diagnostics.AddWarning("opslevel client error", fmt.Sprintf("Unable to reconcile service aliases: '%s'\n%s", givenAliases, err))
+			resp.Diagnostics.AddWarning("Config warning", "On create, OpsLevel API creates a new alias for services. If this causes issues, create team with empty 'aliases'. Then update team with 'aliases'")
 		}
 	}
 

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -161,12 +161,13 @@ func (teamResource *TeamResource) Create(ctx context.Context, req resource.Creat
 		}
 		if err = team.ReconcileAliases(teamResource.client, aliases); err != nil {
 			resp.Diagnostics.AddWarning("opslevel client error", fmt.Sprintf("warning while reconciling team aliases: '%s'\n%s", aliases, err))
+			resp.Diagnostics.AddWarning("Config warning", "On create, OpsLevel API creates a new alias for teams. If this causes issues, create team with empty 'aliases'. Then update team with 'aliases'")
 		}
 	}
 
 	createdTeamResourceModel, diags := NewTeamResourceModel(ctx, *team, planModel)
-	if diags != nil && diags.HasError() {
-		resp.Diagnostics.AddError("Config error", fmt.Sprintf("Unable to handle given team aliases: '%s'", planModel.Aliases))
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -166,7 +166,7 @@ func (teamResource *TeamResource) Create(ctx context.Context, req resource.Creat
 
 	aliases, diags := SetValueToStringSlice(ctx, planModel.Aliases)
 	resp.Diagnostics.Append(diags...)
-	if err = teamResource.reconcileTeamAliases(team, aliases); err != nil {
+	if err = team.ReconcileAliases(teamResource.client, aliases); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to reconcile aliases, got error: %s", err))
 		return
 	}
@@ -266,7 +266,7 @@ func (teamResource *TeamResource) Update(ctx context.Context, req resource.Updat
 
 	aliases, diags := SetValueToStringSlice(ctx, planModel.Aliases)
 	resp.Diagnostics.Append(diags...)
-	if err = teamResource.reconcileTeamAliases(updatedTeam, aliases); err != nil {
+	if err = updatedTeam.ReconcileAliases(teamResource.client, aliases); err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to reconcile aliases, got error: %s", err))
 		return
 	}

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -3,7 +3,6 @@ package opslevel
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -58,14 +57,9 @@ func NewTeamResourceModel(ctx context.Context, team opslevel.Team, givenModel Te
 		Responsibilities: OptionalStringValue(team.Responsibilities),
 	}
 
-	if len(team.ManagedAliases) == 0 && givenModel.Aliases.IsNull() {
-		teamResourceModel.Aliases = types.SetNull(types.StringType)
-	} else {
-		aliases, diags := types.SetValueFrom(ctx, types.StringType, team.ManagedAliases)
-		if diags != nil && diags.HasError() {
-			return TeamResourceModel{}, diags
-		}
-		teamResourceModel.Aliases = aliases
+	teamResourceModel.Aliases, diags = stringAliasesToSetValue(ctx, team.Aliases, givenModel.Aliases)
+	if diags != nil && diags.HasError() {
+		return teamResourceModel, diags
 	}
 
 	if len(givenModel.Member) > 0 && team.Memberships != nil {
@@ -149,30 +143,32 @@ func (teamResource *TeamResource) Create(ctx context.Context, req resource.Creat
 	if len(members) > 0 {
 		teamCreateInput.Members = &members
 	}
-
 	if planModel.Parent.ValueString() != "" {
 		teamCreateInput.ParentTeam = opslevel.NewIdentifier(planModel.Parent.ValueString())
 	}
+
 	team, err := teamResource.client.CreateTeam(teamCreateInput)
 	if err != nil || team == nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to create team, got error: %s", err))
 		return
 	}
-	err = team.Hydrate(teamResource.client)
-	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to hydrate team, got error: %s", err))
-		return
-	}
 
-	aliases, diags := SetValueToStringSlice(ctx, planModel.Aliases)
-	resp.Diagnostics.Append(diags...)
-	if err = team.ReconcileAliases(teamResource.client, aliases); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to reconcile aliases, got error: %s", err))
-		return
+	if len(planModel.Aliases.Elements()) > 0 {
+		aliases, diags := SetValueToStringSlice(ctx, planModel.Aliases)
+		if diags != nil && diags.HasError() {
+			resp.Diagnostics.AddError("Config error", fmt.Sprintf("Unable to handle given team aliases: '%s'", planModel.Aliases))
+			return
+		}
+		if err = team.ReconcileAliases(teamResource.client, aliases); err != nil {
+			resp.Diagnostics.AddWarning("opslevel client error", fmt.Sprintf("warning while reconciling team aliases: '%s'\n%s", aliases, err))
+		}
 	}
 
 	createdTeamResourceModel, diags := NewTeamResourceModel(ctx, *team, planModel)
-	resp.Diagnostics.Append(diags...)
+	if diags != nil && diags.HasError() {
+		resp.Diagnostics.AddError("Config error", fmt.Sprintf("Unable to handle given team aliases: '%s'", planModel.Aliases))
+		return
+	}
 
 	// if parent is set, use an ID or alias for this field based on what is currently in the state
 	if opslevel.IsID(planModel.Parent.ValueString()) {
@@ -265,10 +261,12 @@ func (teamResource *TeamResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	aliases, diags := SetValueToStringSlice(ctx, planModel.Aliases)
-	resp.Diagnostics.Append(diags...)
-	if err = updatedTeam.ReconcileAliases(teamResource.client, aliases); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to reconcile aliases, got error: %s", err))
+	if diags != nil && diags.HasError() {
+		resp.Diagnostics.AddError("Config error", fmt.Sprintf("Unable to handle given team aliases: '%s'", planModel.Aliases))
 		return
+	}
+	if err = updatedTeam.ReconcileAliases(teamResource.client, aliases); err != nil {
+		resp.Diagnostics.AddWarning("opslevel client error", fmt.Sprintf("warning while reconciling team aliases: '%s'\n%s", aliases, err))
 	}
 
 	updatedTeamResourceModel, diags := NewTeamResourceModel(ctx, *updatedTeam, planModel)
@@ -315,30 +313,4 @@ func getMembers(members []TeamMember) ([]opslevel.TeamMembershipUserInput, error
 		return memberInputs, nil
 	}
 	return nil, nil
-}
-
-func (teamResource *TeamResource) reconcileTeamAliases(team *opslevel.Team, expectedAliases []string) error {
-	// get list of existing aliases from OpsLevel
-	existingAliases := team.ManagedAliases
-
-	// if an existing alias is not supposed to be there, delete it
-	for _, existingAlias := range existingAliases {
-		if !slices.Contains(expectedAliases, existingAlias) {
-			err := teamResource.client.DeleteTeamAlias(existingAlias)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	// if an alias does not exist but is supposed to, create it
-	for _, expectedAlias := range expectedAliases {
-		if !slices.Contains(existingAliases, expectedAlias) {
-			_, err := teamResource.client.CreateAliases(team.Id, []string{expectedAlias})
-			if err != nil {
-				return err
-			}
-		}
-	}
-	team.ManagedAliases = expectedAliases
-	return nil
 }

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -94,6 +94,26 @@ func SetValueToStringSlice(ctx context.Context, setValue basetypes.SetValue) ([]
 	return dataAsSlice, diags
 }
 
+func TagSetValueToTagSlice(ctx context.Context, setValue basetypes.SetValue) ([]opslevel.Tag, diag.Diagnostics) {
+	tagSlice := []opslevel.Tag{}
+	if setValue.IsNull() {
+		return tagSlice, nil
+	}
+	tagsAsStringSlice, diags := SetValueToStringSlice(ctx, setValue)
+	if diags.HasError() {
+		return tagSlice, diags
+	}
+	for _, tag := range tagsAsStringSlice {
+		if hasTagFormat(tag) {
+			parts := strings.Split(tag, ":")
+			tagSlice = append(tagSlice, opslevel.Tag{Key: parts[0], Value: parts[1]})
+		} else {
+			diags.AddWarning("Invalid tag format", tag)
+		}
+	}
+	return tagSlice, diags
+}
+
 // Converts a basetypes.MapValue to an opslevel.JSON
 func MapValueToOpslevelJson(ctx context.Context, mapValue basetypes.MapValue) (opslevel.JSON, diag.Diagnostics) {
 	mapAsJson := opslevel.JSON{}

--- a/opslevel/validators.go
+++ b/opslevel/validators.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"

--- a/opslevel/validators.go
+++ b/opslevel/validators.go
@@ -148,9 +148,7 @@ func (v tagFormatValidator) ValidateSet(ctx context.Context, req validator.SetRe
 
 	elems := req.ConfigValue.Elements()
 	for _, elem := range elems {
-		elemAsString := unquote(elem.String())
-		parts := strings.Split(elemAsString, ":")
-		if len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0 {
+		if hasTagFormat(unquote(elem.String())) {
 			continue
 		}
 


### PR DESCRIPTION
## Issues

[Combine reconcileAliases](https://github.com/OpsLevel/team-platform/issues/363)

## Changelog

Add `Config warning` when creating a resource with `aliases` where slug is missing.
Use new ReconcileAliases function from opslevel-go

- [X] List your changes here
- [x] Make a `changie` entry

## Tophatting

### With this Terraform config:
```tf
resource "opslevel_infrastructure" "example" {
  aliases = []
  schema  = "Database"
  owner   = opslevel_team.example.id
  provider_data = {
    account = "dev2"
  }
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "foo25"
  aliases = []

  description = "The test service"
  framework   = "something fancy"
  language    = "elixir"

  lifecycle_alias = "beta"
  tier_alias      = "tier_2"
  owner           = opslevel_team.example.id

  api_document_path             = "/swagger.json"
  preferred_api_document_source = "PULL" //or "PUSH"
}

resource "opslevel_team" "example" {
  name             = "foo4"
  aliases          = []
  responsibilities = "Responsible for foo frontend and backend"

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "taimoor+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "kyle+pat@opslevel.com"
    role  = "manager"
  }
}
```

### Create resources with `aliases = []`, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be created
  + resource "opslevel_infrastructure" "example" {
      + aliases       = []
      + data          = jsonencode(
            {
              + name = "my-database"
            }
        )
      + id            = (known after apply)
      + owner         = (known after apply)
      + provider_data = {
          + account = "dev2"
        }
      + schema        = "Database"
    }

  # opslevel_service.example will be created
  + resource "opslevel_service" "example" {
      + aliases                       = []
      + api_document_path             = "/swagger.json"
      + description                   = "The test service"
      + framework                     = "something fancy"
      + id                            = (known after apply)
      + language                      = "elixir"
      + lifecycle_alias               = "beta"
      + name                          = "foo25"
      + owner                         = (known after apply)
      + preferred_api_document_source = "PULL"
      + tier_alias                    = "tier_2"
    }

  # opslevel_team.example will be created
  + resource "opslevel_team" "example" {
      + aliases          = []
      + id               = (known after apply)
      + name             = "foo4"
      + responsibilities = "Responsible for foo frontend and backend"

      + member {
          + email = "david+pat@opslevel.com"
          + role  = "contributor"
        }
      + member {
          + email = "kyle+pat@opslevel.com"
          + role  = "manager"
        }
      + member {
          + email = "taimoor+pat@opslevel.com"
          + role  = "contributor"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
opslevel_team.example: Creating...
opslevel_team.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUxOA]
opslevel_infrastructure.example: Creating...
opslevel_service.example: Creating...
opslevel_infrastructure.example: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTUwNTg]
opslevel_service.example: Creation complete after 2s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3MjI]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```
### Destroy resources, `terraform destroy` ✅  
-----

## On create, Warn users that aliases are created and how they can work around an infinite apply loop

### With config `aliases` set, but without value in `name`
```tf
resource "opslevel_team" "example" {
  name             = "foo4"
  aliases          = ["newnewnew"]   # <-- slug is missing here
  responsibilities = "Responsible for foo frontend and backend"

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "taimoor+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "kyle+pat@opslevel.com"
    role  = "manager"
  }
}
```

### Run `terraform apply`, note missing alias `foo4_11`
```tf
# ... truncated output
Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_team.example: Creating...
╷
│ Warning: opslevel client error
│ 
│   with opslevel_team.example,
│   on main.tf line 29, in resource "opslevel_team" "example":
│   29: resource "opslevel_team" "example" {
│ 
│ warning while reconciling team aliases: '[newnewnew]'
│ OpsLevel API Errors:
│       - 'alias' slug is locked, it cannot be deleted
│ 
│ OpsLevel API Errors:
│       - 'alias' Alias 'newnewnew' has already been taken
│ 
╵
╷
│ Warning: Config warning
│ 
│   with opslevel_team.example,
│   on main.tf line 29, in resource "opslevel_team" "example":
│   29: resource "opslevel_team" "example" {
│ 
│ On create, OpsLevel API creates a new alias for teams. If this causes issues, create team with empty 'aliases'. Then update team with 'aliases'
╵
╷
│ Error: Config error
│ 
│   with opslevel_team.example,
│   on main.tf line 29, in resource "opslevel_team" "example":
│   29: resource "opslevel_team" "example" {
│ 
│ default aliases from API need to be added to config: [foo4_11 newnewnew]
```

### Add missing alias, `terraform apply` again (still fails - needs alias `foo4_12` now)
```tf
# ... truncated output
│ Warning: Config warning
│ 
│   with opslevel_team.example,
│   on main.tf line 29, in resource "opslevel_team" "example":
│   29: resource "opslevel_team" "example" {
│ 
│ On create, OpsLevel API creates a new alias for teams. If this causes issues, create team with empty 'aliases'. Then update team with 'aliases'
╵
╷
│ Error: Config error
│ 
│   with opslevel_team.example,
│   on main.tf line 29, in resource "opslevel_team" "example":
│   29: resource "opslevel_team" "example" {
│ 
│ default aliases from API need to be added to config: [foo4_12 foo4_11 newnewnew]
```

----
## Happy path

### With this config, note each resource has `aliases = []`
```tf
resource "opslevel_infrastructure" "example" {
  aliases = []
  schema  = "Database"
  owner   = opslevel_team.example.id
  provider_data = {
    account = "dev2"
  }
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "foo25"
  aliases = []

  description = "The test service"
  framework   = "something fancy"
  language    = "elixir"

  lifecycle_alias = "beta"
  tier_alias      = "tier_2"
  owner           = opslevel_team.example.id

  api_document_path             = "/swagger.json"
  preferred_api_document_source = "PULL" //or "PUSH"
}

resource "opslevel_team" "example" {
  name             = "foo4"
  aliases          = []
  responsibilities = "Responsible for foo frontend and backend"

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "taimoor+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "kyle+pat@opslevel.com"
    role  = "manager"
  }
}
```

### Create resources, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be created
  + resource "opslevel_infrastructure" "example" {
      + aliases       = []
      + data          = jsonencode(
            {
              + name = "my-database"
            }
        )
      + id            = (known after apply)
      + owner         = (known after apply)
      + provider_data = {
          + account = "dev2"
        }
      + schema        = "Database"
    }

  # opslevel_service.example will be created
  + resource "opslevel_service" "example" {
      + aliases                       = []
      + api_document_path             = "/swagger.json"
      + description                   = "The test service"
      + framework                     = "something fancy"
      + id                            = (known after apply)
      + language                      = "elixir"
      + lifecycle_alias               = "beta"
      + name                          = "foo25"
      + owner                         = (known after apply)
      + preferred_api_document_source = "PULL"
      + tier_alias                    = "tier_2"
    }

  # opslevel_team.example will be created
  + resource "opslevel_team" "example" {
      + aliases          = []
      + id               = (known after apply)
      + name             = "foo4"
      + responsibilities = "Responsible for foo frontend and backend"

      + member {
          + email = "david+pat@opslevel.com"
          + role  = "contributor"
        }
      + member {
          + email = "kyle+pat@opslevel.com"
          + role  = "manager"
        }
      + member {
          + email = "taimoor+pat@opslevel.com"
          + role  = "contributor"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
opslevel_team.example: Creating...
opslevel_team.example: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_infrastructure.example: Creating...
opslevel_service.example: Creating...
opslevel_infrastructure.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]
opslevel_service.example: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

### Update config, aliases are set but slug is missing
```tf
resource "opslevel_infrastructure" "example" {
  aliases = ["infratest"]
  schema  = "Database"
  owner   = opslevel_team.example.id
  provider_data = {
    account = "dev2"
  }
  data = jsonencode({
    name = "my-database"
  })
}

resource "opslevel_service" "example" {
  name    = "foo25"
  aliases = ["servicetest"]

  description = "The test service"
  framework   = "something fancy"
  language    = "elixir"

  lifecycle_alias = "beta"
  tier_alias      = "tier_2"
  owner           = opslevel_team.example.id

  api_document_path             = "/swagger.json"
  preferred_api_document_source = "PULL" //or "PUSH"
}

resource "opslevel_team" "example" {
  name             = "foo4"
  aliases          = ["teamtest"]
  responsibilities = "Responsible for foo frontend and backend"

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "taimoor+pat@opslevel.com"
    role  = "contributor"
  }
  member {
    email = "kyle+pat@opslevel.com"
    role  = "manager"
  }
}
```

### Attempt to updated resources, needs slugs raised by `Config error`
```tf
# ...truncted output
│ Error: Config error
│ 
│   with opslevel_team.example,
│   on main.tf line 29, in resource "opslevel_team" "example":
│   29: resource "opslevel_team" "example" {
│ 
│ default aliases from API need to be added to config: [foo4_13]

### Add `foo4_13` to `aliases` then `terraform apply`. Infra and Team are created, service has same alias issue
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be updated in-place
  ~ resource "opslevel_infrastructure" "example" {
      ~ aliases       = [
          + "infratest",
        ]
        id            = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc"
        # (4 unchanged attributes hidden)
    }

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      ~ aliases                       = [
          + "servicetest",
        ]
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA"
        name                          = "foo25"
        # (8 unchanged attributes hidden)
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      + aliases          = [
          + "foo4_13",
          + "teamtest",
        ]
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA"
        name             = "foo4"
        # (1 unchanged attribute hidden)

      + member {
          + email = "david+pat@opslevel.com"
          + role  = "contributor"
        }
      + member {
          + email = "kyle+pat@opslevel.com"
          + role  = "manager"
        }
      + member {
          + email = "taimoor+pat@opslevel.com"
          + role  = "contributor"
        }
    }

Plan: 0 to add, 3 to change, 0 to destroy.
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_team.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_infrastructure.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]
opslevel_infrastructure.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]
╷
│ Warning: opslevel client error
│ 
│   with opslevel_service.example,
│   on main.tf line 13, in resource "opslevel_service" "example":
│   13: resource "opslevel_service" "example" {
│ 
│ Unable to reconcile service aliases: '[servicetest]'
│ OpsLevel API Errors:
│       - 'alias' slug is locked, it cannot be deleted
│ 
╵
╷
│ Error: Config error
│ 
│   with opslevel_service.example,
│   on main.tf line 13, in resource "opslevel_service" "example":
│   13: resource "opslevel_service" "example" {
│ 
│ default aliases from API need to be added to config: [foo25]
```

### Fix service alias, `aliases = ["servicetest", "foo25"]`, `terraform apply`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      ~ aliases                       = [
          + "foo25",
          + "servicetest",
        ]
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA"
        name                          = "foo25"
        # (8 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]
opslevel_service.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

### Unset aliases (`aliases = null`) for all resources then `terraform apply`
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]
opslevel_infrastructure.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_infrastructure.example will be updated in-place
  ~ resource "opslevel_infrastructure" "example" {
      - aliases       = [
          - "infratest",
        ] -> null
        id            = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc"
        # (4 unchanged attributes hidden)
    }

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      - aliases                       = [
          - "foo25",
          - "servicetest",
        ] -> null
        id                            = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA"
        name                          = "foo25"
        # (8 unchanged attributes hidden)
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      - aliases          = [
          - "foo4_13",
          - "teamtest",
        ] -> null
        id               = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA"
        name             = "foo4"
        # (1 unchanged attribute hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_team.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTUzOA]
opslevel_infrastructure.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]
opslevel_infrastructure.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI3NTY2NTc]
opslevel_service.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU3NDA]
╷
│ Warning: opslevel client error
│ 
│   with opslevel_team.example,
│   on main.tf line 29, in resource "opslevel_team" "example":
│   29: resource "opslevel_team" "example" {
│ 
│ warning while reconciling team aliases: '[]'
│ OpsLevel API Errors:
│       - 'alias' slug is locked, it cannot be deleted
│ 
╵

Apply complete! Resources: 0 added, 3 changed, 0 destroyed.
```

### `terraform destroy` ✅ 