### PR TITLE
enforce aliases field is empty when creating teams or services

### DIFF
--- a/.changes/unreleased/Bugfix-20240627-105421.yaml
+++ b/.changes/unreleased/Bugfix-20240627-105421.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: 'BREAKING CHANGE: aliases field must be empty or null when creating opslevel_team
+  or opslevel_service. aliases can be updated after creation'
+time: 2024-06-27T10:54:21.569585-05:00

--- a/tests/remote/service.tftest.hcl
+++ b/tests/remote/service.tftest.hcl
@@ -53,7 +53,7 @@ run "from_tier_get_tier_alias" {
 run "resource_service_create_with_all_fields" {
 
   variables {
-    aliases                       = var.aliases
+    aliases                       = []
     api_document_path             = var.api_document_path
     description                   = var.description
     framework                     = var.framework

--- a/tests/remote/team.tftest.hcl
+++ b/tests/remote/team.tftest.hcl
@@ -30,7 +30,7 @@ run "from_team_get_owner_id" {
 run "resource_team_create_with_all_fields" {
 
   variables {
-    aliases          = var.aliases
+    aliases          = []
     name             = var.name
     parent           = run.from_team_get_owner_id.first_team.id
     responsibilities = var.responsibilities


### PR DESCRIPTION
## Issues

When creating an `opslevel_service` or `opslevel_team` with `aliases = ["value"]` set, we have this problem:
- A team is created and OpsLevel assigns the team a default alias
  - If users set `aliases = []`, `aliases = null` or omit this field, things work smoothly 👍 
  - If users set `aliases = ["my_alias"]` and the default alias is not in included, the team is created, but the apply fails and an error explaining "default_alias" is missing is returned.
    - The user updates according to error: `aliases = ["my_alias", "default_alias"]`, same thing happens but now they need to add "default_alias_2" and there is a duplicate team created.
- Same applies to services

### Solution: only add aliases during `update` operations

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this Terraform config:
```tf
resource "opslevel_team" "example" {
  name    = "Test Team One"
  aliases = ["fancy_team"]

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
}

resource "opslevel_service" "example" {
  aliases = ["fancy_service"]
  name    = "Test Service One"
}
```

### Try to create new `team` and `service`. Fails because `aliases` is set.
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_service.example will be created
  + resource "opslevel_service" "example" {
      + aliases = [
          + "fancy_service",
        ]
      + id      = (known after apply)
      + name    = "Test Service One"
    }

  # opslevel_team.example will be created
  + resource "opslevel_team" "example" {
      + aliases = [
          + "fancy_team",
        ]
      + id      = (known after apply)
      + name    = "Test Team One"

      + member {
          + email = "david+pat@opslevel.com"
          + role  = "contributor"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
opslevel_team.example: Creating...
opslevel_service.example: Creating...
╷
│ Error: Config error
│ 
│   with opslevel_team.example,
│   on main.tf line 1, in resource "opslevel_team" "example":
│    1: resource "opslevel_team" "example" {
│ 
│ Setting 'aliases' field is only supported for existing teams. Please create team first, then update aliases on next 'terraform apply'
╵
╷
│ Error: Config error
│ 
│   with opslevel_service.example,
│   on main.tf line 11, in resource "opslevel_service" "example":
│   11: resource "opslevel_service" "example" {
│ 
│ Setting 'aliases' field is only supported for existing services. Please create service first, then update aliases on next 'terraform apply'
```

### Update config, set `aliases = []` for team and service
```tf
resource "opslevel_team" "example" {
  name    = "Test Team One"
  aliases = []

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
}

resource "opslevel_service" "example" {
  aliases = []
  name    = "Test Service One"
}
```

### Create team and service, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_service.example will be created
  + resource "opslevel_service" "example" {
      + aliases = []
      + id      = (known after apply)
      + name    = "Test Service One"
    }

  # opslevel_team.example will be created
  + resource "opslevel_team" "example" {
      + aliases = []
      + id      = (known after apply)
      + name    = "Test Team One"

      + member {
          + email = "david+pat@opslevel.com"
          + role  = "contributor"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
opslevel_team.example: Creating...
opslevel_service.example: Creating...
opslevel_team.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ]
opslevel_service.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

### Update config, set values in `aliases` for team and service
```tf
resource "opslevel_team" "example" {
  name    = "Test Team One"
  aliases = ["fancy_team"]

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
}

resource "opslevel_service" "example" {
  aliases = ["fancy_service"]
  name    = "Test Service One"
}
```

### Try update `terraform apply`. Fails because default aliases missing - displayed in error message
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      ~ aliases = [
          + "fancy_service",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM"
        name    = "Test Service One"
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      ~ aliases = [
          + "fancy_team",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ"
        name    = "Test Team One"

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ]
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM]
╷
│ Warning: opslevel client error
│ 
│   with opslevel_team.example,
│   on main.tf line 1, in resource "opslevel_team" "example":
│    1: resource "opslevel_team" "example" {
│ 
│ warning while reconciling team aliases: '[fancy_team]'
│ OpsLevel API Errors:
│       - 'alias' slug is locked, it cannot be deleted
│ 
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Error: Config error
│ 
│   with opslevel_team.example,
│   on main.tf line 1, in resource "opslevel_team" "example":
│    1: resource "opslevel_team" "example" {
│ 
│ default aliases from API need to be added to config: [test_team_one_2]
╵
╷
│ Error: Config error
│ 
│   with opslevel_service.example,
│   on main.tf line 11, in resource "opslevel_service" "example":
│   11: resource "opslevel_service" "example" {
│ 
│ default aliases from API need to be added to config: [test_service_one]
```

### Update config, add default aliases to `aliases` for team and service
```tf
resource "opslevel_team" "example" {
  name    = "Test Team One"
  aliases = ["fancy_team", "test_team_one_2"]

  member {
    email = "david+pat@opslevel.com"
    role  = "contributor"
  }
}

resource "opslevel_service" "example" {
  aliases = ["fancy_service", "test_service_one"]
  name    = "Test Service One"
}
```

### Update team and service aliases - with default aliases
```tf
opslevel_team.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ]
opslevel_service.example: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_service.example will be updated in-place
  ~ resource "opslevel_service" "example" {
      ~ aliases = [
          + "fancy_service",
          + "test_service_one",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM"
        name    = "Test Service One"
    }

  # opslevel_team.example will be updated in-place
  ~ resource "opslevel_team" "example" {
      + aliases = [
          + "fancy_team",
          + "test_team_one_2",
        ]
        id      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ"
        name    = "Test Team One"

      + member {
          + email = "david+pat@opslevel.com"
          + role  = "contributor"
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.
opslevel_service.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM]
opslevel_team.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ]
opslevel_team.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xOTU1NQ]
opslevel_service.example: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8xMjU4MjM]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
```

### `terraform destroy` ✅ 