### PR TITLE
Db/validate func

### DIFF
--- a/.changes/unreleased/Bugfix-20240718-135248.yaml
+++ b/.changes/unreleased/Bugfix-20240718-135248.yaml
@@ -1,0 +1,4 @@
+kind: Bugfix
+body: correctly handle validating fields set by variables or for loops during 'terraform
+  validate'
+time: 2024-07-18T13:52:48.822483-05:00

--- a/.changes/unreleased/Dependency-20240724-134715.yaml
+++ b/.changes/unreleased/Dependency-20240724-134715.yaml
@@ -1,0 +1,3 @@
+kind: Dependency
+body: bump go module version to 1.22
+time: 2024-07-24T13:47:15.127839-05:00

--- a/.changes/unreleased/Dependency-20240724-134750.yaml
+++ b/.changes/unreleased/Dependency-20240724-134750.yaml
@@ -1,0 +1,3 @@
+kind: Dependency
+body: bump github.com/hashicorp/terraform-plugin-framework to v1.10.0
+time: 2024-07-24T13:47:50.22434-05:00

--- a/.changes/unreleased/Dependency-20240724-134806.yaml
+++ b/.changes/unreleased/Dependency-20240724-134806.yaml
@@ -1,0 +1,3 @@
+kind: Dependency
+body: bump github.com/hashicorp/terraform-plugin-framework-validators to v0.13.0
+time: 2024-07-24T13:48:06.886955-05:00

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/opslevel/terraform-provider-opslevel/opslevel.version={{.Version}}'
+      - '-s -w -X main.version={{.Version}}'
     goos:
       - windows
       - linux

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -109,19 +109,12 @@ tasks:
     vars:
       BINARY: terraform-provider-opslevel_{{.VERSION_DYNAMIC}}
     cmds:
-      - defer: rm {{.BINARY}}
-      - go build -gcflags="all=-N -l" -ldflags="-s -X github.com/opslevel/terraform-provider-opslevel/opslevel.version={{.VERSION_DYNAMIC}}" -o {{.BINARY}} || exit 1
-      - dlv exec --accept-multiclient --continue --headless {{.BINARY}} -- -debug | tee {{.DEBUG_LOG}}
-
-  debug-attach:
-    desc: Attach to headless debug sessions
-    vars:
-      LOCAL_PORT:
-        sh: grep 'API server listening at' {{.DEBUG_LOG}} | cut -d':' -f2 -f3
-      TF_REATTACH_PROVIDERS:
-        sh: grep 'TF_REATTACH_PROVIDERS=' {{.DEBUG_LOG}} | cut -d':' -f2
-    cmds:
-      - dlv connect {{.LOCAL_PORT}}
+      - >-
+        dlv debug .
+        --build-flags="-gcflags='all=-N -l' -ldflags='-X main.version={{.VERSION_DYNAMIC}}'"
+        --api-version=2
+        --
+        --debug
 
   terraform-clean:
     desc: Completely wipe terraform state and all terraform generated files from "{{.WORKSPACE_DIR}}"

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/opslevel/terraform-provider-opslevel
 
-go 1.21
+go 1.22
 
 require (
-	github.com/hashicorp/terraform-plugin-framework v1.9.0
-	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
+	github.com/hashicorp/terraform-plugin-framework v1.10.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/opslevel/opslevel-go/v2024 v2024.7.5
 	github.com/relvacode/iso8601 v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -103,10 +103,10 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-plugin-docs v0.13.0 h1:6e+VIWsVGb6jYJewfzq2ok2smPzZrt1Wlm9koLeKazY=
 github.com/hashicorp/terraform-plugin-docs v0.13.0/go.mod h1:W0oCmHAjIlTHBbvtppWHe8fLfZ2BznQbuv8+UD8OucQ=
-github.com/hashicorp/terraform-plugin-framework v1.9.0 h1:caLcDoxiRucNi2hk8+j3kJwkKfvHznubyFsJMWfZqKU=
-github.com/hashicorp/terraform-plugin-framework v1.9.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
+github.com/hashicorp/terraform-plugin-framework v1.10.0 h1:xXhICE2Fns1RYZxEQebwkB2+kXouLC932Li9qelozrc=
+github.com/hashicorp/terraform-plugin-framework v1.10.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
+github.com/hashicorp/terraform-plugin-framework-validators v0.13.0 h1:bxZfGo9DIUoLLtHMElsu+zwqI4IsMZQBRRy4iLzZJ8E=
+github.com/hashicorp/terraform-plugin-framework-validators v0.13.0/go.mod h1:wGeI02gEhj9nPANU62F2jCaHjXulejm/X+af4PdZaNo=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=
 github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -167,16 +167,13 @@ func (r *CheckAlertSourceUsageResource) UpgradeState(ctx context.Context) map[in
 }
 
 func (r *CheckAlertSourceUsageResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var configModel CheckAlertSourceUsageResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	alertNamePredicate := types.ObjectNull(predicateType)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("alert_name_predicate"), &alertNamePredicate)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	predicateModel, diags := PredicateObjectToModel(ctx, configModel.AlertNamePredicate)
+	predicateModel, diags := PredicateObjectToModel(ctx, alertNamePredicate)
 	resp.Diagnostics.Append(diags...)
-	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
-		return
-	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("alert_name_predicate"), "Invalid Attribute Configuration", err.Error())
 	}

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -92,6 +92,10 @@ var predicateType = map[string]attr.Type{
 }
 
 func (p PredicateModel) Validate() error {
+	// Skip validation for now, when input variables or for loops are used
+	if p.Type.IsUnknown() || p.Type.IsNull() {
+		return nil
+	}
 	predicate := opslevel.Predicate{
 		Type:  opslevel.PredicateTypeEnum(p.Type.ValueString()),
 		Value: p.Value.ValueString(),

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -185,16 +185,13 @@ func (r *CheckRepositoryFileResource) UpgradeState(ctx context.Context) map[int6
 }
 
 func (r *CheckRepositoryFileResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var configModel CheckRepositoryFileResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	fileContentsPredicate := types.ObjectNull(predicateType)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("file_contents_predicate"), &fileContentsPredicate)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	predicateModel, diags := PredicateObjectToModel(ctx, configModel.FileContentsPredicate)
+	predicateModel, diags := PredicateObjectToModel(ctx, fileContentsPredicate)
 	resp.Diagnostics.Append(diags...)
-	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
-		return
-	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -182,12 +182,12 @@ func (r *CheckRepositoryGrepResource) ValidateConfig(ctx context.Context, req re
 
 	predicateModel, diags := PredicateObjectToModel(ctx, configModel.FileContentsPredicate)
 	resp.Diagnostics.Append(diags...)
+	if err := predicateModel.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
+	}
 
 	if configModel.DirectorySearch.ValueBool() && !slices.Contains([]string{"exists", "does_not_exist"}, predicateModel.Type.ValueString()) {
 		resp.Diagnostics.AddError("Config Error", "When 'directory_search' is true, file_contents_predicate type must be 'exists' or 'does_not_exist'")
-	}
-	if err := predicateModel.Validate(); err != nil {
-		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -182,12 +182,12 @@ func (r *CheckRepositoryGrepResource) ValidateConfig(ctx context.Context, req re
 
 	predicateModel, diags := PredicateObjectToModel(ctx, configModel.FileContentsPredicate)
 	resp.Diagnostics.Append(diags...)
-	if err := predicateModel.Validate(); err != nil {
-		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
-	}
 
 	if configModel.DirectorySearch.ValueBool() && !slices.Contains([]string{"exists", "does_not_exist"}, predicateModel.Type.ValueString()) {
 		resp.Diagnostics.AddError("Config Error", "When 'directory_search' is true, file_contents_predicate type must be 'exists' or 'does_not_exist'")
+	}
+	if err := predicateModel.Validate(); err != nil {
+		resp.Diagnostics.AddAttributeError(path.Root("file_contents_predicate"), "Invalid Attribute Configuration", err.Error())
 	}
 }
 

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -176,13 +176,13 @@ func (r *CheckRepositorySearchResource) UpgradeState(ctx context.Context) map[in
 }
 
 func (r *CheckRepositorySearchResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var configModel CheckRepositorySearchResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() {
+	fileContentsPredicate := types.ObjectNull(predicateType)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("file_contents_predicate"), &fileContentsPredicate)...)
+	if resp.Diagnostics.HasError() || fileContentsPredicate.IsNull() || fileContentsPredicate.IsUnknown() {
 		return
 	}
 
-	predicateModel, diags := PredicateObjectToModel(ctx, configModel.FileContentsPredicate)
+	predicateModel, diags := PredicateObjectToModel(ctx, fileContentsPredicate)
 	resp.Diagnostics.Append(diags...)
 	if predicateModel.Type.ValueString() == "exists" || predicateModel.Type.ValueString() == "does_not_exist" {
 		resp.Diagnostics.AddError("Config Error", "file_contents_predicate type must not be 'exists' or 'does_not_exist'")

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -207,17 +207,13 @@ func (r *CheckServiceOwnershipResource) UpgradeState(ctx context.Context) map[in
 }
 
 func (r *CheckServiceOwnershipResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var configModel CheckServiceOwnershipResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	tagPredicate := types.ObjectNull(predicateType)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("tag_predicate"), &tagPredicate)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	predicateModel, diags := PredicateObjectToModel(ctx, configModel.TagPredicate)
+	predicateModel, diags := PredicateObjectToModel(ctx, tagPredicate)
 	resp.Diagnostics.Append(diags...)
-	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
-		return
-	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -170,16 +170,13 @@ func (r *CheckServicePropertyResource) UpgradeState(ctx context.Context) map[int
 }
 
 func (r *CheckServicePropertyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var configModel CheckServicePropertyResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+	predicate := types.ObjectNull(predicateType)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("file_contents_predicate"), &predicate)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	predicateModel, diags := PredicateObjectToModel(ctx, configModel.Predicate)
+	predicateModel, diags := PredicateObjectToModel(ctx, predicate)
 	resp.Diagnostics.Append(diags...)
-	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
-		return
-	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("predicate"), "Invalid Attribute Configuration", err.Error())
 	}

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -171,7 +171,7 @@ func (r *CheckServicePropertyResource) UpgradeState(ctx context.Context) map[int
 
 func (r *CheckServicePropertyResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	predicate := types.ObjectNull(predicateType)
-	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("file_contents_predicate"), &predicate)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("predicate"), &predicate)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -161,16 +161,13 @@ func (r *CheckTagDefinedResource) UpgradeState(ctx context.Context) map[int64]re
 }
 
 func (r *CheckTagDefinedResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var configModel CheckTagDefinedResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() {
+	tagPredicate := types.ObjectNull(predicateType)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("tag_predicate"), &tagPredicate)...)
+	if resp.Diagnostics.HasError() || tagPredicate.IsNull() || tagPredicate.IsUnknown() {
 		return
 	}
-	predicateModel, diags := PredicateObjectToModel(ctx, configModel.TagPredicate)
+	predicateModel, diags := PredicateObjectToModel(ctx, tagPredicate)
 	resp.Diagnostics.Append(diags...)
-	if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
-		return
-	}
 	if err := predicateModel.Validate(); err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("tag_predicate"), "Invalid Attribute Configuration", err.Error())
 	}

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -229,11 +229,11 @@ func (r *CheckToolUsageResource) ValidateConfig(ctx context.Context, req resourc
 		"tool_url_predicate":    configModel.ToolUrlPredicate,
 	}
 	for predicateSchemaName, predicate := range checkToolUsagePredicates {
-		predicateModel, diags := PredicateObjectToModel(ctx, predicate)
-		resp.Diagnostics.Append(diags...)
-		if predicateModel.Type.IsUnknown() || predicateModel.Type.IsNull() {
+		if predicate.IsNull() || predicate.IsUnknown() {
 			continue
 		}
+		predicateModel, diags := PredicateObjectToModel(ctx, predicate)
+		resp.Diagnostics.Append(diags...)
 		if err := predicateModel.Validate(); err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root(predicateSchemaName), "Invalid Attribute Configuration", err.Error())
 		}

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -237,7 +237,7 @@ func (r *FilterResource) ValidateConfig(ctx context.Context, req resource.Valida
 	var predicateModels []FilterPredicateModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
-	if resp.Diagnostics.HasError() {
+	if resp.Diagnostics.HasError() || configModel.Predicate.IsNull() || configModel.Predicate.IsUnknown() {
 		return
 	}
 	resp.Diagnostics.Append(configModel.Predicate.ElementsAs(ctx, &predicateModels, false)...)

--- a/tests/local/resource_filter.tftest.hcl
+++ b/tests/local/resource_filter.tftest.hcl
@@ -71,22 +71,17 @@ run "resource_filter_big_predicate_two" {
   }
 
   assert {
-    condition     = opslevel_filter.big.predicate[1].case_sensitive == true
-    error_message = "expected case_sensitive to be true for opslevel_filter.big.predicate[1]"
-  }
-
-  assert {
     condition     = opslevel_filter.big.predicate[1].key == "lifecycle_index"
     error_message = "wrong predicate 'key' for opslevel_filter.big.predicate[1]"
   }
 
   assert {
-    condition     = opslevel_filter.big.predicate[1].key_data == "big_predicate"
+    condition     = opslevel_filter.big.predicate[1].key_data == null
     error_message = "wrong 'key_data' for opslevel_filter.big.predicate[1]"
   }
 
   assert {
-    condition     = opslevel_filter.big.predicate[1].type == "ends_with"
+    condition     = opslevel_filter.big.predicate[1].type == "greater_than_or_equal_to"
     error_message = "wrong predicate 'type' for opslevel_filter.big.predicate[1]"
   }
 

--- a/tests/local/resources.tf
+++ b/tests/local/resources.tf
@@ -22,11 +22,9 @@ resource "opslevel_filter" "big" {
     value = "1"
   }
   predicate {
-    case_sensitive = true
-    key            = "lifecycle_index"
-    key_data       = "big_predicate"
-    type           = "ends_with"
-    value          = "1"
+    key   = "lifecycle_index"
+    type  = "greater_than_or_equal_to"
+    value = "1"
   }
 }
 


### PR DESCRIPTION
## Issues

[Ensure Terraform validate functions handled "unknown" values](https://github.com/OpsLevel/team-platform/issues/395)

## Changelog

Update `ValidateConfig()` functions to correctly skip validation when field values are not yet known. This applies to fields that are set with `var.some_input`, `each.key`, etc.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Given this Terraform config file
```tf
# main.tf
locals {
  id1 = "Z2lkOi8vb3BzbGV2ZWwvRW50aXR5T2JqZWN0LzEwOTk2NjU"
}

variable "unknown_until_plan" {
  type = object({
    type  = string
    value = string
  })
}

resource "opslevel_check_alert_source_usage" "validate" {
  name                 = "foo"
  alert_type           = "datadog"
  category             = local.id1
  level                = local.id1
  owner                = local.id1
  filter               = local.id1
  alert_name_predicate = var.unknown_until_plan
}

resource "opslevel_check_repository_file" "validate" {
  name                    = "foo"
  directory_search        = false
  filepaths               = ["foo"]
  use_absolute_root       = false
  category                = local.id1
  level                   = local.id1
  owner                   = local.id1
  filter                  = local.id1
  file_contents_predicate = var.unknown_until_plan
}

resource "opslevel_check_repository_search" "validate" {
  name     = "foo"
  category = local.id1
  level    = local.id1
  owner    = local.id1
  filter   = local.id1
  file_contents_predicate = {
    type  = var.unknown_until_plan.type
    value = var.unknown_until_plan.value
  }
}

resource "opslevel_check_service_ownership" "validate" {
  name          = "foo"
  category      = local.id1
  level         = local.id1
  owner         = local.id1
  filter        = local.id1
  tag_predicate = var.unknown_until_plan
}

resource "opslevel_check_service_property" "validate" {
  name      = "foo"
  property  = "name"
  category  = local.id1
  level     = local.id1
  owner     = local.id1
  filter    = local.id1
  predicate = var.unknown_until_plan
}

resource "opslevel_check_tag_defined" "validate" {
  name          = "foo"
  tag_key       = "bar"
  category      = local.id1
  level         = local.id1
  owner         = local.id1
  filter        = local.id1
  tag_predicate = var.unknown_until_plan
}

resource "opslevel_check_tool_usage" "validate" {
  name                  = "foo"
  tool_category         = "admin"
  category              = local.id1
  level                 = local.id1
  owner                 = local.id1
  filter                = local.id1
  tool_url_predicate    = var.unknown_until_plan
  environment_predicate = var.unknown_until_plan
  tool_name_predicate   = var.unknown_until_plan
}

resource "opslevel_filter" "validate" {
  name = "foo"
}
```

### Validate Terraform config (pre-plan), `terraform validate`
```bash
Success! The configuration is valid.
```