### PR TITLE
Add custom property check

### DIFF
--- a/.changes/unreleased/Feature-20240801-124310.yaml
+++ b/.changes/unreleased/Feature-20240801-124310.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: Add ability for 'opslevel_check_service_property' to target custom properties
+  of a service
+time: 2024-08-01T12:43:10.20199-05:00

--- a/examples/resources/opslevel_check_service_property/resource.tf
+++ b/examples/resources/opslevel_check_service_property/resource.tf
@@ -50,8 +50,7 @@ resource "opslevel_check_service_property" "example2" {
   property            = "custom_property"
   property_definition = "my_custom_property"
   predicate = {
-    type  = "equals"
-    value = "foo"
+    type  = "exists"
   }
   notes = "Optional additional info on why this check is run or how to fix it"
 }

--- a/examples/resources/opslevel_check_service_property/resource.tf
+++ b/examples/resources/opslevel_check_service_property/resource.tf
@@ -39,3 +39,19 @@ resource "opslevel_check_service_property" "example" {
   }
   notes = "Optional additional info on why this check is run or how to fix it"
 }
+
+resource "opslevel_check_service_property" "example2" {
+  name    = "foo2"
+  enabled = true
+  # To set a future enable date remove field 'enabled' and use 'enable_on'
+  # enable_on = "2022-05-23T14:14:18.782000Z"
+  category            = data.opslevel_rubric_category.security.id
+  level               = data.opslevel_rubric_level.bronze.id
+  property            = "custom_property"
+  property_definition = "my_custom_property"
+  predicate = {
+    type  = "equals"
+    value = "foo"
+  }
+  notes = "Optional additional info on why this check is run or how to fix it"
+}

--- a/examples/resources/opslevel_check_service_property/resource.tf
+++ b/examples/resources/opslevel_check_service_property/resource.tf
@@ -50,7 +50,7 @@ resource "opslevel_check_service_property" "example2" {
   property            = "custom_property"
   property_definition = "my_custom_property"
   predicate = {
-    type  = "exists"
+    type = "exists"
   }
   notes = "Optional additional info on why this check is run or how to fix it"
 }

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -304,7 +304,7 @@ func (r *CheckServicePropertyResource) Update(ctx context.Context, req resource.
 	if !planModel.PropertyDefinition.IsNull() {
 		input.PropertyDefinition = opslevel.NewIdentifier(planModel.PropertyDefinition.ValueString())
 	} else if !stateModel.PropertyDefinition.IsNull() {
-		input.PropertyDefinition = opslevel.NewIdentifier("")
+		input.PropertyDefinition = &opslevel.IdentifierInput{}
 	}
 
 	// convert environment_predicate object to model from plan

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -45,8 +45,9 @@ type CheckServicePropertyResourceModel struct {
 	Notes       types.String `tfsdk:"notes"`
 	Owner       types.String `tfsdk:"owner"`
 
-	Property  types.String `tfsdk:"property"`
-	Predicate types.Object `tfsdk:"predicate"`
+	Property           types.String `tfsdk:"property"`
+	PropertyDefinition types.String `tfsdk:"property_definition"`
+	Predicate          types.Object `tfsdk:"predicate"`
 }
 
 func NewCheckServicePropertyResourceModel(ctx context.Context, check opslevel.Check, planModel CheckServicePropertyResourceModel) CheckServicePropertyResourceModel {
@@ -73,6 +74,10 @@ func NewCheckServicePropertyResourceModel(ctx context.Context, check opslevel.Ch
 	stateModel.Owner = OptionalStringValue(string(check.Owner.Team.Id))
 
 	stateModel.Property = RequiredStringValue(string(check.ServicePropertyCheckFragment.Property))
+
+	if check.ServicePropertyCheckFragment.PropertyDefinition != nil {
+		stateModel.PropertyDefinition = planModel.PropertyDefinition
+	}
 
 	if check.ServicePropertyCheckFragment.Predicate == nil {
 		stateModel.Predicate = types.ObjectNull(predicateType)
@@ -108,6 +113,10 @@ func (r *CheckServicePropertyResource) Schema(ctx context.Context, req resource.
 				Validators: []validator.String{
 					stringvalidator.OneOf(opslevel.AllServicePropertyTypeEnum...),
 				},
+			},
+			"property_definition": schema.StringAttribute{
+				Description: "The alias of the property that the check will verify (e.g. the specific custom property).",
+				Optional:    true,
 			},
 			"predicate": PredicateSchema(),
 		}),
@@ -210,6 +219,9 @@ func (r *CheckServicePropertyResource) Create(ctx context.Context, req resource.
 	}
 
 	input.ServiceProperty = opslevel.ServicePropertyTypeEnum(planModel.Property.ValueString())
+	if !planModel.PropertyDefinition.IsNull() {
+		input.PropertyDefinition = opslevel.NewIdentifier(planModel.PropertyDefinition.ValueString())
+	}
 
 	// convert environment_predicate object to model from plan
 	predicateModel, diags := PredicateObjectToModel(ctx, planModel.Predicate)
@@ -260,9 +272,11 @@ func (r *CheckServicePropertyResource) Read(ctx context.Context, req resource.Re
 
 func (r *CheckServicePropertyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var planModel CheckServicePropertyResourceModel
+	var stateModel CheckServicePropertyResourceModel
 
 	// Read Terraform plan data into the planModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateModel)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -287,6 +301,11 @@ func (r *CheckServicePropertyResource) Update(ctx context.Context, req resource.
 	}
 
 	input.ServiceProperty = opslevel.RefOf(opslevel.ServicePropertyTypeEnum(planModel.Property.ValueString()))
+	if !planModel.PropertyDefinition.IsNull() {
+		input.PropertyDefinition = opslevel.NewIdentifier(planModel.PropertyDefinition.ValueString())
+	} else if !stateModel.PropertyDefinition.IsNull() {
+		input.PropertyDefinition = opslevel.NewIdentifier("")
+	}
 
 	// convert environment_predicate object to model from plan
 	predicateModel, diags := PredicateObjectToModel(ctx, planModel.Predicate)
@@ -308,10 +327,10 @@ func (r *CheckServicePropertyResource) Update(ctx context.Context, req resource.
 		return
 	}
 
-	stateModel := NewCheckServicePropertyResourceModel(ctx, *data, planModel)
+	verifiedStateModel := NewCheckServicePropertyResourceModel(ctx, *data, planModel)
 
 	tflog.Trace(ctx, "updated a check service property resource")
-	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &verifiedStateModel)...)
 }
 
 func (r *CheckServicePropertyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
## Issues

Fixes issue where the service property check couldn't target a custom property

## Changelog

- [x] List your changes here
- [x] Make a `changie` entry

## Tophatting

### Given this Terraform config file
```tf
data "opslevel_rubric_category" "performance" {
  filter {
    field = "name"
    value = "Performance"
  }
}

data "opslevel_rubric_level" "bronze" {
  filter {
    field = "name"
    value = "Bronze"
  }
}

resource "opslevel_check_service_property" "example2" {
  name    = "foo2"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category            = data.opslevel_rubric_category.performance.id
  level               = data.opslevel_rubric_level.bronze.id
  property            = "custom_property"
  property_definition = "my_custom_property"
  predicate = {
    type  = "exists"
  }
  notes = "Optional additional info on why this check is run or how to fix it"
}
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```bash

Terraform will perform the following actions:

  # opslevel_check_service_property.example2 will be created
  + resource "opslevel_check_service_property" "example2" {
      + category            = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTYw"
      + description         = (known after apply)
      + enabled             = true
      + id                  = (known after apply)
      + level               = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw"
      + name                = "foo2"
      + notes               = "Optional additional info on why this check is run or how to fix it"
      + predicate           = {
          + type = "exists"
        }
      + property            = "custom_property"
      + property_definition = "my_custom_property"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_check_service_property.example2: Creating...
opslevel_check_service_property.example2: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU]


```

### Update the Terraform config file
```tf
resource "opslevel_check_service_property" "example2" {
  name    = "foo2"
  enabled = true
  # To set a future enable date remove field 'enabled' and use 'enable_on'
  # enable_on = "2022-05-23T14:14:18.782000Z"
  category            = data.opslevel_rubric_category.performance.id
  level               = data.opslevel_rubric_level.bronze.id
  property            = "custom_property"
  property_definition = "prop2"
  predicate = {
    type  = "exists"
  }
  notes = "Optional additional info on why this check is run or how to fix it"
}
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```bash
Terraform will perform the following actions:

  # opslevel_check_service_property.example2 will be updated in-place
  ~ resource "opslevel_check_service_property" "example2" {
      ~ description         = "The service does not have a 'my custom property' property." -> (known after apply)
        id                  = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU"
        name                = "foo2"
      ~ property_definition = "my_custom_property" -> "prop2"
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_check_service_property.example2: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU]
opslevel_check_service_property.example2: Modifications complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU]

```

### Update to a different property type
```bash

Terraform will perform the following actions:

  # opslevel_check_service_property.example2 will be updated in-place
  ~ resource "opslevel_check_service_property" "example2" {
      ~ description         = "The service does not have a 'prop2' property." -> (known after apply)
        id                  = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU"
        name                = "foo2"
      ~ predicate           = {
          ~ type  = "does_not_exist" -> "equals"
          + value = "python"
        }
      ~ property            = "custom_property" -> "language"
      - property_definition = "prop2" -> null
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_check_service_property.example2: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU]
opslevel_check_service_property.example2: Modifications complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU]
```

### Update back to a custom property type

```bash
Terraform will perform the following actions:

  # opslevel_check_service_property.example2 will be updated in-place
  ~ resource "opslevel_check_service_property" "example2" {
      ~ description         = "The service has a language that equals <code>python</code>" -> (known after apply)
        id                  = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU"
        name                = "foo2"
      ~ property            = "language" -> "custom_property"
      + property_definition = "my_custom_property"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
opslevel_check_service_property.example2: Modifying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU]

```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```bash
Terraform will perform the following actions:

  # opslevel_check_service_property.example2 will be destroyed
  # (because opslevel_check_service_property.example2 is not in configuration)
  - resource "opslevel_check_service_property" "example2" {
      - category            = "Z2lkOi8vb3BzbGV2ZWwvQ2F0ZWdvcnkvOTYw" -> null
      - description         = "The service has a 'my custom property' property." -> null
      - enabled             = true -> null
      - id                  = "Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU" -> null
      - level               = "Z2lkOi8vb3BzbGV2ZWwvTGV2ZWwvNTIw" -> null
      - name                = "foo2" -> null
      - notes               = "Optional additional info on why this check is run or how to fix it" -> null
      - predicate           = {
          - type = "exists" -> null
        } -> null
      - property            = "custom_property" -> null
      - property_definition = "my_custom_property" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
opslevel_check_service_property.example2: Destroying... [id=Z2lkOi8vb3BzbGV2ZWwvQ2hlY2tzOjpTZXJ2aWNlUHJvcGVydHkvMjc0ODU]
opslevel_check_service_property.example2: Destruction complete after 1s

```

-->
