### PR TITLE
add categories field to scorecard resource

### DIFF
--- a/.changes/unreleased/Feature-20240710-121237.yaml
+++ b/.changes/unreleased/Feature-20240710-121237.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add categories field to scorecard resource, returns category ids
+time: 2024-07-10T12:12:37.146024-05:00

--- a/tests/local/mock_resource/scorecard.tfmock.hcl
+++ b/tests/local/mock_resource/scorecard.tfmock.hcl
@@ -2,6 +2,7 @@ mock_resource "opslevel_scorecard" {
   defaults = {
     # id intentionally omitted - will be assigned a random string
     aliases        = ["scorecard-one", "scorecard-two"]
+    categories     = ["Z2lkOi8vlaksjdfsd"]
     passing_checks = 7
     service_count  = 3
     total_checks   = 10

--- a/tests/local/resource_scorecard.tftest.hcl
+++ b/tests/local/resource_scorecard.tftest.hcl
@@ -15,7 +15,7 @@ run "resource_scorecard_big" {
 
   assert {
     condition     = startswith(element(opslevel_scorecard.big.categories, 0), "Z2lkOi8v")
-    error_message = "wrong description in opslevel_scorecard.big"
+    error_message = "expected category id that starts with 'Z2lkOi8v'"
   }
 
   assert {

--- a/tests/local/resource_scorecard.tftest.hcl
+++ b/tests/local/resource_scorecard.tftest.hcl
@@ -14,6 +14,11 @@ run "resource_scorecard_big" {
   }
 
   assert {
+    condition     = startswith(element(opslevel_scorecard.big.categories, 0), "Z2lkOi8v")
+    error_message = "wrong description in opslevel_scorecard.big"
+  }
+
+  assert {
     condition     = opslevel_scorecard.big.description == "This is a big scorecard"
     error_message = "wrong description in opslevel_scorecard.big"
   }

--- a/tests/remote/scorecard.tftest.hcl
+++ b/tests/remote/scorecard.tftest.hcl
@@ -58,6 +58,7 @@ run "resource_scorecard_create_with_all_fields" {
     condition = alltrue([
       can(opslevel_scorecard.test.affects_overall_service_levels),
       can(opslevel_scorecard.test.aliases),
+      can(opslevel_scorecard.test.categories),
       can(opslevel_scorecard.test.description),
       can(opslevel_scorecard.test.filter_id),
       can(opslevel_scorecard.test.id),


### PR DESCRIPTION
## Issues

[Add category ids to scorecard resource](https://github.com/OpsLevel/team-platform/issues/418)

## Changelog

Add computed (returned from API) `categories` field to `scorecards`. This contains a list of the scorecard's category ids. Today there is always only one id but this leaves room for multiple category ids.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### With this Terraform config
```tf
resource "opslevel_scorecard" "test" {
  affects_overall_service_levels = true
  name                           = "scorecard with a category"
  owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
}

output "scorecard_categories" {
  value = opslevel_scorecard.test.categories
}
```

### Create an `opslevel_scorecard` and output the list of its categories, `terraform apply`
```tf
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opslevel_scorecard.test will be created
  + resource "opslevel_scorecard" "test" {
      + affects_overall_service_levels = true
      + aliases                        = (known after apply)
      + categories                     = (known after apply)
      + id                             = (known after apply)
      + name                           = "scorecard with a category"
      + owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
      + passing_checks                 = (known after apply)
      + service_count                  = (known after apply)
      + total_checks                   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + scorecard_categories = (known after apply)
opslevel_scorecard.test: Creating...
opslevel_scorecard.test: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzE1MDE]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

scorecard_categories = tolist([
  "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODY5OA",
])
```

### Delete the `opslevel_scorecard`, `terraform destroy`
```tf
opslevel_scorecard.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzE1MDE]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # opslevel_scorecard.test will be destroyed
  - resource "opslevel_scorecard" "test" {
      - affects_overall_service_levels = true -> null
      - aliases                        = [
          - "scorecard_with_a_category",
        ] -> null
      - categories                     = [
          - "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODY5OA",
        ] -> null
      - id                             = "Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzE1MDE" -> null
      - name                           = "scorecard with a category" -> null
      - owner_id                       = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA" -> null
      - passing_checks                 = 0 -> null
      - service_count                  = 5 -> null
      - total_checks                   = 0 -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  - scorecard_categories = [
      - "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvODY5OA",
    ] -> null
opslevel_scorecard.test: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvUnVicmljLzE1MDE]
opslevel_scorecard.test: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.
```