### PR TITLE
add regression tests for known buggy optional string fields

### DIFF
--- a/.changes/unreleased/Bugfix-20240705-150620.yaml
+++ b/.changes/unreleased/Bugfix-20240705-150620.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: correctly handle empty string or null for config string fields, like description
+time: 2024-07-05T15:06:20.104003-05:00

--- a/.changes/unreleased/Feature-20240705-150956.yaml
+++ b/.changes/unreleased/Feature-20240705-150956.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add StringValueFromResourceAndModelField to handle ambiguous string config inputs
+time: 2024-07-05T15:09:56.938475-05:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -184,7 +184,7 @@ tasks:
         vars: { SETUP_DIR: "{{.TEST_DIR}}/local" }
       - task: terraform-command
         vars: { TF_COMMAND: "test", TF_CMD_DIR: "{{.TEST_DIR}}/local" }
-      # - task: run-acceptance-tests
+      - task: run-acceptance-tests
 
   test-integration:
     desc: Run integration tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -184,7 +184,8 @@ tasks:
         vars: { SETUP_DIR: "{{.TEST_DIR}}/local" }
       - task: terraform-command
         vars: { TF_COMMAND: "test", TF_CMD_DIR: "{{.TEST_DIR}}/local" }
-      - task: run-acceptance-tests
+      - task: run-local-go-tests
+      # - task: run-acceptance-tests
 
   test-integration:
     desc: Run integration tests
@@ -195,6 +196,13 @@ tasks:
         vars: { SETUP_DIR: "{{.TEST_DIR}}/remote" }
       - task: terraform-command
         vars: { TF_COMMAND: 'test -var-file=test.tfvars -var="api_token=$OPSLEVEL_API_TOKEN"', TF_CMD_DIR: "{{.TEST_DIR}}/remote" }
+
+  run-local-go-tests:
+    internal: true
+    dir: "{{.TEST_DIR}}/acc"
+    cmds:
+      - echo "Running acceptance tests..."
+      - go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... {{ .CLI_ARGS }}
 
   run-acceptance-tests:
     internal: true

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -45,7 +45,7 @@ type FilterResourceModel struct {
 	Predicate  types.List   `tfsdk:"predicate"`
 }
 
-type filterPredicateModel struct {
+type FilterPredicateModel struct {
 	CaseInsensitive types.Bool   `tfsdk:"case_insensitive"`
 	CaseSensitive   types.Bool   `tfsdk:"case_sensitive"`
 	Key             types.String `tfsdk:"key"`
@@ -54,7 +54,7 @@ type filterPredicateModel struct {
 	Value           types.String `tfsdk:"value"`
 }
 
-var filterPredicateType = map[string]attr.Type{
+var FilterPredicateType = map[string]attr.Type{
 	"case_insensitive": types.BoolType,
 	"case_sensitive":   types.BoolType,
 	"key":              types.StringType,
@@ -63,7 +63,7 @@ var filterPredicateType = map[string]attr.Type{
 	"value":            types.StringType,
 }
 
-func (fp filterPredicateModel) Validate() error {
+func (fp FilterPredicateModel) Validate() error {
 	// Key and Value are required fields, but may be unknown at validation time
 	// Creating multiple predicates with a 'for_each' is one example
 	if fp.Key.IsUnknown() || fp.Value.IsUnknown() {
@@ -86,7 +86,7 @@ func NewFilterResourceModel(ctx context.Context, filter opslevel.Filter, givenMo
 	var diags diag.Diagnostics
 	var filterPredicateAttrs []attr.Value
 	var filterPredicatesListValue basetypes.ListValue
-	var givenPredicateModels []filterPredicateModel
+	var givenPredicateModels []FilterPredicateModel
 
 	// Convert predicates from plan to slice of models
 	givenModel.Predicate.ElementsAs(ctx, &givenPredicateModels, false)
@@ -113,13 +113,13 @@ func NewFilterResourceModel(ctx context.Context, filter opslevel.Filter, givenMo
 			attrs["case_insensitive"] = types.BoolNull()
 		}
 
-		predicateObj = types.ObjectValueMust(filterPredicateType, attrs)
+		predicateObj = types.ObjectValueMust(FilterPredicateType, attrs)
 		filterPredicateAttrs = append(filterPredicateAttrs, predicateObj)
 	}
 	if len(filterPredicateAttrs) == 0 {
-		filterPredicatesListValue = types.ListNull(types.ObjectType{AttrTypes: filterPredicateType})
+		filterPredicatesListValue = types.ListNull(types.ObjectType{AttrTypes: FilterPredicateType})
 	} else {
-		filterPredicatesListValue = types.ListValueMust(types.ObjectType{AttrTypes: filterPredicateType}, filterPredicateAttrs)
+		filterPredicatesListValue = types.ListValueMust(types.ObjectType{AttrTypes: FilterPredicateType}, filterPredicateAttrs)
 	}
 
 	return FilterResourceModel{
@@ -192,6 +192,9 @@ func (r *FilterResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						"key_data": schema.StringAttribute{
 							Description: "Additional data used by the predicate. This field is used by predicates with key = 'tags' to specify the tag key. For example, to create a predicate for services containing the tag 'db:mysql', set key_data = 'db' and value = 'mysql'.",
 							Optional:    true,
+							Validators: []validator.String{
+								stringvalidator.NoneOf(""),
+							},
 						},
 						"type": schema.StringAttribute{
 							Description: fmt.Sprintf(
@@ -219,7 +222,7 @@ func (r *FilterResource) Schema(ctx context.Context, req resource.SchemaRequest,
 
 func (r *FilterResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel FilterResourceModel
-	var predicateModels []filterPredicateModel
+	var predicateModels []FilterPredicateModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
 	if resp.Diagnostics.HasError() {
@@ -239,7 +242,7 @@ func (r *FilterResource) ValidateConfig(ctx context.Context, req resource.Valida
 
 func (r *FilterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var planModel FilterResourceModel
-	var predicateModels []filterPredicateModel
+	var predicateModels []FilterPredicateModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
 	if resp.Diagnostics.HasError() {
@@ -301,7 +304,7 @@ func (r *FilterResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 func (r *FilterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var planModel FilterResourceModel
-	var predicateModels []filterPredicateModel
+	var predicateModels []FilterPredicateModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
@@ -376,7 +379,7 @@ func getConnectiveEnum(connective string) *opslevel.ConnectiveEnum {
 	}
 }
 
-func getFilterPredicates(predicates []filterPredicateModel) (*[]opslevel.FilterPredicateInput, error) {
+func getFilterPredicates(predicates []FilterPredicateModel) (*[]opslevel.FilterPredicateInput, error) {
 	filterPredicateInputs := []opslevel.FilterPredicateInput{}
 
 	for _, predicate := range predicates {

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -53,7 +53,7 @@ func NewTeamResourceModel(ctx context.Context, team opslevel.Team, givenModel Te
 	teamResourceModel := TeamResourceModel{
 		Id:               ComputedStringValue(string(team.Id)),
 		Name:             RequiredStringValue(team.Name),
-		Responsibilities: OptionalStringValue(team.Responsibilities),
+		Responsibilities: StringValueFromResourceAndModelField(team.Responsibilities, givenModel.Responsibilities),
 	}
 
 	if givenModel.Aliases.IsNull() {

--- a/tests/acc/terraform_type_conversions_test.go
+++ b/tests/acc/terraform_type_conversions_test.go
@@ -1,0 +1,148 @@
+package opslevel_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	opslevelgo "github.com/opslevel/opslevel-go/v2024"
+	opsleveltf "github.com/opslevel/terraform-provider-opslevel/opslevel"
+)
+
+func TestOpslevelFilterPredicateToObjectValueNullObject(t *testing.T) {
+	nullObject := opsleveltf.OpslevelFilterPredicateToObjectValue(nil, nil)
+	if !nullObject.Equal(types.ObjectNull(opsleveltf.FilterPredicateType)) {
+		t.Fatal("expected null object")
+	}
+}
+
+func TestOpslevelFilterPredicateToObjectValueAllFieldsSet(t *testing.T) {
+	// FilterPredicate.CaseSensitive omitted intentionally, types.BoolNull set in object
+	filterPredicate := opslevelgo.FilterPredicate{
+		Key:     opslevelgo.PredicateKeyEnumName,
+		KeyData: "test data",
+		Type:    opslevelgo.PredicateTypeEnumExists,
+		Value:   "test value",
+	}
+	predicateObj := opsleveltf.OpslevelFilterPredicateToObjectValue(nil, &filterPredicate)
+	attrs := predicateObj.Attributes()
+
+	if !attrs["case_insensitive"].Equal(types.BoolNull()) {
+		t.Logf("expected filter predicate 'case_insensitive' to be BoolNull")
+		t.Fail()
+	}
+	if !attrs["case_sensitive"].Equal(types.BoolNull()) {
+		t.Logf("expected filter predicate 'case_sensitive' to be BoolNull")
+		t.Fail()
+	}
+	if !attrs["key"].Equal(types.StringValue(string(filterPredicate.Key))) {
+		t.Logf("expected filter predicate 'key' to be StringValue of %s", string(filterPredicate.Key))
+		t.Fail()
+	}
+	if !attrs["key_data"].Equal(types.StringValue(filterPredicate.KeyData)) {
+		t.Logf("expected filter predicate 'key_data' to be StringValue of %s", string(filterPredicate.KeyData))
+		t.Fail()
+	}
+	if !attrs["type"].Equal(types.StringValue(string(filterPredicate.Type))) {
+		t.Logf("expected filter predicate 'type' to be StringValue of %s", string(filterPredicate.Type))
+		t.Fail()
+	}
+	if !attrs["value"].Equal(types.StringValue(filterPredicate.Value)) {
+		t.Logf("expected filter predicate 'value' to be StringValue of %s", string(filterPredicate.Value))
+		t.Fail()
+	}
+}
+
+func TestOpslevelFilterPredicateToObjectValueMinimal(t *testing.T) {
+	// FilterPredicate.CaseSensitive omitted intentionally, types.BoolNull set in object
+	filterPredicates := []opslevelgo.FilterPredicate{
+		{
+			Key:  opslevelgo.PredicateKeyEnumAliases,
+			Type: opslevelgo.PredicateTypeEnumDoesNotExist,
+		},
+		{
+			Key:     opslevelgo.PredicateKeyEnumName,
+			KeyData: "",
+			Type:    opslevelgo.PredicateTypeEnumExists,
+			Value:   "",
+		},
+	}
+	for _, filterPredicate := range filterPredicates {
+		// Validate filter predicates to ensure realistic test data
+		if err := filterPredicate.Validate(); err != nil {
+			t.Errorf(err.Error())
+		}
+		predicateObj := opsleveltf.OpslevelFilterPredicateToObjectValue(nil, &filterPredicate)
+		attrs := predicateObj.Attributes()
+
+		if !attrs["case_insensitive"].Equal(types.BoolNull()) {
+			t.Logf("expected filter predicate 'case_insensitive' to be BoolNull")
+			t.Fail()
+		}
+		if !attrs["case_sensitive"].Equal(types.BoolNull()) {
+			t.Logf("expected filter predicate 'case_sensitive' to be BoolNull")
+			t.Fail()
+		}
+		if !attrs["key"].Equal(types.StringValue(string(filterPredicate.Key))) {
+			t.Logf("expected filter predicate 'key' to be StringValue of %s", string(filterPredicate.Key))
+			t.Fail()
+		}
+		if !attrs["key_data"].Equal(types.StringNull()) {
+			t.Log("expected filter predicate 'key_data' to be StringNull")
+			t.Fail()
+		}
+		if !attrs["type"].Equal(types.StringValue(string(filterPredicate.Type))) {
+			t.Logf("expected filter predicate 'type' to be StringValue of '%s'", string(filterPredicate.Type))
+			t.Fail()
+		}
+		if !attrs["value"].Equal(types.StringNull()) {
+			t.Log("expected filter predicate 'value' to be StringNull")
+			t.Fail()
+		}
+	}
+}
+
+func TestExtractFilterPredicateModel(t *testing.T) {
+	var (
+		blankModel = opsleveltf.FilterPredicateModel{}
+		// The schema ensures empty strings are forbidden, should be treated same as null
+		emptyValues = opsleveltf.FilterPredicateModel{
+			Key:     types.StringValue(string(opslevelgo.PredicateKeyEnumLanguage)),
+			KeyData: types.StringValue(""),
+			Type:    types.StringValue(string(opslevelgo.PredicateTypeEnumExists)),
+			Value:   types.StringValue(""),
+		}
+		nullValues = opsleveltf.FilterPredicateModel{
+			Key:  types.StringValue(string(opslevelgo.PredicateKeyEnumLanguage)),
+			Type: types.StringValue(string(opslevelgo.PredicateTypeEnumExists)),
+		}
+	)
+	possibleFilterPredicateModels := []opsleveltf.FilterPredicateModel{emptyValues, nullValues}
+
+	attrsWithEmptyString := map[string]attr.Value{
+		"case_insensitive": types.BoolNull(),
+		"case_sensitive":   types.BoolNull(),
+		"key":              types.StringValue(string(opslevelgo.PredicateKeyEnumLanguage)),
+		"key_data":         types.StringValue(""),
+		"type":             types.StringValue(string(opslevelgo.PredicateTypeEnumExists)),
+		"value":            types.StringValue(""),
+	}
+	attrsWithNullStrings := map[string]attr.Value{
+		"case_insensitive": types.BoolNull(),
+		"case_sensitive":   types.BoolNull(),
+		"key":              types.StringValue(string(opslevelgo.PredicateKeyEnumLanguage)),
+		"key_data":         types.StringNull(),
+		"type":             types.StringValue(string(opslevelgo.PredicateTypeEnumExists)),
+		"value":            types.StringNull(),
+	}
+
+	foundModel, diags := opsleveltf.ExtractFilterPredicateModel(nil, attrsWithEmptyString, possibleFilterPredicateModels)
+	if !diags.HasError() && foundModel == blankModel {
+		t.Errorf("unexpectedly found filter predicate model with empty string values")
+	}
+
+	foundModel, diags = opsleveltf.ExtractFilterPredicateModel(nil, attrsWithNullStrings, possibleFilterPredicateModels)
+	if diags.HasError() && foundModel != blankModel {
+		t.Errorf("failed to find filter predicate model with null string values")
+	}
+}

--- a/tests/remote/property_definition.tftest.hcl
+++ b/tests/remote/property_definition.tftest.hcl
@@ -73,8 +73,8 @@ run "resource_property_definition_create_with_all_fields" {
 run "resource_property_definition_create_with_empty_optional_fields" {
 
   variables {
-    description             = ""
-    name                    = "New ${var.name} with empty fields"
+    description = ""
+    name        = "New ${var.name} with empty fields"
   }
 
   module {

--- a/tests/remote/property_definition.tftest.hcl
+++ b/tests/remote/property_definition.tftest.hcl
@@ -70,6 +70,24 @@ run "resource_property_definition_create_with_all_fields" {
 
 }
 
+run "resource_property_definition_create_with_empty_optional_fields" {
+
+  variables {
+    description             = ""
+    name                    = "New ${var.name} with empty fields"
+  }
+
+  module {
+    source = "./property_definition"
+  }
+
+  assert {
+    condition     = opslevel_property_definition.test.description == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_property_definition_update_unset_optional_fields" {
 
   variables {

--- a/tests/remote/rubric_level.tftest.hcl
+++ b/tests/remote/rubric_level.tftest.hcl
@@ -54,6 +54,24 @@ run "resource_rubric_level_create_with_all_fields" {
 
 }
 
+run "resource_rubric_level_create_with_empty_optional_fields" {
+
+  variables {
+    description             = ""
+    name                    = "New ${var.name} with empty fields"
+  }
+
+  module {
+    source = "./rubric_level"
+  }
+
+  assert {
+    condition     = opslevel_rubric_level.test.description == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_rubric_level_update_unset_optional_fields" {
 
   variables {

--- a/tests/remote/rubric_level.tftest.hcl
+++ b/tests/remote/rubric_level.tftest.hcl
@@ -57,8 +57,8 @@ run "resource_rubric_level_create_with_all_fields" {
 run "resource_rubric_level_create_with_empty_optional_fields" {
 
   variables {
-    description             = ""
-    name                    = "New ${var.name} with empty fields"
+    description = ""
+    name        = "New ${var.name} with empty fields"
   }
 
   module {

--- a/tests/remote/scorecard.tftest.hcl
+++ b/tests/remote/scorecard.tftest.hcl
@@ -102,6 +102,26 @@ run "resource_scorecard_create_with_all_fields" {
 
 }
 
+run "resource_scorecard_create_with_empty_optional_fields" {
+
+  variables {
+    affects_overall_service_levels = var.affects_overall_service_levels
+    description                    = ""
+    owner_id                       = run.from_team_get_owner_id.first_team.id
+    name                           = "New ${var.name} with empty fields"
+  }
+
+  module {
+    source = "./scorecard"
+  }
+
+  assert {
+    condition     = opslevel_scorecard.test.description == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_scorecard_update_unset_optional_fields" {
 
   variables {

--- a/tests/remote/service.tftest.hcl
+++ b/tests/remote/service.tftest.hcl
@@ -155,11 +155,11 @@ run "resource_service_create_with_all_fields" {
 run "resource_service_create_with_empty_optional_fields" {
 
   variables {
-    description                    = ""
-    framework                      = ""
-    language                       = ""
-    name                           = "New ${var.name} with empty fields"
-    product                        = ""
+    description = ""
+    framework   = ""
+    language    = ""
+    name        = "New ${var.name} with empty fields"
+    product     = ""
   }
 
   module {

--- a/tests/remote/service.tftest.hcl
+++ b/tests/remote/service.tftest.hcl
@@ -152,6 +152,42 @@ run "resource_service_create_with_all_fields" {
 
 }
 
+run "resource_service_create_with_empty_optional_fields" {
+
+  variables {
+    description                    = ""
+    framework                      = ""
+    language                       = ""
+    name                           = "New ${var.name} with empty fields"
+    product                        = ""
+  }
+
+  module {
+    source = "./service"
+  }
+
+  assert {
+    condition     = opslevel_service.test.description == ""
+    error_message = var.error_expected_empty_string
+  }
+
+  assert {
+    condition     = opslevel_service.test.framework == ""
+    error_message = var.error_expected_empty_string
+  }
+
+  assert {
+    condition     = opslevel_service.test.language == ""
+    error_message = var.error_expected_empty_string
+  }
+
+  assert {
+    condition     = opslevel_service.test.product == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_service_update_unset_optional_fields" {
 
   variables {

--- a/tests/remote/system.tftest.hcl
+++ b/tests/remote/system.tftest.hcl
@@ -101,6 +101,29 @@ run "resource_system_create_with_all_fields" {
 
 }
 
+run "resource_system_create_with_empty_optional_fields" {
+
+  variables {
+    description = ""
+    name        = "New ${var.name} with empty fields"
+  }
+
+  module {
+    source = "./system"
+  }
+
+  assert {
+    condition     = opslevel_system.test.description == ""
+    error_message = var.error_expected_empty_string
+  }
+
+  assert {
+    condition     = opslevel_system.test.note == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_system_update_unset_optional_fields" {
 
   variables {

--- a/tests/remote/system.tftest.hcl
+++ b/tests/remote/system.tftest.hcl
@@ -106,6 +106,7 @@ run "resource_system_create_with_empty_optional_fields" {
   variables {
     description = ""
     name        = "New ${var.name} with empty fields"
+    note        = ""
   }
 
   module {

--- a/tests/remote/team.tftest.hcl
+++ b/tests/remote/team.tftest.hcl
@@ -79,6 +79,24 @@ run "resource_team_create_with_all_fields" {
 
 }
 
+run "resource_team_create_with_empty_optional_fields" {
+
+  variables {
+    name             = "New ${var.name} with empty fields"
+    responsibilities = ""
+  }
+
+  module {
+    source = "./team"
+  }
+
+  assert {
+    condition     = opslevel_team.test.responsibilities == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_team_update_unset_optional_fields" {
 
   variables {

--- a/tests/remote/team.tftest.hcl
+++ b/tests/remote/team.tftest.hcl
@@ -6,7 +6,7 @@ variables {
   name = "TF Test Team"
 
   # optional fields
-  aliases          = ["test_team_one"]
+  aliases          = ["test_team_foo_bar_baz"]
   parent           = null
   responsibilities = "Team responsibilities"
   # member block

--- a/tests/remote/webhook_action.tftest.hcl
+++ b/tests/remote/webhook_action.tftest.hcl
@@ -78,6 +78,24 @@ run "resource_webhook_action_create_with_all_fields" {
 
 }
 
+run "resource_webhook_action_create_with_empty_optional_fields" {
+
+  variables {
+    description = ""
+    name        = "New ${var.name} with empty fields"
+  }
+
+  module {
+    source = "./webhook_action"
+  }
+
+  assert {
+    condition     = opslevel_webhook_action.test.description == ""
+    error_message = var.error_expected_empty_string
+  }
+
+}
+
 run "resource_webhook_action_update_unset_optional_fields" {
 
   variables {


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

In `opslevel_filter`, ensure `predicate.key_data` is not an empty string in the Terraform config.
Convert `OptionalStringValue()` to `StringValueFromResourceAndModelField()` for ambiguous Terraform config string fields that can be an empty string or null.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

[task test-integration](https://github.com/OpsLevel/terraform-provider-opslevel/actions/runs/9813222207/job/27098796038)
