### PR TITLE
add null cases for StateUpgraders

### DIFF
--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -156,6 +156,8 @@ func (r *CheckAlertSourceUsageResource) UpgradeState(ctx context.Context) map[in
 					alertNamePredicate := alertNamePredicateList.Elements()[0]
 					upgradedStateModel.AlertNamePredicate, diags = types.ObjectValueFrom(ctx, predicateType, alertNamePredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.AlertNamePredicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_manual.go
+++ b/opslevel/resource_opslevel_check_manual.go
@@ -201,6 +201,8 @@ func (r *CheckManualResource) UpgradeState(ctx context.Context) map[int64]resour
 						TimeScale:    updateFrequencyAttrs["time_scale"].(basetypes.StringValue),
 						Value:        updateFrequencyAttrs["value"].(basetypes.Int64Value),
 					}
+				} else {
+					upgradedStateModel.UpdateFrequency = &CheckUpdateFrequency{}
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_manual.go
+++ b/opslevel/resource_opslevel_check_manual.go
@@ -201,8 +201,6 @@ func (r *CheckManualResource) UpgradeState(ctx context.Context) map[int64]resour
 						TimeScale:    updateFrequencyAttrs["time_scale"].(basetypes.StringValue),
 						Value:        updateFrequencyAttrs["value"].(basetypes.Int64Value),
 					}
-				} else {
-					upgradedStateModel.UpdateFrequency = &CheckUpdateFrequency{}
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -174,6 +174,8 @@ func (r *CheckRepositoryFileResource) UpgradeState(ctx context.Context) map[int6
 					fileContentsPredicate := fileContentsPredicateList.Elements()[0]
 					upgradedStateModel.FileContentsPredicate, diags = types.ObjectValueFrom(ctx, predicateType, fileContentsPredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.FileContentsPredicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -163,6 +163,8 @@ func (r *CheckRepositoryGrepResource) UpgradeState(ctx context.Context) map[int6
 					fileContentsPredicate := fileContentsPredicateList.Elements()[0]
 					upgradedStateModel.FileContentsPredicate, diags = types.ObjectValueFrom(ctx, predicateType, fileContentsPredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.FileContentsPredicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -165,6 +165,8 @@ func (r *CheckRepositorySearchResource) UpgradeState(ctx context.Context) map[in
 					fileContentsPredicate := fileContentsPredicateList.Elements()[0]
 					upgradedStateModel.FileContentsPredicate, diags = types.ObjectValueFrom(ctx, predicateType, fileContentsPredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.FileContentsPredicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -196,6 +196,8 @@ func (r *CheckServiceOwnershipResource) UpgradeState(ctx context.Context) map[in
 					tagPredicate := tagPredicateList.Elements()[0]
 					upgradedStateModel.TagPredicate, diags = types.ObjectValueFrom(ctx, predicateType, tagPredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.TagPredicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -159,6 +159,8 @@ func (r *CheckServicePropertyResource) UpgradeState(ctx context.Context) map[int
 					predicate := predicateList.Elements()[0]
 					upgradedStateModel.Predicate, diags = types.ObjectValueFrom(ctx, predicateType, predicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.Predicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -150,6 +150,8 @@ func (r *CheckTagDefinedResource) UpgradeState(ctx context.Context) map[int64]re
 					tagPredicate := tagPredicateList.Elements()[0]
 					upgradedStateModel.TagPredicate, diags = types.ObjectValueFrom(ctx, predicateType, tagPredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.TagPredicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -190,18 +190,24 @@ func (r *CheckToolUsageResource) UpgradeState(ctx context.Context) map[int64]res
 					environmentPredicate := environmentPredicateList.Elements()[0]
 					upgradedStateModel.EnvironmentPredicate, diags = types.ObjectValueFrom(ctx, predicateType, environmentPredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.EnvironmentPredicate = types.ObjectNull(predicateType)
 				}
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tool_name_predicate"), &toolNamePredicateList)...)
 				if len(toolNamePredicateList.Elements()) == 1 {
 					toolNamePredicate := toolNamePredicateList.Elements()[0]
 					upgradedStateModel.ToolNamePredicate, diags = types.ObjectValueFrom(ctx, predicateType, toolNamePredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.ToolNamePredicate = types.ObjectNull(predicateType)
 				}
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("tool_url_predicate"), &toolUrlPredicateList)...)
 				if len(toolUrlPredicateList.Elements()) == 1 {
 					toolUrlPredicate := toolUrlPredicateList.Elements()[0]
 					upgradedStateModel.ToolUrlPredicate, diags = types.ObjectValueFrom(ctx, predicateType, toolUrlPredicate)
 					resp.Diagnostics.Append(diags...)
+				} else {
+					upgradedStateModel.ToolUrlPredicate = types.ObjectNull(predicateType)
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -235,6 +235,8 @@ func (r *InfrastructureResource) UpgradeState(ctx context.Context) map[int64]res
 						Type:    infraProviderDataAttrs["type"].(basetypes.StringValue),
 						Url:     infraProviderDataAttrs["url"].(basetypes.StringValue),
 					}
+				} else {
+					upgradedStateModel.ProviderData = &InfraProviderData{}
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -235,8 +235,6 @@ func (r *InfrastructureResource) UpgradeState(ctx context.Context) map[int64]res
 						Type:    infraProviderDataAttrs["type"].(basetypes.StringValue),
 						Url:     infraProviderDataAttrs["url"].(basetypes.StringValue),
 					}
-				} else {
-					upgradedStateModel.ProviderData = &InfraProviderData{}
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateModel)...)


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->

<!-- Typical Terraform CRUD workflow

### Given this Terraform config file
```tf
# main.tf
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Update the Terraform config file
```tf
# main.tf - with changes
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```tf
# copy paste CLI outputs here
```

-->
