### PR TITLE
allow empty string for Domain description and note fields

### DIFF
--- a/.changes/unreleased/Bugfix-20240703-133905.yaml
+++ b/.changes/unreleased/Bugfix-20240703-133905.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: allow empty string for Domain description and note fields
+time: 2024-07-03T13:39:05.140447-05:00

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -17,6 +17,14 @@ func RequiredStringValue(value string) basetypes.StringValue {
 	return types.StringValue(unquote(value))
 }
 
+// Returns resourceValue wrapped in types.StringValue or types.StringNull if modelValue is null
+func StringValueFromResourceAndModelField(resourceValue string, modelValue basetypes.StringValue) basetypes.StringValue {
+	if modelValue.IsNull() {
+		return types.StringNull()
+	}
+	return types.StringValue(unquote(resourceValue))
+}
+
 // Returns value wrapped in a types.StringValue, or types.StringNull if blank
 func OptionalStringValue(value string) basetypes.StringValue {
 	if value == "" {

--- a/opslevel/validators.go
+++ b/opslevel/validators.go
@@ -25,10 +25,14 @@ func (v idStringValidator) ValidateString(ctx context.Context, request validator
 	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}
+	if request.ConfigValue.ValueString() == "" {
+		response.Diagnostics.AddAttributeError(request.Path, "Config error", "expected a valid id but given an empty string. please set to 'null' or an id starting with 'Z2lkOi8v'")
+		return
+	}
 
 	value := request.ConfigValue.ValueString()
 	if !opslevel.IsID(value) {
-		response.Diagnostics.AddError("Config error", fmt.Sprintf("expected a valid id. id should start with Z2lkOi8v. '%s' was set to `%s`", request.Path, value))
+		response.Diagnostics.AddAttributeError(request.Path, "Config error", fmt.Sprintf("expected a valid id. id should start with 'Z2lkOi8v'. given '%s'", value))
 	}
 }
 

--- a/tests/remote/domain.tftest.hcl
+++ b/tests/remote/domain.tftest.hcl
@@ -82,6 +82,7 @@ run "resource_domain_create_with_empty_optional_fields" {
 
   variables {
     description = ""
+    name        = "New ${var.name} with empty fields"
     note        = ""
   }
 

--- a/tests/remote/domain.tftest.hcl
+++ b/tests/remote/domain.tftest.hcl
@@ -78,6 +78,29 @@ run "resource_domain_create_with_all_fields" {
 
 }
 
+run "resource_domain_create_with_empty_optional_fields" {
+
+  variables {
+    description = ""
+    note        = ""
+  }
+
+  module {
+    source = "./domain"
+  }
+
+  assert {
+    condition     = opslevel_domain.test.description == ""
+    error_message = var.error_expected_empty_string
+  }
+
+  assert {
+    condition     = opslevel_domain.test.note == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_domain_update_unset_optional_fields" {
 
   variables {

--- a/tests/remote/test.tfvars
+++ b/tests/remote/test.tfvars
@@ -56,6 +56,7 @@ enum_tool_category = [
   "wiki",
 ]
 error_empty_datasource             = "zero 'TYPE' found in 'TYPE' datasource"
+error_expected_empty_string        = "expected field to be an empty string"
 error_expected_null_field          = "expected field to be null"
 error_unexpected_datasource_fields = "cannot reference all expected 'TYPE' datasource fields"
 error_unexpected_resource_fields   = "cannot reference all expected 'TYPE' resource fields"


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this Terraform config, `description` and `note` are null
```tf
resource "opslevel_domain" "example" {
  name        = "Example Domain 123"
  description = null
  note        = null
}
```

### Create `Domain`, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_domain.example will be created
  + resource "opslevel_domain" "example" {
      + aliases = (known after apply)
      + id      = (known after apply)
      + name    = "Example Domain 123"
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_domain.example: Creating...
opslevel_domain.example: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI4MTUxMzc]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Destroy `Domain` to recreate it with new config ✅ 

### Update Terraform config, `description` and `note` are empty strings
```tf
resource "opslevel_domain" "example" {
  name        = "Example Domain 123"
  description = ""
  note        = ""
}
```

### Create `Domain` with updated config, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_domain.example will be created
  + resource "opslevel_domain" "example" {
      + aliases     = (known after apply)
      + id          = (known after apply)
      + name        = "Example Domain 123"
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_domain.example: Creating...
opslevel_domain.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzI4MTUxNDU]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Update Terraform config, `description` and `note` back to `null`
```tf
resource "opslevel_domain" "example" {
  name        = "Example Domain 123"
  description = null
  note        = null
}
```

### `terraform plan` - no differences