### PR TITLE
tags validation no longer fails when given input variables

### DIFF
--- a/.changes/unreleased/Bugfix-20240731-084025.yaml
+++ b/.changes/unreleased/Bugfix-20240731-084025.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: tags validation no longer fails when given input variables
+time: 2024-07-31T08:40:25.885967-05:00

--- a/opslevel/validators.go
+++ b/opslevel/validators.go
@@ -151,7 +151,7 @@ func (v tagFormatValidator) ValidateSet(ctx context.Context, req validator.SetRe
 
 	elems := req.ConfigValue.Elements()
 	for _, elem := range elems {
-		if hasTagFormat(unquote(elem.String())) {
+		if elem.IsNull() || elem.IsUnknown() || hasTagFormat(unquote(elem.String())) {
 			continue
 		}
 


### PR DESCRIPTION
## Issues

[opslevel_service: tag validation fails with datasource or variable](https://github.com/OpsLevel/terraform-provider-opslevel/issues/415)

## Changelog

Update `TagFormatValidator` so elements in set of `tags` do not fail when given input variables.

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Given this Terraform config file
```tf
variable "test" {
  type    = string
  default = "bar"
}

resource "opslevel_service" "db" {
  name = "Small Service"
  tags = ["foo:${var.test}"]
}
```

Run `terraform validate` on this config file
```bash
> terraform validate
Success! The configuration is valid.
```
