### PR TITLE
set OwnershipTagKeys field explicit path after upstream update

### DIFF
--- a/opslevel/resource_opslevel_integration_aws.go
+++ b/opslevel/resource_opslevel_integration_aws.go
@@ -47,7 +47,7 @@ func NewIntegrationAwsResourceModel(awsIntegration opslevel.Integration) Integra
 		Name:                  OptionalStringValue(awsIntegration.Name),
 		OwnershipTagOverrides: types.BoolValue(awsIntegration.OwnershipTagOverride),
 	}
-	ownershipTagKeys := OptionalStringListValue(awsIntegration.OwnershipTagKeys)
+	ownershipTagKeys := OptionalStringListValue(awsIntegration.AWSIntegrationFragment.OwnershipTagKeys)
 	integrationAwsResourceModel.OwnershipTagKeys = ownershipTagKeys
 
 	return integrationAwsResourceModel


### PR DESCRIPTION
## Issues

<!-- paste an issue link here from github/gitlab -->

## Changelog

Updated need after `opslevel-go` update

- [ ] List your changes here
- [ ] Make a `changie` entry, N/A internal

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->

<!-- Typical Terraform CRUD workflow

### Given this Terraform config file
```tf
# main.tf
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Update the Terraform config file
```tf
# main.tf - with changes
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```tf
# copy paste CLI outputs here
```

-->
