### PR TITLE
no need to touch Terraform state during migration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,8 +4,6 @@ We at OpsLevel have been working on upgrading [our Terraform provider](https://g
 
 While the majority of these improvements are under the hood, there are a few Terraform configuration changes to be aware of.
 
-For errors encountered during `terraform apply`, see the [State Migration](#state-migration) section below.
-
 # BREAKING CHANGES to some resource fields
 
 The following resources with fields that were “block type fields" will need an “=” added.
@@ -168,36 +166,3 @@ Changes to Outputs:
       + "Example Domain",
     ]
 ```
-
-# State Migration
-
-The structure of some resource data has changed from v0.11.0 to v1.0.0.
-If you encounter erros like `Error: Unable to Read Previously Saved State for UpgradeResourceState`
-while upgrading to the OpsLevel v1.0.0 Terraform provider, the following will get you unstuck.
-
-### Get ids of resources that raise errors
-
-Assuming `opslevel_check_tag_defined.my_tag` raises an error like
-`AttributeName("environment_predicate"): invalid JSON, expected "{", got "["`, run
-`terraform state show opslevel_check_tag_defined.my_tag` and extract the value of `id`.
-Extract and keep all ids for resources that raise errors.
-
-If `terraform state show ...` raises an error, try `terraform state pull > my_tf_state.json`
-and extract ids from `my_tf_state.json`.
-
-### Remove problematic resources from state
-
-This does NOT remove the resources from OpsLevel - only from Terraform's state.
-Run `terraform state rm opslevel_check_tag_defined.my_tag` and repeat for all
-resources that raise errors.
-Optionally verify resources removed from state with `terraform state list`.
-
-### Import resources from OpsLevel into Terraform state
-
-Import OpsLevel resources into Terraform's state by running
-`terraform import opslevel_check_tag_defined.my_tag <resource-id>` and repeat
-for all resources that raise errors. Note <resource-id> matches the `id` of the OpsLevel
-resource as returned by the [OpsLevel cli](https://github.com/opslevel/cli), if `id` is
-not otherwise known.
-Optionally verify resources imported to state with `terraform state list`.
-

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,12 @@
 # Migration Guide to v1.0.0
 
+For everyone upgrading from a version before v1.0.0, we recommend upgrading straight to v1.2 or higher.
+
 We at OpsLevel have been working on upgrading [our Terraform provider](https://github.com/OpsLevel/terraform-provider-opslevel) to version 1.0.0.
 
 While the majority of these improvements are under the hood, there are a few Terraform configuration changes to be aware of.
+
+For errors encountered during `terraform apply`, see the [State Migration](#state-migration) section below - Applies only to v1.0.0 up to v1.1.x
 
 # BREAKING CHANGES to some resource fields
 
@@ -166,3 +170,38 @@ Changes to Outputs:
       + "Example Domain",
     ]
 ```
+
+# State Migration (Applies to v1.0.0 up to v1.1.x)
+
+We recommend upgrading straight to v1.2 or higher. But for versions between v1.0.0 and v1.1.x, the following may be needed.
+
+The structure of some resource data has changed from v0.11.0 to v1.0.0.
+If you encounter erros like `Error: Unable to Read Previously Saved State for UpgradeResourceState`
+while upgrading to the OpsLevel v1.0.0 Terraform provider, the following will get you unstuck.
+
+### Get ids of resources that raise errors
+
+Assuming `opslevel_check_tag_defined.my_tag` raises an error like
+`AttributeName("environment_predicate"): invalid JSON, expected "{", got "["`, run
+`terraform state show opslevel_check_tag_defined.my_tag` and extract the value of `id`.
+Extract and keep all ids for resources that raise errors.
+
+If `terraform state show ...` raises an error, try `terraform state pull > my_tf_state.json`
+and extract ids from `my_tf_state.json`.
+
+### Remove problematic resources from state
+
+This does NOT remove the resources from OpsLevel - only from Terraform's state.
+Run `terraform state rm opslevel_check_tag_defined.my_tag` and repeat for all
+resources that raise errors.
+Optionally verify resources removed from state with `terraform state list`.
+
+### Import resources from OpsLevel into Terraform state
+
+Import OpsLevel resources into Terraform's state by running
+`terraform import opslevel_check_tag_defined.my_tag <resource-id>` and repeat
+for all resources that raise errors. Note <resource-id> matches the `id` of the OpsLevel
+resource as returned by the [OpsLevel cli](https://github.com/opslevel/cli), if `id` is
+not otherwise known.
+Optionally verify resources imported to state with `terraform state list`.
+


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry, N/A docs only

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->

<!-- Typical Terraform CRUD workflow

### Given this Terraform config file
```tf
# main.tf
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Update the Terraform config file
```tf
# main.tf - with changes
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```tf
# copy paste CLI outputs here
```

-->
