### PR TITLE
Blockout package version check

### DIFF
--- a/examples/resources/opslevel_check_package_version/import.sh
+++ b/examples/resources/opslevel_check_package_version/import.sh
@@ -1,0 +1,1 @@
+terraform import opslevel_check_package_version.example Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MDI0

--- a/examples/resources/opslevel_check_package_version/resource.tf
+++ b/examples/resources/opslevel_check_package_version/resource.tf
@@ -1,0 +1,71 @@
+data "opslevel_rubric_category" "security" {
+  filter {
+    field = "name"
+    value = "Security"
+  }
+}
+
+data "opslevel_rubric_level" "bronze" {
+  filter {
+    field = "name"
+    value = "Bronze"
+  }
+}
+
+data "opslevel_team" "devs" {
+  alias = "developers"
+}
+
+data "opslevel_filter" "tier1" {
+  filter {
+    field = "name"
+    value = "Tier 1"
+  }
+}
+
+resource "opslevel_check_package_version" "example" {
+  name      = "foo"
+  enable = true
+  category  = data.opslevel_rubric_category.security.id
+  level     = data.opslevel_rubric_level.bronze.id
+  notes     = "Optional additional info on why this check is run or how to fix it"
+
+  package_constraint = "exists"
+  package_manager = "gradle"
+  package_name = "log4j"
+}
+
+resource "opslevel_check_package_version" "example2" {
+  name      = "foo"
+  enable = true
+  category  = data.opslevel_rubric_category.security.id
+  level     = data.opslevel_rubric_level.bronze.id
+  notes     = "Optional additional info on why this check is run or how to fix it"
+
+  package_constraint = "matches-version"
+  package_manager = "npm"
+  package_name = "leftpad"
+  missing_package_result = "passed"
+    version_constraint_predicate = {
+        type = "matches_regex"
+        value = "1.0.*"
+    }
+}
+
+resource "opslevel_check_package_version" "example3" {
+  name      = "foo"
+  enable = true
+  category  = data.opslevel_rubric_category.security.id
+  level     = data.opslevel_rubric_level.bronze.id
+  notes     = "Optional additional info on why this check is run or how to fix it"
+
+  package_constraint = "matches-version"
+  package_manager = "go"
+  package_name = "client-go/.*"
+  pakcage_name_is_regex = true
+  missing_package_result = "passed"
+  version_constraint_predicate = {
+    type = "matches_regex"
+    value = "1.27.*"
+  }
+}

--- a/examples/resources/opslevel_check_package_version/resource.tf
+++ b/examples/resources/opslevel_check_package_version/resource.tf
@@ -24,48 +24,48 @@ data "opslevel_filter" "tier1" {
 }
 
 resource "opslevel_check_package_version" "example" {
-  name      = "foo"
-  enable = true
-  category  = data.opslevel_rubric_category.security.id
-  level     = data.opslevel_rubric_level.bronze.id
-  notes     = "Optional additional info on why this check is run or how to fix it"
+  name     = "foo"
+  enable   = true
+  category = data.opslevel_rubric_category.security.id
+  level    = data.opslevel_rubric_level.bronze.id
+  notes    = "Optional additional info on why this check is run or how to fix it"
 
   package_constraint = "exists"
-  package_manager = "gradle"
-  package_name = "log4j"
+  package_manager    = "gradle"
+  package_name       = "log4j"
 }
 
 resource "opslevel_check_package_version" "example2" {
-  name      = "foo"
-  enable = true
-  category  = data.opslevel_rubric_category.security.id
-  level     = data.opslevel_rubric_level.bronze.id
-  notes     = "Optional additional info on why this check is run or how to fix it"
+  name     = "foo"
+  enable   = true
+  category = data.opslevel_rubric_category.security.id
+  level    = data.opslevel_rubric_level.bronze.id
+  notes    = "Optional additional info on why this check is run or how to fix it"
 
-  package_constraint = "matches-version"
-  package_manager = "npm"
-  package_name = "leftpad"
+  package_constraint     = "matches-version"
+  package_manager        = "npm"
+  package_name           = "leftpad"
   missing_package_result = "passed"
-    version_constraint_predicate = {
-        type = "matches_regex"
-        value = "1.0.*"
-    }
+  version_constraint_predicate = {
+    type  = "matches_regex"
+    value = "1.0.*"
+  }
 }
 
 resource "opslevel_check_package_version" "example3" {
-  name      = "foo"
-  enable = true
-  category  = data.opslevel_rubric_category.security.id
-  level     = data.opslevel_rubric_level.bronze.id
-  notes     = "Optional additional info on why this check is run or how to fix it"
+  name     = "foo"
+  enable   = true
+  category = data.opslevel_rubric_category.security.id
+  level    = data.opslevel_rubric_level.bronze.id
+  notes    = "Optional additional info on why this check is run or how to fix it"
 
-  package_constraint = "matches-version"
-  package_manager = "go"
-  package_name = "client-go/.*"
-  pakcage_name_is_regex = true
+  package_constraint     = "matches-version"
+  package_manager        = "go"
+  package_name           = "client-go/.*"
+  pakcage_name_is_regex  = true
   missing_package_result = "passed"
   version_constraint_predicate = {
-    type = "matches_regex"
+    type  = "matches_regex"
     value = "1.27.*"
   }
 }

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -189,6 +189,7 @@ func (p *OpslevelProvider) Resources(context.Context) []func() resource.Resource
 		NewCheckToolUsageResource,
 		NewCheckCustomEventResource,
 		NewCheckServicePropertyResource,
+		NewCheckPackageVersionResource,
 		NewDomainResource,
 		NewFilterResource,
 		NewInfrastructureResource,

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -1,0 +1,211 @@
+package opslevel
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+	"github.com/relvacode/iso8601"
+)
+
+var (
+	_ resource.ResourceWithConfigure   = &CheckPackageVersionResource{}
+	_ resource.ResourceWithImportState = &CheckPackageVersionResource{}
+)
+
+func NewCheckPackageVersionResource() resource.Resource {
+	return &CheckPackageVersionResource{}
+}
+
+// CheckPackageVersionResource defines the resource implementation.
+type CheckPackageVersionResource struct {
+	CommonResourceClient
+}
+
+type CheckPackageVersionResourceModel struct {
+	Category    types.String `tfsdk:"category"`
+	Description types.String `tfsdk:"description"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+	EnableOn    types.String `tfsdk:"enable_on"`
+	Filter      types.String `tfsdk:"filter"`
+	Id          types.String `tfsdk:"id"`
+	Level       types.String `tfsdk:"level"`
+	Name        types.String `tfsdk:"name"`
+	Notes       types.String `tfsdk:"notes"`
+	Owner       types.String `tfsdk:"owner"`
+
+	// TODO: Unique Fields Here
+}
+
+func NewCheckPackageVersionResourceModel(ctx context.Context, check opslevel.Check, planModel CheckPackageVersionResourceModel) CheckPackageVersionResourceModel {
+	var stateModel CheckPackageVersionResourceModel
+
+	stateModel.Category = RequiredStringValue(string(check.Category.Id))
+	if planModel.Enabled.IsNull() {
+		stateModel.Enabled = types.BoolValue(false)
+	} else {
+		stateModel.Enabled = OptionalBoolValue(&check.Enabled)
+	}
+	if planModel.EnableOn.IsNull() {
+		stateModel.EnableOn = types.StringNull()
+	} else {
+		// We pass through the plan value because of time formatting issue to ensure the state gets the exact value the customer specified
+		stateModel.EnableOn = planModel.EnableOn
+	}
+	stateModel.Filter = OptionalStringValue(string(check.Filter.Id))
+	stateModel.Id = ComputedStringValue(string(check.Id))
+	stateModel.Level = RequiredStringValue(string(check.Level.Id))
+	stateModel.Name = RequiredStringValue(check.Name)
+	stateModel.Notes = OptionalStringValue(check.Notes)
+	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
+
+	// TODO: Unique Fields Here
+
+	return stateModel
+}
+
+func (r *CheckPackageVersionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_check_package_version"
+}
+
+func (r *CheckPackageVersionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Version: 1,
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Check PackageVersion Resource",
+
+		Attributes: CheckBaseAttributes(map[string]schema.Attribute{
+			// TODO: Unique Fields Here
+		}),
+	}
+}
+
+func (r *CheckPackageVersionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var planModel CheckPackageVersionResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := opslevel.CheckPackageVersionCreateInput{
+		CategoryId: asID(planModel.Category),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    asID(planModel.Level),
+		Name:       planModel.Name.ValueString(),
+		Notes:      planModel.Notes.ValueStringPointer(),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
+
+	// TODO: Unique Fields Here
+
+	data, err := r.client.CreateCheckPackageVersion(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create check package version, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckPackageVersionResourceModel(ctx, *data, planModel)
+
+	tflog.Trace(ctx, "created a check package_version resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckPackageVersionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var planModel CheckPackageVersionResourceModel
+
+	// Read Terraform prior stateModel data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data, err := r.client.GetCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check package_version, got error: %s", err))
+		return
+	}
+	stateModel := NewCheckPackageVersionResourceModel(ctx, *data, planModel)
+
+	// Save updated data into Terraform stateModel
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckPackageVersionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planModel CheckPackageVersionResourceModel
+
+	// Read Terraform plan data into the planModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := opslevel.CheckPackageVersionUpdateInput{
+		CategoryId: opslevel.RefOf(asID(planModel.Category)),
+		Enabled:    planModel.Enabled.ValueBoolPointer(),
+		FilterId:   opslevel.RefOf(asID(planModel.Filter)),
+		LevelId:    opslevel.RefOf(asID(planModel.Level)),
+		Id:         asID(planModel.Id),
+		Name:       opslevel.RefOf(planModel.Name.ValueString()),
+		Notes:      opslevel.RefOf(planModel.Notes.ValueString()),
+		OwnerId:    opslevel.RefOf(asID(planModel.Owner)),
+	}
+	if !planModel.EnableOn.IsNull() {
+		enabledOn, err := iso8601.ParseString(planModel.EnableOn.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("error", err.Error())
+		}
+		input.EnableOn = &iso8601.Time{Time: enabledOn}
+	}
+
+	// TODO: Unique Fields Here
+
+	data, err := r.client.UpdateCheckPackageVersion(input)
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to update check package version, got error: %s", err))
+		return
+	}
+
+	stateModel := NewCheckPackageVersionResourceModel(ctx, *data, planModel)
+
+	tflog.Trace(ctx, "updated a check package_version resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}
+
+func (r *CheckPackageVersionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var planModel CheckPackageVersionResourceModel
+
+	// Read Terraform prior state data into the planModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &planModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteCheck(asID(planModel.Id))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check package_version, got error: %s", err))
+		return
+	}
+	tflog.Trace(ctx, "deleted a check package_version resource")
+}
+
+func (r *CheckPackageVersionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -85,7 +85,7 @@ func NewCheckPackageVersionResourceModel(ctx context.Context, check opslevel.Che
 	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
 
 	if check.MissingPackageResult != nil {
-		stateModel.MissingPackageResult = RequiredStringValue(string(*check.MissingPackageResult))
+		stateModel.MissingPackageResult = OptionalStringValue(string(*check.MissingPackageResult))
 	}
 	stateModel.PackageConstraint = RequiredStringValue(string(check.PackageConstraint))
 	stateModel.PackageManager = RequiredStringValue(string(check.PackageManager))

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -89,7 +89,9 @@ func NewCheckPackageVersionResourceModel(ctx context.Context, check opslevel.Che
 	stateModel.PackageConstraint = RequiredStringValue(string(check.PackageConstraint))
 	stateModel.PackageManager = RequiredStringValue(string(check.PackageManager))
 	stateModel.PackageName = RequiredStringValue(check.PackageName)
-	stateModel.PackageNameIsRegex = OptionalBoolValue(&check.PackageNameIsRegex)
+	if !planModel.PackageNameIsRegex.IsNull() {
+		stateModel.PackageNameIsRegex = OptionalBoolValue(&check.PackageNameIsRegex)
+	}
 	stateModel.VersionConstraintPredicate = ParsePredicate(check.VersionConstraintPredicate)
 
 	return stateModel
@@ -298,8 +300,7 @@ func (r *CheckPackageVersionResource) Update(ctx context.Context, req resource.U
 	if !planModel.PackageNameIsRegex.IsNull() {
 		input.PackageNameIsRegex = planModel.PackageNameIsRegex.ValueBoolPointer()
 	} else if !stateModel.PackageNameIsRegex.IsNull() { // Then Unset
-		var v *bool
-		input.PackageNameIsRegex = v
+		input.PackageNameIsRegex = opslevel.RefOf(false)
 	}
 
 	predicateModel, diags := PredicateObjectToModel(ctx, planModel.VersionConstraintPredicate)

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -3,6 +3,8 @@ package opslevel
 import (
 	"context"
 	"fmt"
+	"slices"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -13,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/opslevel/opslevel-go/v2024"
 	"github.com/relvacode/iso8601"
-	"slices"
 )
 
 var (
@@ -143,7 +144,7 @@ func (r *CheckPackageVersionResource) Schema(ctx context.Context, req resource.S
 
 func (r *CheckPackageVersionResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckPackageVersionResourceModel
-	var packageVersionPossiblePredicateTypes = []opslevel.PredicateTypeEnum{opslevel.PredicateTypeEnumSatisfiesVersionConstraint, opslevel.PredicateTypeEnumMatchesRegex, opslevel.PredicateTypeEnumDoesNotMatchRegex}
+	packageVersionPossiblePredicateTypes := []opslevel.PredicateTypeEnum{opslevel.PredicateTypeEnumSatisfiesVersionConstraint, opslevel.PredicateTypeEnumMatchesRegex, opslevel.PredicateTypeEnumDoesNotMatchRegex}
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
 	if resp.Diagnostics.HasError() {

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -41,7 +41,6 @@ type CheckPackageVersionResourceModel struct {
 	Notes       types.String `tfsdk:"notes"`
 	Owner       types.String `tfsdk:"owner"`
 
-	// TODO: Unique Fields Here
 	MissingPackageResult       types.String `tfsdk:"missing_package_result"`
 	PackageConstraint          types.String `tfsdk:"package_constraint"`
 	PackageManager             types.String `tfsdk:"package_manager"`

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -101,7 +101,6 @@ func (r *CheckPackageVersionResource) Metadata(ctx context.Context, req resource
 
 func (r *CheckPackageVersionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check PackageVersion Resource",
 


### PR DESCRIPTION
## Issues

Blockout package version check.

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

### Given this Terraform config file
```tf
data "opslevel_rubric_category" "performance" {
  filter {
    field = "name"
    value = "Performance"
  }
}

data "opslevel_rubric_level" "bronze" {
  filter {
    field = "name"
    value = "Bronze"
  }
}

resource "opslevel_check_package_version" "example" {
  name    = "foo"
  enabled = true
  category = data.opslevel_rubric_category.performance.id
  level    = data.opslevel_rubric_level.bronze.id

  package_constraint = "exists"
  package_manager = "npm"
  package_name = "leftpad"
}
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```bash
Terraform will perform the following actions:

  # opslevel_check_package_version.example will be created
  + resource "opslevel_check_package_version" "example" {
      + category           = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTYw"
      + description        = (known after apply)
      + enabled            = true
      + id                 = (known after apply)
      + level              = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name               = "foo"
      + package_constraint = "exists"
      + package_manager    = "npm"
      + package_name       = "leftpad"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_check_package_version.example: Creating...
opslevel_check_package_version.example: Creation complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpQYWNrYWdlVmVyc2lvbi8yNzQ0Nw]
```

### Update the Terraform config file
```tf
resource "opslevel_check_package_version" "example" {
  name    = "foo"
  enabled = true
  category = data.opslevel_rubric_category.performance.id
  level    = data.opslevel_rubric_level.bronze.id

  package_constraint = "matches_version"
  package_manager = "npm"
  package_name = "leftpad"
  missing_package_result = "passed"
  version_constraint_predicate = {
    type  = "satisfies_version_constraint"
    value = "3.5.2"
  }
}
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```bash
Terraform will perform the following actions:

  # opslevel_check_package_version.example will be updated in-place
  ~ resource "opslevel_check_package_version" "example" {
      + description                  = (known after apply)
        id                           = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpQYWNrYWdlVmVyc2lvbi8yNzQ0Nw"
      + missing_package_result       = "passed"
        name                         = "foo"
      ~ package_constraint           = "exists" -> "matches_version"
      + version_constraint_predicate = {
          + type  = "satisfies_version_constraint"
          + value = "3.5.2"
        }
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_check_package_version.example: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpQYWNrYWdlVmVyc2lvbi8yNzQ0Nw]
opslevel_check_package_version.example: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpQYWNrYWdlVmVyc2lvbi8yNzQ0Nw]
```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```bash
Terraform will perform the following actions:

  # opslevel_check_package_version.example will be destroyed
  # (because opslevel_check_package_version.example is not in configuration)
  - resource "opslevel_check_package_version" "example" {
      - category                     = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTYw" -> null
      - enabled                      = true -> null
      - id                           = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpQYWNrYWdlVmVyc2lvbi8yNzQ0Nw" -> null
      - level                        = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - missing_package_result       = "passed" -> null
      - name                         = "foo" -> null
      - package_constraint           = "matches_version" -> null
      - package_manager              = "npm" -> null
      - package_name                 = "leftpad" -> null
      - version_constraint_predicate = {
          - type  = "satisfies_version_constraint" -> null
          - value = "3.5.2" -> null
        } -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_check_package_version.example: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpQYWNrYWdlVmVyc2lvbi8yNzQ0Nw]
opslevel_check_package_version.example: Destruction complete after 0s
```


I did a bunch more manual testing where i remove, unset and invert individual fields to find bugs and made some changes to make them work.  This also sus'd out an API bug that is now fixed.

