### PR TITLE
add rest of filter predicate tests

### DIFF
--- a/tests/remote/filter_predicate_aliases.tftest.hcl
+++ b/tests/remote/filter_predicate_aliases.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with aliases predicate"
+  predicate_value = "fancy"
+  aliases_predicates = setproduct(
+    ["aliases"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_aliases_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_contains"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["aliases_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_equals"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["aliases_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_exists"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["aliases_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_aliases_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.aliases_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].key == "aliases"
+    error_message = format(
+      "expected predicate key 'aliases' got '%s'",
+      opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_aliases.tftest.hcl
+++ b/tests/remote/filter_predicate_aliases.tftest.hcl
@@ -3,14 +3,10 @@ variables {
   predicate_value = "fancy"
   aliases_predicates = setproduct(
     ["aliases"],
-    concat([
-      "contains",
-      "does_not_contain",
-      "does_not_match_regex",
-      "ends_with",
-      "matches_regex",
-      "starts_with",
-      ],
+    concat(
+      var.predicate_types_contains,
+      var.predicate_types_ends_or_starts_with,
+      var.predicate_types_matches_regex,
       var.predicate_types_equals,
       var.predicate_types_exists
     ),
@@ -27,7 +23,7 @@ run "resource_filter_with_aliases_predicate_contains" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_contain", "contains"], pair[1])
+      if contains(var.predicate_types_contains, pair[1])
     })
   }
 
@@ -76,7 +72,7 @@ run "resource_filter_with_aliases_predicate_contains" {
   assert {
     condition = opslevel_filter.all_predicates["aliases_contains"].predicate[0].type == "contains"
     error_message = format(
-      "expected predicate type 'does_not_contain' got '%s'",
+      "expected predicate type 'contains' got '%s'",
       opslevel_filter.all_predicates["aliases_contains"].predicate[0].type
     )
   }
@@ -156,7 +152,7 @@ run "resource_filter_with_aliases_predicate_equals" {
   assert {
     condition = opslevel_filter.all_predicates["aliases_equals"].predicate[0].type == "equals"
     error_message = format(
-      "expected predicate type 'does_not_equal' got '%s'",
+      "expected predicate type 'equals' got '%s'",
       opslevel_filter.all_predicates["aliases_equals"].predicate[0].type
     )
   }
@@ -232,7 +228,7 @@ run "resource_filter_with_aliases_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["aliases_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["aliases_exists"].predicate[0].type
     )
   }
@@ -259,7 +255,7 @@ run "resource_filter_with_aliases_predicate_matches_regex" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+      if contains(var.predicate_types_matches_regex, pair[1])
     })
   }
 
@@ -308,7 +304,7 @@ run "resource_filter_with_aliases_predicate_matches_regex" {
   assert {
     condition = opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].type == "matches_regex"
     error_message = format(
-      "expected predicate type 'does_not_match_regex' got '%s'",
+      "expected predicate type 'matches_regex' got '%s'",
       opslevel_filter.all_predicates["aliases_matches_regex"].predicate[0].type
     )
   }
@@ -339,7 +335,7 @@ run "resource_filter_with_aliases_predicate_starts_or_ends_with" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["ends_with", "starts_with"], pair[1])
+      if contains(var.predicate_types_ends_or_starts_with, pair[1])
     })
   }
 
@@ -388,7 +384,7 @@ run "resource_filter_with_aliases_predicate_starts_or_ends_with" {
   assert {
     condition = opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].type == "starts_with"
     error_message = format(
-      "expected predicate type 'ends_with' got '%s'",
+      "expected predicate type 'starts_with' got '%s'",
       opslevel_filter.all_predicates["aliases_starts_with"].predicate[0].type
     )
   }

--- a/tests/remote/filter_predicate_framework.tftest.hcl
+++ b/tests/remote/filter_predicate_framework.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with framework predicate"
+  predicate_value = "fancy"
+  framework_predicates = setproduct(
+    ["framework"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_framework_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_contains"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["framework_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_equals"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["framework_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_exists"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["framework_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_framework_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.framework_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["framework_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].key == "framework"
+    error_message = format(
+      "expected predicate key 'framework' got '%s'",
+      opslevel_filter.all_predicates["framework_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["framework_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["framework_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["framework_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_framework.tftest.hcl
+++ b/tests/remote/filter_predicate_framework.tftest.hcl
@@ -3,14 +3,10 @@ variables {
   predicate_value = "fancy"
   framework_predicates = setproduct(
     ["framework"],
-    concat([
-      "contains",
-      "does_not_contain",
-      "does_not_match_regex",
-      "ends_with",
-      "matches_regex",
-      "starts_with",
-      ],
+    concat(
+      var.predicate_types_contains,
+      var.predicate_types_ends_or_starts_with,
+      var.predicate_types_matches_regex,
       var.predicate_types_equals,
       var.predicate_types_exists
     ),
@@ -27,7 +23,7 @@ run "resource_filter_with_framework_predicate_contains" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_contain", "contains"], pair[1])
+      if contains(var.predicate_types_contains, pair[1])
     })
   }
 
@@ -76,7 +72,7 @@ run "resource_filter_with_framework_predicate_contains" {
   assert {
     condition = opslevel_filter.all_predicates["framework_contains"].predicate[0].type == "contains"
     error_message = format(
-      "expected predicate type 'does_not_contain' got '%s'",
+      "expected predicate type 'contains' got '%s'",
       opslevel_filter.all_predicates["framework_contains"].predicate[0].type
     )
   }
@@ -156,7 +152,7 @@ run "resource_filter_with_framework_predicate_equals" {
   assert {
     condition = opslevel_filter.all_predicates["framework_equals"].predicate[0].type == "equals"
     error_message = format(
-      "expected predicate type 'does_not_equal' got '%s'",
+      "expected predicate type 'equals' got '%s'",
       opslevel_filter.all_predicates["framework_equals"].predicate[0].type
     )
   }
@@ -232,7 +228,7 @@ run "resource_filter_with_framework_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["framework_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["framework_exists"].predicate[0].type
     )
   }
@@ -259,7 +255,7 @@ run "resource_filter_with_framework_predicate_matches_regex" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+      if contains(var.predicate_types_matches_regex, pair[1])
     })
   }
 
@@ -339,7 +335,7 @@ run "resource_filter_with_framework_predicate_starts_or_ends_with" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["ends_with", "starts_with"], pair[1])
+      if contains(var.predicate_types_ends_or_starts_with, pair[1])
     })
   }
 

--- a/tests/remote/filter_predicate_language.tftest.hcl
+++ b/tests/remote/filter_predicate_language.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with language predicate"
+  predicate_value = "fancy"
+  language_predicates = setproduct(
+    ["language"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_language_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_contains"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["language_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_language_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_equals"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["language_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_language_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_exists"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["language_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_language_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["language_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_language_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.language_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_ends_with"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["language_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_starts_with"].predicate[0].key == "language"
+    error_message = format(
+      "expected predicate key 'language' got '%s'",
+      opslevel_filter.all_predicates["language_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["language_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["language_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["language_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["language_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_language.tftest.hcl
+++ b/tests/remote/filter_predicate_language.tftest.hcl
@@ -3,14 +3,10 @@ variables {
   predicate_value = "fancy"
   language_predicates = setproduct(
     ["language"],
-    concat([
-      "contains",
-      "does_not_contain",
-      "does_not_match_regex",
-      "ends_with",
-      "matches_regex",
-      "starts_with",
-      ],
+    concat(
+      var.predicate_types_contains,
+      var.predicate_types_ends_or_starts_with,
+      var.predicate_types_matches_regex,
       var.predicate_types_equals,
       var.predicate_types_exists
     ),
@@ -27,7 +23,7 @@ run "resource_filter_with_language_predicate_contains" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_contain", "contains"], pair[1])
+      if contains(var.predicate_types_contains, pair[1])
     })
   }
 
@@ -76,7 +72,7 @@ run "resource_filter_with_language_predicate_contains" {
   assert {
     condition = opslevel_filter.all_predicates["language_contains"].predicate[0].type == "contains"
     error_message = format(
-      "expected predicate type 'does_not_contain' got '%s'",
+      "expected predicate type 'contains' got '%s'",
       opslevel_filter.all_predicates["language_contains"].predicate[0].type
     )
   }
@@ -156,7 +152,7 @@ run "resource_filter_with_language_predicate_equals" {
   assert {
     condition = opslevel_filter.all_predicates["language_equals"].predicate[0].type == "equals"
     error_message = format(
-      "expected predicate type 'does_not_equal' got '%s'",
+      "expected predicate type 'equals' got '%s'",
       opslevel_filter.all_predicates["language_equals"].predicate[0].type
     )
   }
@@ -232,7 +228,7 @@ run "resource_filter_with_language_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["language_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["language_exists"].predicate[0].type
     )
   }
@@ -259,7 +255,7 @@ run "resource_filter_with_language_predicate_matches_regex" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+      if contains(var.predicate_types_matches_regex, pair[1])
     })
   }
 
@@ -308,7 +304,7 @@ run "resource_filter_with_language_predicate_matches_regex" {
   assert {
     condition = opslevel_filter.all_predicates["language_matches_regex"].predicate[0].type == "matches_regex"
     error_message = format(
-      "expected predicate type 'does_not_match_regex' got '%s'",
+      "expected predicate type 'matches_regex' got '%s'",
       opslevel_filter.all_predicates["language_matches_regex"].predicate[0].type
     )
   }
@@ -339,7 +335,7 @@ run "resource_filter_with_language_predicate_starts_or_ends_with" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["ends_with", "starts_with"], pair[1])
+      if contains(var.predicate_types_ends_or_starts_with, pair[1])
     })
   }
 
@@ -388,7 +384,7 @@ run "resource_filter_with_language_predicate_starts_or_ends_with" {
   assert {
     condition = opslevel_filter.all_predicates["language_starts_with"].predicate[0].type == "starts_with"
     error_message = format(
-      "expected predicate type 'ends_with' got '%s'",
+      "expected predicate type 'starts_with' got '%s'",
       opslevel_filter.all_predicates["language_starts_with"].predicate[0].type
     )
   }

--- a/tests/remote/filter_predicate_lifecycle_index.tftest.hcl
+++ b/tests/remote/filter_predicate_lifecycle_index.tftest.hcl
@@ -70,7 +70,7 @@ run "resource_filter_with_lifecycle_index_predicate_equals" {
   assert {
     condition = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].type == "equals"
     error_message = format(
-      "expected predicate type 'does_not_equal' got '%s'",
+      "expected predicate type 'equals' got '%s'",
       opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].type
     )
   }
@@ -146,7 +146,7 @@ run "resource_filter_with_lifecycle_index_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].type
     )
   }

--- a/tests/remote/filter_predicate_lifecycle_index.tftest.hcl
+++ b/tests/remote/filter_predicate_lifecycle_index.tftest.hcl
@@ -1,0 +1,264 @@
+variables {
+  name            = "TF Test Filter with lifecycle_index predicate"
+  predicate_value = "1"
+  lifecycle_index_predicates = setproduct(
+    ["lifecycle_index"],
+    concat(
+      ["less_than_or_equal_to", "greater_than_or_equal_to"],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_lifecycle_index_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_lifecycle_index_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_lifecycle_index_predicate_greater_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "greater_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].type == "greater_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'greater_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_greater_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_lifecycle_index_predicate_less_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.lifecycle_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "less_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].key == "lifecycle_index"
+    error_message = format(
+      "expected predicate key 'lifecycle_index' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].type == "less_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'less_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["lifecycle_index_less_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_name.tftest.hcl
+++ b/tests/remote/filter_predicate_name.tftest.hcl
@@ -3,14 +3,10 @@ variables {
   predicate_value = "fancy"
   name_predicates = setproduct(
     ["name"],
-    concat([
-      "contains",
-      "does_not_contain",
-      "does_not_match_regex",
-      "ends_with",
-      "matches_regex",
-      "starts_with",
-      ],
+    concat(
+      var.predicate_types_contains,
+      var.predicate_types_ends_or_starts_with,
+      var.predicate_types_matches_regex,
       var.predicate_types_equals,
       var.predicate_types_exists
     ),
@@ -27,7 +23,7 @@ run "resource_filter_with_name_predicate_contains" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_contain", "contains"], pair[1])
+      if contains(var.predicate_types_contains, pair[1])
     })
   }
 
@@ -76,7 +72,7 @@ run "resource_filter_with_name_predicate_contains" {
   assert {
     condition = opslevel_filter.all_predicates["name_contains"].predicate[0].type == "contains"
     error_message = format(
-      "expected predicate type 'does_not_contain' got '%s'",
+      "expected predicate type 'contains' got '%s'",
       opslevel_filter.all_predicates["name_contains"].predicate[0].type
     )
   }
@@ -156,7 +152,7 @@ run "resource_filter_with_name_predicate_equals" {
   assert {
     condition = opslevel_filter.all_predicates["name_equals"].predicate[0].type == "equals"
     error_message = format(
-      "expected predicate type 'does_not_equal' got '%s'",
+      "expected predicate type 'equals' got '%s'",
       opslevel_filter.all_predicates["name_equals"].predicate[0].type
     )
   }
@@ -232,7 +228,7 @@ run "resource_filter_with_name_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["name_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["name_exists"].predicate[0].type
     )
   }
@@ -259,7 +255,7 @@ run "resource_filter_with_name_predicate_matches_regex" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+      if contains(var.predicate_types_matches_regex, pair[1])
     })
   }
 
@@ -339,7 +335,7 @@ run "resource_filter_with_name_predicate_starts_or_ends_with" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["ends_with", "starts_with"], pair[1])
+      if contains(var.predicate_types_ends_or_starts_with, pair[1])
     })
   }
 

--- a/tests/remote/filter_predicate_name.tftest.hcl
+++ b/tests/remote/filter_predicate_name.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with name predicate"
+  predicate_value = "fancy"
+  name_predicates = setproduct(
+    ["name"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_name_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_contains"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["name_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_name_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_equals"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["name_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_name_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_exists"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["name_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_name_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["name_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_name_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.name_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_ends_with"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["name_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_starts_with"].predicate[0].key == "name"
+    error_message = format(
+      "expected predicate key 'name' got '%s'",
+      opslevel_filter.all_predicates["name_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["name_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["name_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["name_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["name_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_product.tftest.hcl
+++ b/tests/remote/filter_predicate_product.tftest.hcl
@@ -1,0 +1,410 @@
+variables {
+  name            = "TF Test Filter with product predicate"
+  predicate_value = "fancy"
+  product_predicates = setproduct(
+    ["product"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_product_predicate_contains" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_contains"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["product_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_contains"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_product_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_equals"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["product_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_product_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_exists"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["product_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_product_predicate_matches_regex" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["product_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_product_predicate_starts_or_ends_with" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.product_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_ends_with"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["product_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_ends_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_starts_with"].predicate[0].key == "product"
+    error_message = format(
+      "expected predicate key 'product' got '%s'",
+      opslevel_filter.all_predicates["product_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["product_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["product_starts_with"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["product_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["product_starts_with"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_product.tftest.hcl
+++ b/tests/remote/filter_predicate_product.tftest.hcl
@@ -3,14 +3,10 @@ variables {
   predicate_value = "fancy"
   product_predicates = setproduct(
     ["product"],
-    concat([
-      "contains",
-      "does_not_contain",
-      "does_not_match_regex",
-      "ends_with",
-      "matches_regex",
-      "starts_with",
-      ],
+    concat(
+      var.predicate_types_contains,
+      var.predicate_types_ends_or_starts_with,
+      var.predicate_types_matches_regex,
       var.predicate_types_equals,
       var.predicate_types_exists
     ),
@@ -27,7 +23,7 @@ run "resource_filter_with_product_predicate_contains" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_contain", "contains"], pair[1])
+      if contains(var.predicate_types_contains, pair[1])
     })
   }
 
@@ -76,7 +72,7 @@ run "resource_filter_with_product_predicate_contains" {
   assert {
     condition = opslevel_filter.all_predicates["product_contains"].predicate[0].type == "contains"
     error_message = format(
-      "expected predicate type 'does_not_contain' got '%s'",
+      "expected predicate type 'contains' got '%s'",
       opslevel_filter.all_predicates["product_contains"].predicate[0].type
     )
   }
@@ -156,7 +152,7 @@ run "resource_filter_with_product_predicate_equals" {
   assert {
     condition = opslevel_filter.all_predicates["product_equals"].predicate[0].type == "equals"
     error_message = format(
-      "expected predicate type 'does_not_equal' got '%s'",
+      "expected predicate type 'equals' got '%s'",
       opslevel_filter.all_predicates["product_equals"].predicate[0].type
     )
   }
@@ -232,7 +228,7 @@ run "resource_filter_with_product_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["product_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["product_exists"].predicate[0].type
     )
   }
@@ -259,7 +255,7 @@ run "resource_filter_with_product_predicate_matches_regex" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+      if contains(var.predicate_types_matches_regex, pair[1])
     })
   }
 
@@ -308,7 +304,7 @@ run "resource_filter_with_product_predicate_matches_regex" {
   assert {
     condition = opslevel_filter.all_predicates["product_matches_regex"].predicate[0].type == "matches_regex"
     error_message = format(
-      "expected predicate type 'does_not_match_regex' got '%s'",
+      "expected predicate type 'matches_regex' got '%s'",
       opslevel_filter.all_predicates["product_matches_regex"].predicate[0].type
     )
   }
@@ -339,7 +335,7 @@ run "resource_filter_with_product_predicate_starts_or_ends_with" {
         key_data = null,
         value    = var.predicate_value
       }
-      if contains(["ends_with", "starts_with"], pair[1])
+      if contains(var.predicate_types_ends_or_starts_with, pair[1])
     })
   }
 
@@ -388,7 +384,7 @@ run "resource_filter_with_product_predicate_starts_or_ends_with" {
   assert {
     condition = opslevel_filter.all_predicates["product_starts_with"].predicate[0].type == "starts_with"
     error_message = format(
-      "expected predicate type 'ends_with' got '%s'",
+      "expected predicate type 'starts_with' got '%s'",
       opslevel_filter.all_predicates["product_starts_with"].predicate[0].type
     )
   }

--- a/tests/remote/filter_predicate_properties.tftest.hcl
+++ b/tests/remote/filter_predicate_properties.tftest.hcl
@@ -1,0 +1,135 @@
+variables {
+  name                  = "TF Test Filter with properties predicate"
+  jq_expression         = ".[] | select(.name == fancy)"
+  predicate_key_data    = "property_definition_id"
+  properties_predicates = setproduct(["properties"], concat(var.predicate_types_exists, ["satisfies_jq_expression"]))
+}
+
+run "resource_filter_with_properties_predicate_exists" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
+        key = pair[0], type = pair[1], key_data = var.predicate_key_data, value = contains(var.predicate_types_exists, pair[1]) ? null : var.jq_expression
+      }
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key == "properties"
+    error_message = format(
+      "expected predicate key 'properties' got '%s'",
+      opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["properties_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_exists"].predicate[0].key == "properties"
+    error_message = format(
+      "expected predicate key 'properties' got '%s'",
+      opslevel_filter.all_predicates["properties_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'exists' got '%s'",
+      opslevel_filter.all_predicates["properties_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_exists"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["properties_exists"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["properties_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_properties_predicate_satisfies_jq_expression" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
+        key = pair[0], type = pair[1], key_data = var.predicate_key_data, value = var.jq_expression
+      }
+      if "satisfies_jq_expression" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key == "properties"
+    error_message = format(
+      "expected predicate key 'properties' got '%s'",
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].type == "satisfies_jq_expression"
+    error_message = format(
+      "expected predicate type 'satisfies_jq_expression' got '%s'",
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].value == var.jq_expression
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.jq_expression,
+      opslevel_filter.all_predicates["properties_satisfies_jq_expression"].predicate[0].type
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_properties.tftest.hcl
+++ b/tests/remote/filter_predicate_properties.tftest.hcl
@@ -11,8 +11,12 @@ run "resource_filter_with_properties_predicate_exists" {
     connective = "and"
     predicates = tomap({
       for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
-        key = pair[0], type = pair[1], key_data = var.predicate_key_data, value = contains(var.predicate_types_exists, pair[1]) ? null : var.jq_expression
+        key = pair[0],
+        type = pair[1],
+        key_data = var.predicate_key_data,
+        value = null
       }
+      if contains(var.predicate_types_exists, pair[1])
     })
   }
 
@@ -88,7 +92,10 @@ run "resource_filter_with_properties_predicate_satisfies_jq_expression" {
     connective = "and"
     predicates = tomap({
       for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
-        key = pair[0], type = pair[1], key_data = var.predicate_key_data, value = var.jq_expression
+        key = pair[0],
+        type = pair[1],
+        key_data = var.predicate_key_data,
+        value = var.jq_expression
       }
       if "satisfies_jq_expression" == pair[1]
     })

--- a/tests/remote/filter_predicate_properties.tftest.hcl
+++ b/tests/remote/filter_predicate_properties.tftest.hcl
@@ -11,10 +11,10 @@ run "resource_filter_with_properties_predicate_exists" {
     connective = "and"
     predicates = tomap({
       for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
-        key = pair[0],
-        type = pair[1],
+        key      = pair[0],
+        type     = pair[1],
         key_data = var.predicate_key_data,
-        value = null
+        value    = null
       }
       if contains(var.predicate_types_exists, pair[1])
     })
@@ -92,10 +92,10 @@ run "resource_filter_with_properties_predicate_satisfies_jq_expression" {
     connective = "and"
     predicates = tomap({
       for pair in var.properties_predicates : "${pair[0]}_${pair[1]}" => {
-        key = pair[0],
-        type = pair[1],
+        key      = pair[0],
+        type     = pair[1],
         key_data = var.predicate_key_data,
-        value = var.jq_expression
+        value    = var.jq_expression
       }
       if "satisfies_jq_expression" == pair[1]
     })

--- a/tests/remote/filter_predicate_tags.tftest.hcl
+++ b/tests/remote/filter_predicate_tags.tftest.hcl
@@ -4,15 +4,11 @@ variables {
   predicate_value    = "fancy"
   tags_predicates = setproduct(
     ["tags"],
-    concat([
-      "contains",
-      "does_not_contain",
-      "does_not_match_regex",
-      "ends_with",
-      "matches_regex",
-      "satisfies_version_constraint",
-      "starts_with",
-      ],
+    concat(
+      ["satisfies_version_constraint"],
+      var.predicate_types_contains,
+      var.predicate_types_ends_or_starts_with,
+      var.predicate_types_matches_regex,
       var.predicate_types_equals,
       var.predicate_types_exists
     ),
@@ -30,7 +26,7 @@ run "resource_filter_with_tags_predicate_contains" {
         key_data = var.predicate_key_data,
         value    = var.predicate_value
       }
-      if contains(["does_not_contain", "contains"], pair[1])
+      if contains(var.predicate_types_contains, pair[1])
     })
   }
 
@@ -83,7 +79,7 @@ run "resource_filter_with_tags_predicate_contains" {
   assert {
     condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].type == "contains"
     error_message = format(
-      "expected predicate type 'does_not_contain' got '%s'",
+      "expected predicate type 'contains' got '%s'",
       opslevel_filter.all_predicates["tags_contains"].predicate[0].type
     )
   }
@@ -119,7 +115,7 @@ run "resource_filter_with_tags_predicate_equals" {
         key_data = var.predicate_key_data,
         value    = var.predicate_value
       }
-      if contains(["does_not_equal", "equals"], pair[1])
+      if contains(var.predicate_types_equals, pair[1])
     })
   }
 
@@ -172,7 +168,7 @@ run "resource_filter_with_tags_predicate_equals" {
   assert {
     condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].type == "equals"
     error_message = format(
-      "expected predicate type 'does_not_equal' got '%s'",
+      "expected predicate type 'equals' got '%s'",
       opslevel_filter.all_predicates["tags_equals"].predicate[0].type
     )
   }
@@ -208,7 +204,7 @@ run "resource_filter_with_tags_predicate_exists" {
         key_data = var.predicate_key_data,
         value    = null
       }
-      if contains(["does_not_exist", "exists"], pair[1])
+      if contains(var.predicate_types_exists, pair[1])
     })
   }
 
@@ -257,7 +253,7 @@ run "resource_filter_with_tags_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["tags_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["tags_exists"].predicate[0].type
     )
   }
@@ -289,7 +285,7 @@ run "resource_filter_with_tags_predicate_matches_regex" {
         key_data = var.predicate_key_data,
         value    = var.predicate_value
       }
-      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+      if contains(var.predicate_types_matches_regex, pair[1])
     })
   }
 
@@ -342,7 +338,7 @@ run "resource_filter_with_tags_predicate_matches_regex" {
   assert {
     condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].type == "matches_regex"
     error_message = format(
-      "expected predicate type 'does_not_match_regex' got '%s'",
+      "expected predicate type 'matches_regex' got '%s'",
       opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].type
     )
   }
@@ -378,7 +374,7 @@ run "resource_filter_with_tags_predicate_starts_or_ends_with" {
         key_data = var.predicate_key_data,
         value    = var.predicate_value
       }
-      if contains(["ends_with", "starts_with"], pair[1])
+      if contains(var.predicate_types_ends_or_starts_with, pair[1])
     })
   }
 
@@ -431,7 +427,7 @@ run "resource_filter_with_tags_predicate_starts_or_ends_with" {
   assert {
     condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].type == "starts_with"
     error_message = format(
-      "expected predicate type 'ends_with' got '%s'",
+      "expected predicate type 'starts_with' got '%s'",
       opslevel_filter.all_predicates["tags_starts_with"].predicate[0].type
     )
   }
@@ -486,7 +482,7 @@ run "resource_filter_with_tags_predicate_satisfies_version_constraint" {
   assert {
     condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].type == "satisfies_version_constraint"
     error_message = format(
-      "expected predicate type 'ends_with' got '%s'",
+      "expected predicate type 'satisfies_version_constraint' got '%s'",
       opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].type
     )
   }

--- a/tests/remote/filter_predicate_tags.tftest.hcl
+++ b/tests/remote/filter_predicate_tags.tftest.hcl
@@ -1,0 +1,512 @@
+variables {
+  name               = "TF Test Filter with tags predicate"
+  predicate_key_data = "test_tag"
+  predicate_value    = "fancy"
+  tags_predicates = setproduct(
+    ["tags"],
+    concat([
+      "contains",
+      "does_not_contain",
+      "does_not_match_regex",
+      "ends_with",
+      "matches_regex",
+      "satisfies_version_constraint",
+      "starts_with",
+      ],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_tags_predicate_contains" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_contain", "contains"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].type == "does_not_contain"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_does_not_contain"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].type == "contains"
+    error_message = format(
+      "expected predicate type 'does_not_contain' got '%s'",
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_contains"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_contains"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_equals" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_equal", "equals"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_exists" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = null
+      }
+      if contains(["does_not_exist", "exists"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tags_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_exists"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tags_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_exists"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_exists"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tags_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_matches_regex" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["does_not_match_regex", "matches_regex"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].type == "does_not_match_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_does_not_match_regex"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].type == "matches_regex"
+    error_message = format(
+      "expected predicate type 'does_not_match_regex' got '%s'",
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_matches_regex"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_starts_or_ends_with" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if contains(["ends_with", "starts_with"], pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].type == "ends_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_ends_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_ends_with"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].type == "starts_with"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_starts_with"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_starts_with"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tags_predicate_satisfies_version_constraint" {
+
+  variables {
+    connective = "and"
+    predicates = tomap({
+      for pair in var.tags_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = var.predicate_key_data,
+        value    = var.predicate_value
+      }
+      if "satisfies_version_constraint" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key == "tags"
+    error_message = format(
+      "expected predicate key 'tags' got '%s'",
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].type == "satisfies_version_constraint"
+    error_message = format(
+      "expected predicate type 'ends_with' got '%s'",
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key_data == var.predicate_key_data
+    error_message = format(
+      "expected predicate key_data '%s' got '%s'",
+      var.predicate_key_data,
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].key_data
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tags_satisfies_version_constraint"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_tier_index.tftest.hcl
+++ b/tests/remote/filter_predicate_tier_index.tftest.hcl
@@ -1,0 +1,264 @@
+variables {
+  name            = "TF Test Filter with tier_index predicate"
+  predicate_value = "1"
+  tier_index_predicates = setproduct(
+    ["tier_index"],
+    concat(
+      ["less_than_or_equal_to", "greater_than_or_equal_to"],
+      var.predicate_types_equals,
+      var.predicate_types_exists
+    ),
+  )
+}
+
+run "resource_filter_with_tier_index_predicate_equals" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if contains(var.predicate_types_equals, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].type == "does_not_equal"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_does_not_equal"].predicate[0].value
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_equals"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].type == "equals"
+    error_message = format(
+      "expected predicate type 'does_not_equal' got '%s'",
+      opslevel_filter.all_predicates["tier_index_equals"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_equals"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_equals"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tier_index_predicate_exists" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = null
+      }
+      if contains(var.predicate_types_exists, pair[1])
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].type == "does_not_exist"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_does_not_exist"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_exists"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].type == "exists"
+    error_message = format(
+      "expected predicate type 'does_not_exist' got '%s'",
+      opslevel_filter.all_predicates["tier_index_exists"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].value == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_filter_with_tier_index_predicate_greater_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "greater_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].type == "greater_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'greater_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_greater_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}
+
+run "resource_filter_with_tier_index_predicate_less_than_or_equal_to" {
+
+  variables {
+    predicates = tomap({
+      for pair in var.tier_index_predicates : "${pair[0]}_${pair[1]}" => {
+        key      = pair[0],
+        type     = pair[1],
+        key_data = null,
+        value    = var.predicate_value
+      }
+      if "less_than_or_equal_to" == pair[1]
+    })
+  }
+
+  module {
+    source = "./filter"
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].key == "tier_index"
+    error_message = format(
+      "expected predicate key 'tier_index' got '%s'",
+      opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].key
+    )
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].type == "less_than_or_equal_to"
+    error_message = format(
+      "expected predicate type 'less_than_or_equal_to' got '%s'",
+      opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].type
+    )
+  }
+
+  assert {
+    condition     = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].key_data == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].value == var.predicate_value
+    error_message = format(
+      "expected predicate value '%s' got '%s'",
+      var.predicate_value,
+      opslevel_filter.all_predicates["tier_index_less_than_or_equal_to"].predicate[0].value
+    )
+  }
+
+}

--- a/tests/remote/filter_predicate_tier_index.tftest.hcl
+++ b/tests/remote/filter_predicate_tier_index.tftest.hcl
@@ -146,7 +146,7 @@ run "resource_filter_with_tier_index_predicate_exists" {
   assert {
     condition = opslevel_filter.all_predicates["tier_index_exists"].predicate[0].type == "exists"
     error_message = format(
-      "expected predicate type 'does_not_exist' got '%s'",
+      "expected predicate type 'exists' got '%s'",
       opslevel_filter.all_predicates["tier_index_exists"].predicate[0].type
     )
   }

--- a/tests/remote/test.tfvars
+++ b/tests/remote/test.tfvars
@@ -55,17 +55,20 @@ enum_tool_category = [
   "status_page",
   "wiki",
 ]
-error_empty_datasource             = "zero 'TYPE' found in 'TYPE' datasource"
-error_expected_empty_string        = "expected field to be an empty string"
-error_expected_null_field          = "expected field to be null"
-error_unexpected_datasource_fields = "cannot reference all expected 'TYPE' datasource fields"
-error_unexpected_resource_fields   = "cannot reference all expected 'TYPE' resource fields"
-error_wrong_alias                  = "wrong alias for 'TYPE'"
-error_wrong_description            = "wrong description for 'TYPE'"
-error_wrong_index                  = "wrong index for 'TYPE'"
-error_wrong_id                     = "wrong id for 'TYPE'"
-error_wrong_name                   = "wrong name for 'TYPE'"
-error_wrong_owner                  = "wrong owner for 'TYPE'"
-id_prefix                          = "Z2lkOi8v"
-predicate_types_equals             = ["does_not_equal", "equals"]
-predicate_types_exists             = ["does_not_exist", "exists"]
+error_empty_datasource              = "zero 'TYPE' found in 'TYPE' datasource"
+error_expected_empty_string         = "expected field to be an empty string"
+error_expected_null_field           = "expected field to be null"
+error_unexpected_datasource_fields  = "cannot reference all expected 'TYPE' datasource fields"
+error_unexpected_resource_fields    = "cannot reference all expected 'TYPE' resource fields"
+error_wrong_alias                   = "wrong alias for 'TYPE'"
+error_wrong_description             = "wrong description for 'TYPE'"
+error_wrong_index                   = "wrong index for 'TYPE'"
+error_wrong_id                      = "wrong id for 'TYPE'"
+error_wrong_name                    = "wrong name for 'TYPE'"
+error_wrong_owner                   = "wrong owner for 'TYPE'"
+id_prefix                           = "Z2lkOi8v"
+predicate_types_contains            = ["does_not_contain", "contains"]
+predicate_types_ends_or_starts_with = ["ends_with", "starts_with"]
+predicate_types_matches_regex       = ["does_not_match_regex", "matches_regex"]
+predicate_types_equals              = ["does_not_equal", "equals"]
+predicate_types_exists              = ["does_not_exist", "exists"]


### PR DESCRIPTION
## Issues
a## Issues

[Predicates in filters can be cryptic](https://github.com/OpsLevel/team-platform/issues/433)
Second half of this [first predicate tests PR](https://github.com/OpsLevel/terraform-provider-opslevel/pull/424)

## Changelog

Add integration tests focusing on the following predicate filters:
- `aliases`
- `framework`
- `language`
- `lifecycle_index`
- `name`
- `product`
- `properties`
- `tags`
- `tier_index`

Note: `lifecycle_index` and `tier_index` are basically the same
`aliases`, `framework`, `language`, `name`, `product`, `properties` and `tags` are basically the same

- [X] List your changes here
- [ ] Make a `changie` entry, N/A testing only

## Tophatting

```bash
task test-integration -- \
 "-filter=filter_predicate_aliases.tftest.hcl" \
 "-filter=filter_predicate_framework.tftest.hcl" \
 "-filter=filter_predicate_language.tftest.hcl" \
 "-filter=filter_predicate_lifecycle_index.tftest.hcl" \
 "-filter=filter_predicate_name.tftest.hcl" \
 "-filter=filter_predicate_product.tftest.hcl" \
 "-filter=filter_predicate_properties.tftest.hcl" \
 "-filter=filter_predicate_tags.tftest.hcl" \
 "-filter=filter_predicate_tier_index.tftest.hcl"
```

```tf
task: [terraform-command] terraform -chdir=tests/remote test -var-file=test.tfvars -var="api_token=$OPSLEVEL_API_TOKEN" '-filter=filter_predicate_aliases.tftest.hcl' '-filter=filter_predicate_framework.tftest.hcl' '-filter=filter_predicate_language.tftest.hcl' '-filter=filter_p
redicate_lifecycle_index.tftest.hcl' '-filter=filter_predicate_name.tftest.hcl' '-filter=filter_predicate_product.tftest.hcl' '-filter=filter_predicate_properties.tftest.hcl' '-filter=filter_predicate_tags.tftest.hcl' '-filter=filter_predicate_tier_index.tftest.hcl'
filter_predicate_aliases.tftest.hcl... in progress
  run "resource_filter_with_aliases_predicate_contains"... pass
  run "resource_filter_with_aliases_predicate_equals"... pass
  run "resource_filter_with_aliases_predicate_exists"... pass
  run "resource_filter_with_aliases_predicate_matches_regex"... pass
  run "resource_filter_with_aliases_predicate_starts_or_ends_with"... pass
filter_predicate_aliases.tftest.hcl... tearing down
filter_predicate_aliases.tftest.hcl... pass
filter_predicate_framework.tftest.hcl... in progress
  run "resource_filter_with_framework_predicate_contains"... pass
  run "resource_filter_with_framework_predicate_equals"... pass
  run "resource_filter_with_framework_predicate_exists"... pass
  run "resource_filter_with_framework_predicate_matches_regex"... pass
  run "resource_filter_with_framework_predicate_starts_or_ends_with"... pass
filter_predicate_framework.tftest.hcl... tearing down
filter_predicate_framework.tftest.hcl... pass
filter_predicate_language.tftest.hcl... in progress
  run "resource_filter_with_language_predicate_contains"... pass
  run "resource_filter_with_language_predicate_equals"... pass
  run "resource_filter_with_language_predicate_exists"... pass
  run "resource_filter_with_language_predicate_matches_regex"... pass
  run "resource_filter_with_language_predicate_starts_or_ends_with"... pass
filter_predicate_language.tftest.hcl... tearing down
filter_predicate_language.tftest.hcl... pass
filter_predicate_lifecycle_index.tftest.hcl... in progress
  run "resource_filter_with_lifecycle_index_predicate_equals"... pass
  run "resource_filter_with_lifecycle_index_predicate_exists"... pass
  run "resource_filter_with_lifecycle_index_predicate_greater_than_or_equal_to"... pass
  run "resource_filter_with_lifecycle_index_predicate_less_than_or_equal_to"... pass
filter_predicate_lifecycle_index.tftest.hcl... tearing down
filter_predicate_lifecycle_index.tftest.hcl... pass
filter_predicate_name.tftest.hcl... in progress
  run "resource_filter_with_name_predicate_contains"... pass
  run "resource_filter_with_name_predicate_equals"... pass
  run "resource_filter_with_name_predicate_exists"... pass
  run "resource_filter_with_name_predicate_matches_regex"... pass
  run "resource_filter_with_name_predicate_starts_or_ends_with"... pass
filter_predicate_name.tftest.hcl... tearing down
filter_predicate_name.tftest.hcl... pass
filter_predicate_product.tftest.hcl... in progress
  run "resource_filter_with_product_predicate_contains"... pass
  run "resource_filter_with_product_predicate_equals"... pass
  run "resource_filter_with_product_predicate_exists"... pass
  run "resource_filter_with_product_predicate_matches_regex"... pass
  run "resource_filter_with_product_predicate_starts_or_ends_with"... pass
filter_predicate_product.tftest.hcl... tearing down
filter_predicate_product.tftest.hcl... pass
filter_predicate_properties.tftest.hcl... in progress
  run "resource_filter_with_properties_predicate_exists"... pass
  run "resource_filter_with_properties_predicate_satisfies_jq_expression"... pass
filter_predicate_properties.tftest.hcl... tearing down
filter_predicate_properties.tftest.hcl... pass
filter_predicate_tags.tftest.hcl... in progress
  run "resource_filter_with_tags_predicate_contains"... pass
  run "resource_filter_with_tags_predicate_equals"... pass
  run "resource_filter_with_tags_predicate_exists"... pass
  run "resource_filter_with_tags_predicate_matches_regex"... pass
  run "resource_filter_with_tags_predicate_starts_or_ends_with"... pass
  run "resource_filter_with_tags_predicate_satisfies_version_constraint"... pass
filter_predicate_tags.tftest.hcl... tearing down
filter_predicate_tags.tftest.hcl... pass
filter_predicate_tier_index.tftest.hcl... in progress
  run "resource_filter_with_tier_index_predicate_equals"... pass
  run "resource_filter_with_tier_index_predicate_exists"... pass
  run "resource_filter_with_tier_index_predicate_greater_than_or_equal_to"... pass
  run "resource_filter_with_tier_index_predicate_less_than_or_equal_to"... pass
filter_predicate_tier_index.tftest.hcl... tearing down
filter_predicate_tier_index.tftest.hcl... pass

Success! 41 passed, 0 failed.
```
<!-- paste an issue link here from github/gitlab -->

## Changelog

- [ ] List your changes here
- [ ] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->

<!-- Typical Terraform CRUD workflow

### Given this Terraform config file
```tf
# main.tf
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Update the Terraform config file
```tf
# main.tf - with changes
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```tf
# copy paste CLI outputs here
```

-->
