### PR TITLE
add StateUpgrader for opslevel_check_service_ownership

### DIFF
--- a/.changes/unreleased/Bugfix-20240715-112534.yaml
+++ b/.changes/unreleased/Bugfix-20240715-112534.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix Terraform state upgrades for previous provider versions on checks resources
+time: 2024-07-15T11:25:34.595155-05:00

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -93,6 +93,7 @@ func (r *CheckAlertSourceUsageResource) Metadata(ctx context.Context, req resour
 
 func (r *CheckAlertSourceUsageResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Alert Source Usage Resource",
 

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -106,6 +107,59 @@ func (r *CheckAlertSourceUsageResource) Schema(ctx context.Context, req resource
 			},
 			"alert_name_predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckAlertSourceUsageResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Description: "Check Alert Source Usage Resource",
+				Attributes: getCheckBaseSchemaV0(map[string]schema.Attribute{
+					"alert_type": schema.StringAttribute{
+						Description: "The type of the alert source.",
+						Required:    true,
+					},
+					"id": schema.StringAttribute{
+						Description: "The ID of this resource.",
+						Computed:    true,
+					},
+				}),
+				Blocks: map[string]schema.Block{
+					"alert_name_predicate": schema.ListNestedBlock{
+						NestedObject: predicateSchemaV0,
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var diags diag.Diagnostics
+				upgradedStateModel := CheckAlertSourceUsageResourceModel{}
+				alertNamePredicateList := types.ListNull(types.ObjectType{AttrTypes: predicateType})
+
+				// base check attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("category"), &upgradedStateModel.Category)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enable_on"), &upgradedStateModel.EnableOn)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enabled"), &upgradedStateModel.Enabled)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("filter"), &upgradedStateModel.Filter)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &upgradedStateModel.Id)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("level"), &upgradedStateModel.Level)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &upgradedStateModel.Name)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("notes"), &upgradedStateModel.Notes)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("owner"), &upgradedStateModel.Owner)...)
+
+				// alert source specific attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("alert_type"), &upgradedStateModel.AlertType)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("alert_name_predicate"), &alertNamePredicateList)...)
+				if len(alertNamePredicateList.Elements()) == 1 {
+					alertNamePredicate := alertNamePredicateList.Elements()[0]
+					upgradedStateModel.AlertNamePredicate, diags = types.ObjectValueFrom(ctx, predicateType, alertNamePredicate)
+					resp.Diagnostics.Append(diags...)
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)
+			},
+		},
 	}
 }
 

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -136,3 +136,68 @@ func PredicateSchema() schema.SingleNestedAttribute {
 		},
 	}
 }
+
+// pre-v1.x base schema fields for checks used by StateUpgraders
+func getCheckBaseSchemaV0(extras map[string]schema.Attribute) map[string]schema.Attribute {
+	output := map[string]schema.Attribute{
+		"last_updated": schema.StringAttribute{
+			Optional: true,
+			Computed: true,
+		},
+		"name": schema.StringAttribute{
+			Description: "The display name of the check.",
+			Required:    true,
+		},
+		"enabled": schema.BoolAttribute{
+			Description: `Whether the check is enabled or not.  Do not use this field in tandem with 'enable_on'.`,
+			Required:    true,
+		},
+		"enable_on": schema.StringAttribute{
+			Description: `The date when the check will be automatically enabled.
+If you use this field you should add both 'enabled' and 'enable_on' to the lifecycle ignore_changes settings.
+See example in opslevel_check_manual for proper configuration.
+`,
+			Optional: true,
+		},
+		"category": schema.StringAttribute{
+			Description: "The id of the category the check belongs to.",
+			Required:    true,
+		},
+		"level": schema.StringAttribute{
+			Description: "The id of the level the check belongs to.",
+			Required:    true,
+		},
+		"owner": schema.StringAttribute{
+			Description: "The id of the team that owns the check.",
+			Optional:    true,
+		},
+		"filter": schema.StringAttribute{
+			Description: "The id of the filter of the check.",
+			Optional:    true,
+		},
+		"notes": schema.StringAttribute{
+			Description: "Additional information about the check.",
+			Optional:    true,
+		},
+	}
+	for k, v := range extras {
+		output[k] = v
+	}
+	return output
+}
+
+var predicateSchemaV0 = schema.SingleNestedAttribute{
+	Description: "A condition that should be satisfied.",
+	Optional:    true,
+	Attributes: map[string]schema.Attribute{
+		"type": schema.StringAttribute{
+			Description: "A condition that should be satisfied.",
+			Required:    true,
+			Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllPredicateTypeEnum...)},
+		},
+		"value": schema.StringAttribute{
+			Description: "The condition value used by the predicate.",
+			Optional:    true,
+		},
+	},
+}

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -186,9 +186,7 @@ See example in opslevel_check_manual for proper configuration.
 	return output
 }
 
-var predicateSchemaV0 = schema.SingleNestedAttribute{
-	Description: "A condition that should be satisfied.",
-	Optional:    true,
+var predicateSchemaV0 = schema.NestedBlockObject{
 	Attributes: map[string]schema.Attribute{
 		"type": schema.StringAttribute{
 			Description: "A condition that should be satisfied.",

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -125,7 +125,7 @@ func (r *CheckRepositoryFileResource) UpgradeState(ctx context.Context) map[int6
 			PriorSchema: &schema.Schema{
 				Description: "Check Repository File Resource",
 				Attributes: getCheckBaseSchemaV0(map[string]schema.Attribute{
-					"directory_search": schema.StringAttribute{
+					"directory_search": schema.BoolAttribute{
 						Description: "Whether the check looks for the existence of a directory instead of a file.",
 						Required:    true,
 					},

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -113,6 +114,70 @@ func (r *CheckRepositoryFileResource) Schema(ctx context.Context, req resource.S
 				Required:    true,
 			},
 		}),
+	}
+}
+
+func (r *CheckRepositoryFileResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Description: "Check Repository File Resource",
+				Attributes: getCheckBaseSchemaV0(map[string]schema.Attribute{
+					"directory_search": schema.StringAttribute{
+						Description: "Whether the check looks for the existence of a directory instead of a file.",
+						Required:    true,
+					},
+					"filepaths": schema.ListAttribute{
+						Description: "Restrict the search to certain file paths.",
+						ElementType: types.StringType,
+						Required:    true,
+					},
+					"id": schema.StringAttribute{
+						Description: "The ID of this resource.",
+						Computed:    true,
+					},
+					"use_absolute_root": schema.BoolAttribute{
+						Description: "Whether the checks looks at the absolute root of a repo or the relative root (the directory specified when attached a repo to a service).",
+						Required:    true,
+					},
+				}),
+				Blocks: map[string]schema.Block{
+					"file_contents_predicate": schema.ListNestedBlock{
+						NestedObject: predicateSchemaV0,
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var diags diag.Diagnostics
+				upgradedStateModel := CheckRepositoryFileResourceModel{}
+				fileContentsPredicateList := types.ListNull(types.ObjectType{AttrTypes: predicateType})
+
+				// base check attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("category"), &upgradedStateModel.Category)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enable_on"), &upgradedStateModel.EnableOn)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enabled"), &upgradedStateModel.Enabled)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("filter"), &upgradedStateModel.Filter)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &upgradedStateModel.Id)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("level"), &upgradedStateModel.Level)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &upgradedStateModel.Name)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("notes"), &upgradedStateModel.Notes)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("owner"), &upgradedStateModel.Owner)...)
+
+				// repository file specific attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("directory_search"), &upgradedStateModel.DirectorySearch)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("filepaths"), &upgradedStateModel.Filepaths)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("use_absolute_root"), &upgradedStateModel.UseAbsoluteRoot)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("file_contents_predicate"), &fileContentsPredicateList)...)
+				if len(fileContentsPredicateList.Elements()) == 1 {
+					fileContentsPredicate := fileContentsPredicateList.Elements()[0]
+					upgradedStateModel.FileContentsPredicate, diags = types.ObjectValueFrom(ctx, predicateType, fileContentsPredicate)
+					resp.Diagnostics.Append(diags...)
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)
+			},
+		},
 	}
 }
 

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -95,6 +95,7 @@ func (r *CheckRepositoryFileResource) Metadata(ctx context.Context, req resource
 
 func (r *CheckRepositoryFileResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Repository File Resource",
 

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -101,6 +101,7 @@ func (r *CheckRepositorySearchResource) Schema(ctx context.Context, req resource
 	predicateSchema.Required = true
 
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Repository Search Resource",
 

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -107,6 +107,7 @@ func (r *CheckServiceOwnershipResource) Metadata(ctx context.Context, req resour
 func (r *CheckServiceOwnershipResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	enumAllContactTypes := append(opslevel.AllContactType, "any")
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Service Ownership Resource",
 
@@ -133,6 +134,60 @@ func (r *CheckServiceOwnershipResource) Schema(ctx context.Context, req resource
 			},
 			"tag_predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	enumAllContactTypes := append(opslevel.AllContactType, "any")
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Description: "Check Service Ownership Resource",
+				Attributes: getCheckBaseSchemaV0(map[string]schema.Attribute{
+					"contact_method": schema.StringAttribute{
+						Description: "The type of contact method that is required.",
+						Optional:    true,
+						Validators:  []validator.String{stringvalidator.OneOfCaseInsensitive(enumAllContactTypes...)},
+					},
+					"require_contact_method": schema.BoolAttribute{
+						Description: "True if a service's owner must have a contact method, False otherwise.",
+						Optional:    true,
+					},
+					"tag_key": schema.StringAttribute{
+						Description: "The tag key where the tag predicate should be applied.",
+						Optional:    true,
+					},
+					"tag_predicate": predicateSchemaV0,
+				}),
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) { /* ... */
+				upgradedStateModel := CheckServiceOwnershipResourceModel{}
+				predicateModel := types.ObjectNull(predicateType)
+
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("category"), &upgradedStateModel.Category)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("contact_method"), &upgradedStateModel.ContactMethod)...)
+				// resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("description"), &upgradedStateData.Description)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enable_on"), &upgradedStateModel.EnableOn)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enabled"), &upgradedStateModel.Enabled)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("filter"), &upgradedStateModel.Filter)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &upgradedStateModel.Id)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("level"), &upgradedStateModel.Level)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &upgradedStateModel.Name)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("notes"), &upgradedStateModel.Notes)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("owner"), &upgradedStateModel.Owner)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("require_contact_method"), &upgradedStateModel.RequireContactMethod)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tag_key"), &upgradedStateModel.TagKey)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tag_predicate"), &predicateModel)...)
+				// resp.Diagnostics.Append(req.State.Get(ctx, &priorStateData)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				upgradedStateModel.TagPredicate = predicateModel
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)
+			},
+		},
 	}
 }
 

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -22,6 +22,7 @@ import (
 var (
 	_ resource.ResourceWithConfigure      = &CheckServiceOwnershipResource{}
 	_ resource.ResourceWithImportState    = &CheckServiceOwnershipResource{}
+	_ resource.ResourceWithUpgradeState   = &CheckServiceOwnershipResource{}
 	_ resource.ResourceWithValidateConfig = &CheckServiceOwnershipResource{}
 )
 
@@ -137,7 +138,7 @@ func (r *CheckServiceOwnershipResource) Schema(ctx context.Context, req resource
 	}
 }
 
-func UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+func (r *CheckServiceOwnershipResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	enumAllContactTypes := append(opslevel.AllContactType, "any")
 	return map[int64]resource.StateUpgrader{
 		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
@@ -158,8 +159,12 @@ func UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 						Description: "The tag key where the tag predicate should be applied.",
 						Optional:    true,
 					},
-					"tag_predicate": predicateSchemaV0,
 				}),
+				Blocks: map[string]schema.Block{
+					"tag_predicate": schema.ListNestedBlock{
+						NestedObject: predicateSchemaV0,
+					},
+				},
 			},
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) { /* ... */
 				upgradedStateModel := CheckServiceOwnershipResourceModel{}
@@ -171,7 +176,7 @@ func UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enable_on"), &upgradedStateModel.EnableOn)...)
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enabled"), &upgradedStateModel.Enabled)...)
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("filter"), &upgradedStateModel.Filter)...)
-				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &upgradedStateModel.Id)...)
+				// resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &upgradedStateModel.Id)...)
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("level"), &upgradedStateModel.Level)...)
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &upgradedStateModel.Name)...)
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("notes"), &upgradedStateModel.Notes)...)

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -94,6 +94,7 @@ func (r *CheckServicePropertyResource) Metadata(ctx context.Context, req resourc
 
 func (r *CheckServicePropertyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Service Property Resource",
 

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -91,6 +91,7 @@ func (r *CheckTagDefinedResource) Metadata(ctx context.Context, req resource.Met
 
 func (r *CheckTagDefinedResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Tag Defined Resource",
 

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -100,6 +101,59 @@ func (r *CheckTagDefinedResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"tag_predicate": PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckTagDefinedResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Description: "Check Tag Defined Resource",
+				Attributes: getCheckBaseSchemaV0(map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						Description: "The ID of this resource.",
+						Computed:    true,
+					},
+					"tag_key": schema.StringAttribute{
+						Description: "The tag key where the tag predicate should be applied.",
+						Required:    true,
+					},
+				}),
+				Blocks: map[string]schema.Block{
+					"tag_predicate": schema.ListNestedBlock{
+						NestedObject: predicateSchemaV0,
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var diags diag.Diagnostics
+				upgradedStateModel := CheckTagDefinedResourceModel{}
+				tagPredicateList := types.ListNull(types.ObjectType{AttrTypes: predicateType})
+
+				// base check attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("category"), &upgradedStateModel.Category)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enable_on"), &upgradedStateModel.EnableOn)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enabled"), &upgradedStateModel.Enabled)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("filter"), &upgradedStateModel.Filter)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &upgradedStateModel.Id)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("level"), &upgradedStateModel.Level)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &upgradedStateModel.Name)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("notes"), &upgradedStateModel.Notes)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("owner"), &upgradedStateModel.Owner)...)
+
+				// check tag defined specific attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tag_key"), &upgradedStateModel.TagKey)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tag_predicate"), &tagPredicateList)...)
+				if len(tagPredicateList.Elements()) == 1 {
+					tagPredicate := tagPredicateList.Elements()[0]
+					upgradedStateModel.TagPredicate, diags = types.ObjectValueFrom(ctx, predicateType, tagPredicate)
+					resp.Diagnostics.Append(diags...)
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)
+			},
+		},
 	}
 }
 

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -117,6 +117,7 @@ func (r *CheckToolUsageResource) Metadata(ctx context.Context, req resource.Meta
 
 func (r *CheckToolUsageResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Tool Usage Resource",
 

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -132,6 +133,79 @@ func (r *CheckToolUsageResource) Schema(ctx context.Context, req resource.Schema
 			"tool_name_predicate":   PredicateSchema(),
 			"tool_url_predicate":    PredicateSchema(),
 		}),
+	}
+}
+
+func (r *CheckToolUsageResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Description: "Check Tool Usage Resource",
+				Attributes: getCheckBaseSchemaV0(map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						Description: "The ID of this resource.",
+						Computed:    true,
+					},
+					"tool_category": schema.StringAttribute{
+						Description: "The category that the tool belongs to.",
+						Required:    true,
+					},
+				}),
+				Blocks: map[string]schema.Block{
+					"environment_predicate": schema.ListNestedBlock{
+						NestedObject: predicateSchemaV0,
+					},
+					"tool_name_predicate": schema.ListNestedBlock{
+						NestedObject: predicateSchemaV0,
+					},
+					"tool_url_predicate": schema.ListNestedBlock{
+						NestedObject: predicateSchemaV0,
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var diags diag.Diagnostics
+				upgradedStateModel := CheckToolUsageResourceModel{}
+				environmentPredicateList := types.ListNull(types.ObjectType{AttrTypes: predicateType})
+				toolNamePredicateList := types.ListNull(types.ObjectType{AttrTypes: predicateType})
+				toolUrlPredicateList := types.ListNull(types.ObjectType{AttrTypes: predicateType})
+
+				// base check attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("category"), &upgradedStateModel.Category)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enable_on"), &upgradedStateModel.EnableOn)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("enabled"), &upgradedStateModel.Enabled)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("filter"), &upgradedStateModel.Filter)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("id"), &upgradedStateModel.Id)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("level"), &upgradedStateModel.Level)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &upgradedStateModel.Name)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("notes"), &upgradedStateModel.Notes)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("owner"), &upgradedStateModel.Owner)...)
+
+				// tool usage specific attributes
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tool_category"), &upgradedStateModel.ToolCategory)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("environment_predicate"), &environmentPredicateList)...)
+				if len(environmentPredicateList.Elements()) == 1 {
+					environmentPredicate := environmentPredicateList.Elements()[0]
+					upgradedStateModel.EnvironmentPredicate, diags = types.ObjectValueFrom(ctx, predicateType, environmentPredicate)
+					resp.Diagnostics.Append(diags...)
+				}
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tool_name_predicate"), &toolNamePredicateList)...)
+				if len(toolNamePredicateList.Elements()) == 1 {
+					toolNamePredicate := toolNamePredicateList.Elements()[0]
+					upgradedStateModel.ToolNamePredicate, diags = types.ObjectValueFrom(ctx, predicateType, toolNamePredicate)
+					resp.Diagnostics.Append(diags...)
+				}
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tool_url_predicate"), &toolUrlPredicateList)...)
+				if len(toolUrlPredicateList.Elements()) == 1 {
+					toolUrlPredicate := toolUrlPredicateList.Elements()[0]
+					upgradedStateModel.ToolUrlPredicate, diags = types.ObjectValueFrom(ctx, predicateType, toolUrlPredicate)
+					resp.Diagnostics.Append(diags...)
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Issues

[Add StateUpgraders to Terraform provider](https://github.com/OpsLevel/team-platform/issues/421)

## Changelog

Adding `StateUpgrader`s to these resources:
- [x] opslevel_check_alert_source_usage
- [x] opslevel_check_repository_file
- [x] opslevel_check_repository_grep
- [x] opslevel_check_repository_search
- [X] opslevel_check_service_ownership
- [x] opslevel_check_service_property
- [x] opslevel_check_tag_defined
- [x] opslevel_check_tool_usage

Added v0 (old `v0.11.0`) schemas for checks. The "v0" base schema and generic predicate schemas are done.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Setup OpsLevel's Terraform provider version `v0.11.0`
```bash
# checkout code at v0.11.0 release
git checkout tags/v0.11.0

# setup submodule known from v0.11.0 release
git submodule deinit --all -f  
git submodule init
git submodule update

# old task that is now part of 'task setup'
task setup-terraform
```

### With this Terraform config (note `*_predicate` blocks that have changed as of v1.x)
```tf
locals {
  category_id = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level_id    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
  owner_id    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter_id   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
}

resource "opslevel_check_alert_source_usage" "test" {
  alert_type = "datadog"
  name       = "Import alert source usage check"
  enabled    = false
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  alert_name_predicate {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_repository_file" "test" {
  directory_search  = false
  filepaths         = ["one", "two"]
  use_absolute_root = false
  name              = "Import repository file check"
  enabled           = false
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  file_contents_predicate {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_service_ownership" "test" {
  contact_method = "ANY"
  name           = "Import service ownership check"
  enabled        = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category               = local.category_id
  filter                 = local.filter_id
  level                  = local.level_id
  owner                  = local.owner_id
  notes                  = "Some notes"
  require_contact_method = true
  tag_key                = "team"
  tag_predicate {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_service_property" "test" {
  property = "language"
  name     = "Import service property check"
  enabled  = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  predicate {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_tag_defined" "test" {
  tag_key = "somekey"
  name    = "Import check tag defined check"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  tag_predicate {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_tool_usage" "test" {
  tool_category = "observability"
  name          = "Import check tag defined check"
  enabled       = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  environment_predicate {
    type  = "equals"
    value = "ownership"
  }
  tool_name_predicate {
    type  = "equals"
    value = "ownership"
  }
  tool_url_predicate {
    type  = "equals"
    value = "ownership"
  }
}
```

### Create with `terraform apply`, then print Terraform state with `terraform show` in workspace directory. (NOTE the predicate blocks)
```tf
# opslevel_check_alert_source_usage.test:
resource "opslevel_check_alert_source_usage" "test" {
    alert_type = "datadog"
    category   = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
    enabled    = false
    filter     = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
    id         = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI3MTI0"
    level      = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
    name       = "Import alert source usage check"
    notes      = "Some notes"
    owner      = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"

    alert_name_predicate {
        type  = "equals"
        value = "ownership"
    }
}

# opslevel_check_repository_file.test:
resource "opslevel_check_repository_file" "test" {
    category          = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
    directory_search  = false
    enabled           = false
    filepaths         = [
        "one",
        "two",
    ]
    filter            = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
    id                = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNzEyNQ"
    level             = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
    name              = "Import repository file check"
    notes             = "Some notes"
    owner             = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    use_absolute_root = false

    file_contents_predicate {
        type  = "equals"
        value = "ownership"
    }
}

# opslevel_check_service_ownership.test:
resource "opslevel_check_service_ownership" "test" {
    category               = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
    contact_method         = "ANY"
    enabled                = true
    filter                 = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
    id                     = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNzEyNg"
    level                  = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
    name                   = "Import service ownership check"
    notes                  = "Some notes"
    owner                  = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    require_contact_method = true
    tag_key                = "team"

    tag_predicate {
        type  = "equals"
        value = "ownership"
    }
}

# opslevel_check_service_property.test:
resource "opslevel_check_service_property" "test" {
    category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
    enabled  = true
    filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
    id       = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjcxMjM"
    level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
    name     = "Import service property check"
    notes    = "Some notes"
    owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    property = "language"

    predicate {
        type  = "equals"
        value = "ownership"
    }
}

# opslevel_check_tag_defined.test:
resource "opslevel_check_tag_defined" "test" {
    category = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
    enabled  = true
    filter   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
    id       = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI3MTI3"
    level    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
    name     = "Import check tag defined check"
    notes    = "Some notes"
    owner    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    tag_key  = "somekey"

    tag_predicate {
        type  = "equals"
        value = "ownership"
    }
}

# opslevel_check_tool_usage.test:
resource "opslevel_check_tool_usage" "test" {
    category      = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
    enabled       = true
    filter        = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
    id            = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjcxMjg"
    level         = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
    name          = "Import check tag defined check"
    notes         = "Some notes"
    owner         = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
    tool_category = "observability"

    environment_predicate {
        type  = "equals"
        value = "ownership"
    }

    tool_name_predicate {
        type  = "equals"
        value = "ownership"
    }

    tool_url_predicate {
        type  = "equals"
        value = "ownership"
    }
}
```

### Update OpsLevel's Terraform provider version to use latest
```bash
# Check out this feature branch
git switch -
task setup
```

### Update Terraform config (NOTE `*_predicate` nested attributes)
```tf
locals {
  category_id = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvNjk3Nw"
  level_id    = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvMzcxMA"
  owner_id    = "Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xNzQzNA"
  filter_id   = "Z2lkOi8vb3BzbGV2ZWwvRmlsdGVyLzM1NzA"
}

resource "opslevel_check_alert_source_usage" "test" {
  alert_type = "datadog"
  name       = "IMPORT ALERT SOURCE USAGE CHECK"
  enabled    = false
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  alert_name_predicate = {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_repository_file" "test" {
  directory_search  = false
  filepaths         = ["one", "two"]
  use_absolute_root = false
  name              = "IMPORT REPOSITORY FILE CHECK"
  enabled           = false
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  file_contents_predicate = {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_service_ownership" "test" {
  contact_method = "ANY"
  name           = "IMPORT SERVICE OWNERSHIP CHECK"
  enabled        = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category               = local.category_id
  filter                 = local.filter_id
  level                  = local.level_id
  owner                  = local.owner_id
  notes                  = "Some notes"
  require_contact_method = true
  tag_key                = "team"
  tag_predicate = {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_service_property" "test" {
  property = "language"
  name     = "IMPORT SERVICE PROPERTY CHECK"
  enabled  = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  predicate = {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_tag_defined" "test" {
  tag_key = "somekey"
  name    = "IMPORT CHECK TAG DEFINED CHECK"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  tag_predicate = {
    type  = "equals"
    value = "ownership"
  }
}

resource "opslevel_check_tool_usage" "test" {
  tool_category = "observability"
  name          = "IMPORT CHECK TAG DEFINED CHECK"
  enabled       = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category = local.category_id
  filter   = local.filter_id
  level    = local.level_id
  owner    = local.owner_id
  notes    = "Some notes"
  environment_predicate = {
    type  = "equals"
    value = "ownership"
  }
  tool_name_predicate = {
    type  = "equals"
    value = "ownership"
  }
  tool_url_predicate = {
    type  = "equals"
    value = "ownership"
  }
}
```

### Apply update with newest version of Terraform provider, `terraform apply`
```tf
opslevel_check_alert_source_usage.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI3MTI0]
opslevel_check_service_property.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjcxMjM]
opslevel_check_service_ownership.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNzEyNg]
opslevel_check_tag_defined.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI3MTI3]
opslevel_check_repository_file.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNzEyNQ]
opslevel_check_tool_usage.test: Refreshing state... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjcxMjg]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # opslevel_check_alert_source_usage.test will be updated in-place
  ~ resource "opslevel_check_alert_source_usage" "test" {
      ~ description          = "The service is using a DataDog alert source, named 'ownership'." -> (known after apply)
        id                   = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI3MTI0"
      ~ name                 = "Import alert source usage check" -> "IMPORT ALERT SOURCE USAGE CHECK"
        # (8 unchanged attributes hidden)
    }

  # opslevel_check_repository_file.test will be updated in-place
  ~ resource "opslevel_check_repository_file" "test" {
      ~ description             = "Repo files ''one' or 'two'' equals 'ownership'." -> (known after apply)
        id                      = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNzEyNQ"
      ~ name                    = "Import repository file check" -> "IMPORT REPOSITORY FILE CHECK"
        # (10 unchanged attributes hidden)
    }

  # opslevel_check_service_ownership.test will be updated in-place
  ~ resource "opslevel_check_service_ownership" "test" {
      ~ description            = "Verifies that the service has an owner defined and with an optional requirement for a contact method and/or tag to be associated with that owner." -> (known after apply)
        id                     = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNzEyNg"
      ~ name                   = "Import service ownership check" -> "IMPORT SERVICE OWNERSHIP CHECK"
        # (10 unchanged attributes hidden)
    }

  # opslevel_check_service_property.test will be updated in-place
  ~ resource "opslevel_check_service_property" "test" {
      ~ description = "The service has a language that equals <code>ownership</code>" -> (known after apply)
        id          = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjcxMjM"
      ~ name        = "Import service property check" -> "IMPORT SERVICE PROPERTY CHECK"
        # (8 unchanged attributes hidden)
    }

  # opslevel_check_tag_defined.test will be updated in-place
  ~ resource "opslevel_check_tag_defined" "test" {
      ~ description   = "Verifies that the service has the specified tag defined." -> (known after apply)
        id            = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI3MTI3"
      ~ name          = "Import check tag defined check" -> "IMPORT CHECK TAG DEFINED CHECK"
        # (8 unchanged attributes hidden)
    }

  # opslevel_check_tool_usage.test will be updated in-place
  ~ resource "opslevel_check_tool_usage" "test" {
      ~ description           = "The service is using 'ownership' as an observability tool in the 'ownership' environment matching the url: 'ownership'." -> (known after apply)
        id                    = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjcxMjg"
      ~ name                  = "Import check tag defined check" -> "IMPORT CHECK TAG DEFINED CHECK"
        # (10 unchanged attributes hidden)
    }

Plan: 0 to add, 6 to change, 0 to destroy.
opslevel_check_tag_defined.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI3MTI3]
opslevel_check_repository_file.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNzEyNQ]
opslevel_check_alert_source_usage.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI3MTI0]
opslevel_check_service_property.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjcxMjM]
opslevel_check_service_ownership.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNzEyNg]
opslevel_check_tool_usage.test: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjcxMjg]
opslevel_check_service_ownership.test: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpIYXNPd25lci8yNzEyNg]
opslevel_check_alert_source_usage.test: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpBbGVydFNvdXJjZVVzYWdlLzI3MTI0]
opslevel_check_tool_usage.test: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUb29sVXNhZ2UvMjcxMjg]
opslevel_check_tag_defined.test: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpUYWdEZWZpbmVkLzI3MTI3]
opslevel_check_service_property.test: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjcxMjM]
opslevel_check_repository_file.test: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpSZXBvRmlsZS8yNzEyNQ]

Apply complete! Resources: 0 added, 6 changed, 0 destroyed.
```

### Destroy resources `terraform destroy` ✅ 