### PR TITLE
fix state import of opslevel_check_repository_search

### DIFF
--- a/.changes/unreleased/Bugfix-20240716-131900.yaml
+++ b/.changes/unreleased/Bugfix-20240716-131900.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix state import of opslevel_check_repository_search
+time: 2024-07-16T13:19:00.491117-05:00

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -144,7 +144,7 @@ func (r *CheckRepositorySearchResource) UpgradeState(ctx context.Context) map[in
 			},
 			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 				var diags diag.Diagnostics
-				upgradedStateModel := CheckRepositoryFileResourceModel{}
+				upgradedStateModel := CheckRepositorySearchResourceModel{}
 				fileContentsPredicateList := types.ListNull(types.ObjectType{AttrTypes: predicateType})
 
 				// base check attributes
@@ -159,7 +159,7 @@ func (r *CheckRepositorySearchResource) UpgradeState(ctx context.Context) map[in
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("owner"), &upgradedStateModel.Owner)...)
 
 				// repository file specific attributes
-				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("file_extensions"), &upgradedStateModel.Filepaths)...)
+				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("file_extensions"), &upgradedStateModel.FileExtensions)...)
 				resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("file_contents_predicate"), &fileContentsPredicateList)...)
 				if len(fileContentsPredicateList.Elements()) == 1 {
 					fileContentsPredicate := fileContentsPredicateList.Elements()[0]


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Fix state upgrader logic due to copy paste typo....

- [ ] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->

<!-- Typical Terraform CRUD workflow

### Given this Terraform config file
```tf
# main.tf
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Update the Terraform config file
```tf
# main.tf - with changes
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```tf
# copy paste CLI outputs here
```

-->
