### PR TITLE
add rest of filter predicate tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -197,7 +197,7 @@ tasks:
       - task: setup-terraform-from
         vars: { SETUP_DIR: "{{.TEST_DIR}}/remote" }
       - task: terraform-command
-        vars: { TF_COMMAND: 'test -var-file=test.tfvars -var="api_token=$OPSLEVEL_API_TOKEN"', TF_CMD_DIR: "{{.TEST_DIR}}/remote" }
+        vars: { TF_COMMAND: 'test -var-file=test.tfvars -var="api_token=$OPSLEVEL_API_TOKEN" {{.CLI_ARGS}}', TF_CMD_DIR: "{{.TEST_DIR}}/remote" }
 
   run-unit-tests:
     internal: true
@@ -316,7 +316,7 @@ tasks:
 
   terraform-command:
     internal: true
-    cmds: ["terraform -chdir={{.TF_CMD_DIR}} {{.TF_COMMAND}} {{.CLI_ARGS}}"]
+    cmds: ["terraform -chdir={{.TF_CMD_DIR}} {{.TF_COMMAND}}"]
     requires:
       vars: [TF_COMMAND, TF_CMD_DIR]
     preconditions:

--- a/tests/local/mock_resource/filter.tfmock.hcl
+++ b/tests/local/mock_resource/filter.tfmock.hcl
@@ -2,8 +2,7 @@ mock_resource "opslevel_filter" {
   # placeholder - only computed fields here are "id"
   defaults = {
     predicate = {
-      case_insensitive = null
-      case_sensitive   = null
+      case_sensitive = null
     }
   }
 }

--- a/tests/remote/check_alert_source_usage.tftest.hcl
+++ b/tests/remote/check_alert_source_usage.tftest.hcl
@@ -29,8 +29,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_git_branch_protection.tftest.hcl
+++ b/tests/remote/check_git_branch_protection.tftest.hcl
@@ -22,8 +22,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_has_documentation.tftest.hcl
+++ b/tests/remote/check_has_documentation.tftest.hcl
@@ -24,8 +24,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_has_recent_deploy.tftest.hcl
+++ b/tests/remote/check_has_recent_deploy.tftest.hcl
@@ -23,8 +23,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_manual.tftest.hcl
+++ b/tests/remote/check_manual.tftest.hcl
@@ -30,8 +30,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_repository_file.tftest.hcl
+++ b/tests/remote/check_repository_file.tftest.hcl
@@ -31,8 +31,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_repository_grep.tftest.hcl
+++ b/tests/remote/check_repository_grep.tftest.hcl
@@ -29,8 +29,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_repository_integrated.tftest.hcl
+++ b/tests/remote/check_repository_integrated.tftest.hcl
@@ -22,8 +22,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_repository_search.tftest.hcl
+++ b/tests/remote/check_repository_search.tftest.hcl
@@ -29,8 +29,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_service_configuration.tftest.hcl
+++ b/tests/remote/check_service_configuration.tftest.hcl
@@ -22,8 +22,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_service_dependency.tftest.hcl
+++ b/tests/remote/check_service_dependency.tftest.hcl
@@ -22,8 +22,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_service_ownership.tftest.hcl
+++ b/tests/remote/check_service_ownership.tftest.hcl
@@ -29,8 +29,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_service_property.tftest.hcl
+++ b/tests/remote/check_service_property.tftest.hcl
@@ -29,8 +29,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_tag_defined.tftest.hcl
+++ b/tests/remote/check_tag_defined.tftest.hcl
@@ -29,8 +29,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/check_tool_usage.tftest.hcl
+++ b/tests/remote/check_tool_usage.tftest.hcl
@@ -37,8 +37,7 @@ run "from_filter_get_filter_id" {
   command = plan
 
   variables {
-    connective     = null
-    predicate_list = null
+    connective = null
   }
 
   module {

--- a/tests/remote/domain/variables.tf
+++ b/tests/remote/domain/variables.tf
@@ -1,6 +1,7 @@
 variable "description" {
   type        = string
   description = "The description of the domain."
+  default     = null
 }
 
 variable "name" {
@@ -11,11 +12,13 @@ variable "name" {
 variable "note" {
   type        = string
   description = "Additional information about the domain."
+  default     = null
 }
 
 variable "owner_id" {
   type        = string
   description = "The id of the team that owns the domain."
+  default     = null
 
   validation {
     condition     = var.owner_id == null ? true : startswith(var.owner_id, "Z2lkOi8v")

--- a/tests/remote/filter.tftest.hcl
+++ b/tests/remote/filter.tftest.hcl
@@ -1,4 +1,3 @@
-# TODO: test predicate_list
 variables {
   filter_one  = "opslevel_filter"
   filters_all = "opslevel_filters"
@@ -7,8 +6,7 @@ variables {
   name = "TF Test Filter"
 
   # optional fields
-  connective     = "and"
-  predicate_list = []
+  connective = "and"
 }
 
 run "resource_filter_create_with_all_fields" {
@@ -16,7 +14,6 @@ run "resource_filter_create_with_all_fields" {
   variables {
     connective = var.connective
     name       = var.name
-    # predicate_list = var.predicate_list
   }
 
   module {

--- a/tests/remote/filter/main.tf
+++ b/tests/remote/filter/main.tf
@@ -17,12 +17,15 @@ data "opslevel_filter" "first_filter_by_id" {
 resource "opslevel_filter" "test" {
   name       = var.name
   connective = var.connective
-  #predicate {
-  #  case_insensitive = var.predicate.case_insensitive
-  #  case_sensitive   = var.predicate.case_sensitive
-  #  key              = var.predicate.key
-  #  key_data         = var.predicate.key_data
-  #  type             = var.predicate.type
-  #  value            = var.predicate.value
-  #}
+}
+
+resource "opslevel_filter" "all_predicates" {
+  for_each = var.predicates
+  name     = each.key
+  predicate {
+    key      = each.value.key
+    key_data = each.value.key_data
+    type     = each.value.type
+    value    = each.value.value
+  }
 }

--- a/tests/remote/filter/variables.tf
+++ b/tests/remote/filter/variables.tf
@@ -9,17 +9,18 @@ variable "connective" {
     ], var.connective)
     error_message = "expected connective_enum to be 'and' or 'or'"
   }
+  default = null
 }
 
-variable "predicate_list" {
-  type = list(object({
-    case_insensitive = optional(bool)
-    case_sensitive   = optional(bool)
-    key              = string
-    key_data         = optional(string)
-    type             = string
-    value            = optional(string)
+variable "predicates" {
+  type = map(object({
+    case_sensitive = optional(bool)
+    key            = string
+    key_data       = optional(string)
+    type           = string
+    value          = optional(string)
   }))
+  default = {}
 }
 
 variable "name" {

--- a/tests/remote/filter_predicate_aliases.tftest.hcl
+++ b/tests/remote/filter_predicate_aliases.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with aliases predicate"
+  predicate_value = "fancy"
+  aliases_predicates = setproduct(
+    ["aliases"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_aliases_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_contains"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["aliases_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_equals"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["aliases_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_exists"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["aliases_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_domain_id.tftest.hcl
+++ b/tests/remote/filter_predicate_domain_id.tftest.hcl
@@ -1,0 +1,171 @@
+variables {
+  name = "TF Test Filter with domain_id predicate"
+  domain_id_predicates = setproduct(
+    ["domain_id"],
+    concat(var.predicate_types_equals, var.predicate_types_exists)
+  )
+}
+
+run "get_domain" {
+  command = plan
+
+  variables {
+    name = "placeholder"
+  }
+
+  module {
+    source = "./domain"
+  }
+}
+
+run "resource_filter_with_domain_id_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.domain_id_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = run.get_domain.first_domain.id
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_does_not_equal"].predicate[0].key == "domain_id"
+    error_message = format(
+      "expected predicate key 'domain_id' got '%s'",
+      opslevel_filter.all_predicates["domain_id_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["domain_id_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["domain_id_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_does_not_equal"].predicate[0].value == run.get_domain.first_domain.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_domain.first_domain.id,
+      opslevel_filter.all_predicates["domain_id_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_equals"].predicate[0].key == "domain_id"
+    error_message = format(
+      "expected predicate key 'domain_id' got '%s'",
+      opslevel_filter.all_predicates["domain_id_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'equals' got '%s'",
+      opslevel_filter.all_predicates["domain_id_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["domain_id_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_equals"].predicate[0].value == run.get_domain.first_domain.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_domain.first_domain.id,
+      opslevel_filter.all_predicates["domain_id_equals"].predicate[0].type
+    )
+  }
+
+}
+
+run "resource_filter_with_domain_id_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.domain_id_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_does_not_exist"].predicate[0].key == "domain_id"
+    error_message = format(
+      "expected predicate key 'domain_id' got '%s'",
+      opslevel_filter.all_predicates["domain_id_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["domain_id_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["domain_id_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["domain_id_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_exists"].predicate[0].key == "domain_id"
+    error_message = format(
+      "expected predicate key 'domain_id' got '%s'",
+      opslevel_filter.all_predicates["domain_id_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["domain_id_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'exists' got '%s'",
+      opslevel_filter.all_predicates["domain_id_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["domain_id_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["domain_id_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}

--- a/tests/remote/filter_predicate_filter_id.tftest.hcl
+++ b/tests/remote/filter_predicate_filter_id.tftest.hcl
@@ -1,0 +1,95 @@
+variables {
+  name                 = "TF Test Filter with filter_id predicate"
+  filter_id_predicates = setproduct(["filter_id"], ["does_not_match", "matches"])
+}
+
+run "get_filter" {
+  command = plan
+
+  variables {
+    name = "placeholder"
+  }
+
+  module {
+    source = "./filter"
+  }
+}
+
+run "resource_filter_with_filter_id_predicate_matches" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.filter_id_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = run.get_filter.first_filter.id
+      }
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["filter_id_does_not_match"].predicate[0].key == "filter_id"
+    error_message = format(
+      "expected predicate key 'filter_id' got '%s'",
+      opslevel_filter.all_predicates["filter_id_does_not_match"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["filter_id_does_not_match"].predicate[0].type == "does_not_match"
+    error_message = format(
+      "expected predicate type 'does_not_match' got '%s'",
+      opslevel_filter.all_predicates["filter_id_does_not_match"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["filter_id_does_not_match"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["filter_id_does_not_match"].predicate[0].value == run.get_filter.first_filter.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_filter.first_filter.id,
+      opslevel_filter.all_predicates["filter_id_does_not_match"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["filter_id_matches"].predicate[0].key == "filter_id"
+    error_message = format(
+      "expected predicate key 'filter_id' got '%s'",
+      opslevel_filter.all_predicates["filter_id_matches"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["filter_id_matches"].predicate[0].type == "matches"
+    error_message = format(
+      "expected predicate type 'matches' got '%s'",
+      opslevel_filter.all_predicates["filter_id_matches"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["filter_id_matches"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["filter_id_matches"].predicate[0].value == run.get_filter.first_filter.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_filter.first_filter.id,
+      opslevel_filter.all_predicates["filter_id_matches"].predicate[0].type
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_framework.tftest.hcl
+++ b/tests/remote/filter_predicate_framework.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with framework predicate"
+  predicate_value = "fancy"
+  framework_predicates = setproduct(
+    ["framework"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_framework_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_contains"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["framework_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_equals"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["framework_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_exists"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["framework_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["framework_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["framework_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_language.tftest.hcl
+++ b/tests/remote/filter_predicate_language.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with language predicate"
+  predicate_value = "fancy"
+  language_predicates = setproduct(
+    ["language"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_language_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_contains"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["language_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_language_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_equals"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["language_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_language_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_exists"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["language_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_language_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["language_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_language_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_ends_with"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["language_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_starts_with"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["language_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_lifecycle_index.tftest.hcl
+++ b/tests/remote/filter_predicate_lifecycle_index.tftest.hcl
@@ -1,0 +1,264 @@
+variables {
+  name            = "TF Test Filter with lifecycle_index predicate"
+  predicate_value = "1"
+  lifecycle_index_predicates = setproduct(
+    ["lifecycle_index"],
+    concat(
+      ["less_than_or_equal_to", "greater_than_or_equal_to"],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_lifecycle_index_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_lifecycle_index_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_lifecycle_index_predicate_greater_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "greater_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].type == "greater_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'greater_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_lifecycle_index_predicate_less_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "less_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].type == "less_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'less_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_name.tftest.hcl
+++ b/tests/remote/filter_predicate_name.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with name predicate"
+  predicate_value = "fancy"
+  name_predicates = setproduct(
+    ["name"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_name_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_contains"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["name_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_name_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_equals"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["name_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_name_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_exists"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["name_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_name_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["name_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_name_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_ends_with"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["name_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_starts_with"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["name_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_owner_id.tftest.hcl
+++ b/tests/remote/filter_predicate_owner_id.tftest.hcl
@@ -1,0 +1,171 @@
+variables {
+  name = "TF Test Filter with owner_id predicate"
+  owner_id_predicates = setproduct(
+    ["owner_id"],
+    concat(var.predicate_types_equals, var.predicate_types_exists)
+  )
+}
+
+run "get_team" {
+  command = plan
+
+  variables {
+    name = "placeholder"
+  }
+
+  module {
+    source = "./team"
+  }
+}
+
+run "resource_filter_with_owner_id_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.owner_id_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = run.get_team.first_team.id
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_does_not_equal"].predicate[0].key == "owner_id"
+    error_message = format(
+      "expected predicate key 'owner_id' got '%s'",
+      opslevel_filter.all_predicates["owner_id_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["owner_id_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["owner_id_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_does_not_equal"].predicate[0].value == run.get_team.first_team.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_team.first_team.id,
+      opslevel_filter.all_predicates["owner_id_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_equals"].predicate[0].key == "owner_id"
+    error_message = format(
+      "expected predicate key 'owner_id' got '%s'",
+      opslevel_filter.all_predicates["owner_id_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'equals' got '%s'",
+      opslevel_filter.all_predicates["owner_id_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["owner_id_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_equals"].predicate[0].value == run.get_team.first_team.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_team.first_team.id,
+      opslevel_filter.all_predicates["owner_id_equals"].predicate[0].type
+    )
+  }
+
+}
+
+run "resource_filter_with_owner_id_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.owner_id_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_does_not_exist"].predicate[0].key == "owner_id"
+    error_message = format(
+      "expected predicate key 'owner_id' got '%s'",
+      opslevel_filter.all_predicates["owner_id_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["owner_id_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["owner_id_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["owner_id_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_exists"].predicate[0].key == "owner_id"
+    error_message = format(
+      "expected predicate key 'owner_id' got '%s'",
+      opslevel_filter.all_predicates["owner_id_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["owner_id_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'exists' got '%s'",
+      opslevel_filter.all_predicates["owner_id_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["owner_id_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["owner_id_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}

--- a/tests/remote/filter_predicate_product.tftest.hcl
+++ b/tests/remote/filter_predicate_product.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with product predicate"
+  predicate_value = "fancy"
+  product_predicates = setproduct(
+    ["product"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_product_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_contains"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["product_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_product_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_equals"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["product_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_product_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_exists"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["product_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_product_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["product_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_product_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_ends_with"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["product_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_starts_with"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["product_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_properties.tftest.hcl
+++ b/tests/remote/filter_predicate_properties.tftest.hcl
@@ -1,0 +1,135 @@
+variables {
+  name                  = "TF Test Filter with properties predicate"
+  jq_expression         = ".[] | select(.name == fancy)"
+  predicate_key_data    = "property_definition_id"
+  properties_predicates = setproduct(["properties"], concat(var.predicate_types_exists, ["satisfies_jq_expression"]))
+}
+
+run "resource_filter_with_properties_predicate_exists" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
+        key = pair[0], type = pair[1], key_data = var.predicate_key_data, value = contains(var.predicate_types_exists, pair[1]) ? null : var.jq_expression
+      }
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key == "properties"
+    error_message = format(
+      "expected predicate key 'properties' got '%s'",
+      opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_exists"].predicate[0].key == "properties"
+    error_message = format(
+      "expected predicate key 'properties' got '%s'",
+      opslevel_filter.all_predicates["properties_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'exists' got '%s'",
+      opslevel_filter.all_predicates["properties_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_exists"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["properties_exists"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["properties_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_properties_predicate_satisfies_jq_expression" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
+        key = pair[0], type = pair[1], key_data = var.predicate_key_data, value = var.jq_expression
+      }
+      if "satisfies_jq_expression" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key == "properties"
+    error_message = format(
+      "expected predicate key 'properties' got '%s'",
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].type == "satisfies_jq_expression"
+    error_message = format(
+      "expected predicate type 'satisfies_jq_expression' got '%s'",
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].value == var.jq_expression
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.jq_expression,
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].type
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_repository_ids.tftest.hcl
+++ b/tests/remote/filter_predicate_repository_ids.tftest.hcl
@@ -1,0 +1,75 @@
+variables {
+  name                      = "TF Test Filter with repository_ids predicate"
+  repository_ids_predicates = setproduct(["repository_ids"], var.predicate_types_exists)
+}
+
+run "resource_filter_with_repository_ids_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.repository_ids_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["repository_ids_does_not_exist"].predicate[0].key == "repository_ids"
+    error_message = format(
+      "expected predicate key 'repository_ids' got '%s'",
+      opslevel_filter.all_predicates["repository_ids_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["repository_ids_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["repository_ids_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["repository_ids_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["repository_ids_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["repository_ids_exists"].predicate[0].key == "repository_ids"
+    error_message = format(
+      "expected predicate key 'repository_ids' got '%s'",
+      opslevel_filter.all_predicates["repository_ids_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["repository_ids_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'exists' got '%s'",
+      opslevel_filter.all_predicates["repository_ids_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["repository_ids_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["repository_ids_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}

--- a/tests/remote/filter_predicate_system_id.tftest.hcl
+++ b/tests/remote/filter_predicate_system_id.tftest.hcl
@@ -1,0 +1,171 @@
+variables {
+  name = "TF Test Filter with system_id predicate"
+  system_id_predicates = setproduct(
+    ["system_id"],
+    concat(var.predicate_types_equals, var.predicate_types_exists)
+  )
+}
+
+run "get_system" {
+  command = plan
+
+  variables {
+    name = "placeholder"
+  }
+
+  module {
+    source = "./system"
+  }
+}
+
+run "resource_filter_with_system_id_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.system_id_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = run.get_system.first_system.id
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_does_not_equal"].predicate[0].key == "system_id"
+    error_message = format(
+      "expected predicate key 'system_id' got '%s'",
+      opslevel_filter.all_predicates["system_id_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["system_id_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["system_id_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_does_not_equal"].predicate[0].value == run.get_system.first_system.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_system.first_system.id,
+      opslevel_filter.all_predicates["system_id_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_equals"].predicate[0].key == "system_id"
+    error_message = format(
+      "expected predicate key 'system_id' got '%s'",
+      opslevel_filter.all_predicates["system_id_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'equals' got '%s'",
+      opslevel_filter.all_predicates["system_id_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["system_id_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_equals"].predicate[0].value == run.get_system.first_system.id
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      run.get_system.first_system.id,
+      opslevel_filter.all_predicates["system_id_equals"].predicate[0].type
+    )
+  }
+
+}
+
+run "resource_filter_with_system_id_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.system_id_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_does_not_exist"].predicate[0].key == "system_id"
+    error_message = format(
+      "expected predicate key 'system_id' got '%s'",
+      opslevel_filter.all_predicates["system_id_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["system_id_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["system_id_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["system_id_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_exists"].predicate[0].key == "system_id"
+    error_message = format(
+      "expected predicate key 'system_id' got '%s'",
+      opslevel_filter.all_predicates["system_id_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["system_id_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'exists' got '%s'",
+      opslevel_filter.all_predicates["system_id_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["system_id_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["system_id_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}

--- a/tests/remote/filter_predicate_tags.tftest.hcl
+++ b/tests/remote/filter_predicate_tags.tftest.hcl
@@ -1,0 +1,512 @@
+variables {
+  name               = "TF Test Filter with tags predicate"
+  predicate_key_data = "test_tag"
+  predicate_value    = "fancy"
+  tags_predicates = setproduct(
+    ["tags"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "satisfies_version_constraint",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_tags_predicate_contains" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_equals" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_equal", "equals"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_exists" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = null
+      }
+      if contains(["does_not_exist", "exists"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_exists"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tags_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_exists"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_exists"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tags_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_matches_regex" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_starts_or_ends_with" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_satisfies_version_constraint" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if "satisfies_version_constraint" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].type == "satisfies_version_constraint"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_tier_index.tftest.hcl
+++ b/tests/remote/filter_predicate_tier_index.tftest.hcl
@@ -1,0 +1,264 @@
+variables {
+  name            = "TF Test Filter with tier_index predicate"
+  predicate_value = "1"
+  tier_index_predicates = setproduct(
+    ["tier_index"],
+    concat(
+      ["less_than_or_equal_to", "greater_than_or_equal_to"],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_tier_index_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tier_index_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tier_index_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tier_index_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_tier_index_predicate_greater_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "greater_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].type == "greater_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'greater_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tier_index_predicate_less_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "less_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].type == "less_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'less_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/scorecard.tftest.hcl
+++ b/tests/remote/scorecard.tftest.hcl
@@ -15,11 +15,6 @@ variables {
 run "from_filter_get_filter_id" {
   command = plan
 
-  variables {
-    connective     = null
-    predicate_list = null
-  }
-
   module {
     source = "./filter"
   }

--- a/tests/remote/system/outputs.tf
+++ b/tests/remote/system/outputs.tf
@@ -1,0 +1,3 @@
+output "first_system" {
+  value = data.opslevel_system.first_system_by_id
+}

--- a/tests/remote/system/variables.tf
+++ b/tests/remote/system/variables.tf
@@ -1,6 +1,7 @@
 variable "description" {
   type        = string
   description = "The description for the system."
+  default     = null
 }
 
 variable "domain_id" {
@@ -11,6 +12,7 @@ variable "domain_id" {
     condition     = var.domain_id == null ? true : startswith(var.domain_id, "Z2lkOi8v")
     error_message = "expected domain_id to be a valid ID starting with 'Z2lkOi8v'"
   }
+  default = null
 }
 
 variable "name" {
@@ -21,11 +23,13 @@ variable "name" {
 variable "note" {
   type        = string
   description = "Additional information about the system."
+  default     = null
 }
 
 variable "owner_id" {
   type        = string
   description = "The id of the team that owns the system."
+  default     = null
 
   validation {
     condition     = var.owner_id == null ? true : startswith(var.owner_id, "Z2lkOi8v")

--- a/tests/remote/team/variables.tf
+++ b/tests/remote/team/variables.tf
@@ -1,6 +1,7 @@
 variable "aliases" {
   type        = list(string)
   description = "A list of human-friendly, unique identifiers for the team."
+  default     = null
 }
 
 variable "name" {
@@ -11,9 +12,11 @@ variable "name" {
 variable "parent" {
   type        = string
   description = "The id or alias of the parent team."
+  default     = null
 }
 
 variable "responsibilities" {
   type        = string
   description = "A description of what the team is responsible for."
+  default     = null
 }

--- a/tests/remote/test.tfvars
+++ b/tests/remote/test.tfvars
@@ -67,3 +67,5 @@ error_wrong_id                     = "wrong id for 'TYPE'"
 error_wrong_name                   = "wrong name for 'TYPE'"
 error_wrong_owner                  = "wrong owner for 'TYPE'"
 id_prefix                          = "Z2lkOi8v"
+predicate_types_equals             = ["does_not_equal", "equals"]
+predicate_types_exists             = ["does_not_exist", "exists"]


### PR DESCRIPTION
## Issues

[Predicates in filters can be cryptic](https://github.com/OpsLevel/team-platform/issues/433)
Second half of this [first predicate tests PR](https://github.com/OpsLevel/terraform-provider-opslevel/pull/424)

## Changelog

Add integration tests focusing on the following predicate filters:
- `aliases`
- `framework`
- `language`
- `lifecycle_index`
- `name`
- `product`
- `properties`
- `tags`
- `tier_index`

Note: `lifecycle_index` and `tier_index` are basically the same
`aliases`, `framework`, `language`, `name`, `product`, `properties` and `tags` are basically the same

- [X] List your changes here
- [ ] Make a `changie` entry, N/A testing only

## Tophatting

```bash
task test-integration -- \
 "-filter=filter_predicate_aliases.tftest.hcl" \
 "-filter=filter_predicate_framework.tftest.hcl" \
 "-filter=filter_predicate_language.tftest.hcl" \
 "-filter=filter_predicate_lifecycle_index.tftest.hcl" \
 "-filter=filter_predicate_name.tftest.hcl" \
 "-filter=filter_predicate_product.tftest.hcl" \
 "-filter=filter_predicate_properties.tftest.hcl" \
 "-filter=filter_predicate_tags.tftest.hcl" \
 "-filter=filter_predicate_tier_index.tftest.hcl"
```

```tf
task: [terraform-command] terraform -chdir=tests/remote test -var-file=test.tfvars -var="api_token=$OPSLEVEL_API_TOKEN" '-filter=filter_predicate_aliases.tftest.hcl' '-filter=filter_predicate_framework.tftest.hcl' '-filter=filter_predicate_language.tftest.hcl' '-filter=filter_p
redicate_lifecycle_index.tftest.hcl' '-filter=filter_predicate_name.tftest.hcl' '-filter=filter_predicate_product.tftest.hcl' '-filter=filter_predicate_properties.tftest.hcl' '-filter=filter_predicate_tags.tftest.hcl' '-filter=filter_predicate_tier_index.tftest.hcl'
filter_predicate_aliases.tftest.hcl... in progress
  run "resource_filter_with_aliases_predicate_contains"... pass
  run "resource_filter_with_aliases_predicate_equals"... pass
  run "resource_filter_with_aliases_predicate_exists"... pass
  run "resource_filter_with_aliases_predicate_matches_regex"... pass
  run "resource_filter_with_aliases_predicate_starts_or_ends_with"... pass
filter_predicate_aliases.tftest.hcl... tearing down
filter_predicate_aliases.tftest.hcl... pass
filter_predicate_framework.tftest.hcl... in progress
  run "resource_filter_with_framework_predicate_contains"... pass
  run "resource_filter_with_framework_predicate_equals"... pass
  run "resource_filter_with_framework_predicate_exists"... pass
  run "resource_filter_with_framework_predicate_matches_regex"... pass
  run "resource_filter_with_framework_predicate_starts_or_ends_with"... pass
filter_predicate_framework.tftest.hcl... tearing down
filter_predicate_framework.tftest.hcl... pass
filter_predicate_language.tftest.hcl... in progress
  run "resource_filter_with_language_predicate_contains"... pass
  run "resource_filter_with_language_predicate_equals"... pass
  run "resource_filter_with_language_predicate_exists"... pass
  run "resource_filter_with_language_predicate_matches_regex"... pass
  run "resource_filter_with_language_predicate_starts_or_ends_with"... pass
filter_predicate_language.tftest.hcl... tearing down
filter_predicate_language.tftest.hcl... pass
filter_predicate_lifecycle_index.tftest.hcl... in progress
  run "resource_filter_with_lifecycle_index_predicate_equals"... pass
  run "resource_filter_with_lifecycle_index_predicate_exists"... pass
  run "resource_filter_with_lifecycle_index_predicate_greater_than_or_equal_to"... pass
  run "resource_filter_with_lifecycle_index_predicate_less_than_or_equal_to"... pass
filter_predicate_lifecycle_index.tftest.hcl... tearing down
filter_predicate_lifecycle_index.tftest.hcl... pass
filter_predicate_name.tftest.hcl... in progress
  run "resource_filter_with_name_predicate_contains"... pass
  run "resource_filter_with_name_predicate_equals"... pass
  run "resource_filter_with_name_predicate_exists"... pass
  run "resource_filter_with_name_predicate_matches_regex"... pass
  run "resource_filter_with_name_predicate_starts_or_ends_with"... pass
filter_predicate_name.tftest.hcl... tearing down
filter_predicate_name.tftest.hcl... pass
filter_predicate_product.tftest.hcl... in progress
  run "resource_filter_with_product_predicate_contains"... pass
  run "resource_filter_with_product_predicate_equals"... pass
  run "resource_filter_with_product_predicate_exists"... pass
  run "resource_filter_with_product_predicate_matches_regex"... pass
  run "resource_filter_with_product_predicate_starts_or_ends_with"... pass
filter_predicate_product.tftest.hcl... tearing down
filter_predicate_product.tftest.hcl... pass
filter_predicate_properties.tftest.hcl... in progress
  run "resource_filter_with_properties_predicate_exists"... pass
  run "resource_filter_with_properties_predicate_satisfies_jq_expression"... pass
filter_predicate_properties.tftest.hcl... tearing down
filter_predicate_properties.tftest.hcl... pass
filter_predicate_tags.tftest.hcl... in progress
  run "resource_filter_with_tags_predicate_contains"... pass
  run "resource_filter_with_tags_predicate_equals"... pass
  run "resource_filter_with_tags_predicate_exists"... pass
  run "resource_filter_with_tags_predicate_matches_regex"... pass
  run "resource_filter_with_tags_predicate_starts_or_ends_with"... pass
  run "resource_filter_with_tags_predicate_satisfies_version_constraint"... pass
filter_predicate_tags.tftest.hcl... tearing down
filter_predicate_tags.tftest.hcl... pass
filter_predicate_tier_index.tftest.hcl... in progress
  run "resource_filter_with_tier_index_predicate_equals"... pass
  run "resource_filter_with_tier_index_predicate_exists"... pass
  run "resource_filter_with_tier_index_predicate_greater_than_or_equal_to"... pass
  run "resource_filter_with_tier_index_predicate_less_than_or_equal_to"... pass
filter_predicate_tier_index.tftest.hcl... tearing down
filter_predicate_tier_index.tftest.hcl... pass

Success! 41 passed, 0 failed.
```