### PR TITLE
add opslevel_service_dependencies datasource

### DIFF
--- a/.changes/unreleased/Feature-20240808-161107.yaml
+++ b/.changes/unreleased/Feature-20240808-161107.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add opslevel_service_dependencies datasource
+time: 2024-08-08T16:11:07.119526-05:00

--- a/examples/data-sources/opslevel_service_dependencies/data-source.tf
+++ b/examples/data-sources/opslevel_service_dependencies/data-source.tf
@@ -1,0 +1,15 @@
+data "opslevel_service" "foo" {
+  alias = "foo"
+}
+
+data "opslevel_service" "bar" {
+  id = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Njcw"
+}
+
+data "opslevel_service_dependencies" "by_alias" {
+  service = data.opslevel_service.foo.alias
+}
+
+data "opslevel_service_dependencies" "by_id" {
+  service = data.opslevel_service.bar.id
+}

--- a/opslevel/datasource_opslevel_service_dependencies.go
+++ b/opslevel/datasource_opslevel_service_dependencies.go
@@ -57,7 +57,7 @@ func (d *ServiceDependenciesDataSource) Metadata(ctx context.Context, req dataso
 
 var depsAttrs = map[string]schema.Attribute{
 	"id": schema.StringAttribute{
-		Description: "The ID of the serviceDependency.",
+		Description: "The ID of the service dependency.",
 		Computed:    true,
 	},
 	"locked": schema.BoolAttribute{
@@ -163,6 +163,6 @@ func (d *ServiceDependenciesDataSource) Read(ctx context.Context, req datasource
 	stateModel = NewServiceDependenciesModel(serviceIdentifier, dependents, dependencies)
 
 	// Save data into Terraform state
-	tflog.Trace(ctx, "read an OpsLevel Service data source")
+	tflog.Trace(ctx, "read an OpsLevel Service Dependencies data source")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
 }

--- a/opslevel/datasource_opslevel_service_dependencies.go
+++ b/opslevel/datasource_opslevel_service_dependencies.go
@@ -1,0 +1,128 @@
+package opslevel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
+)
+
+// Ensure ServiceDataSource implements DataSourceWithConfigure interface
+var _ datasource.DataSourceWithConfigure = &ServiceDataSource{}
+
+func NewServiceDependenciesDataSource() datasource.DataSource {
+	return &ServiceDependenciesDataSource{}
+}
+
+// ServiceDataSource manages a Service data source.
+type ServiceDependenciesDataSource struct {
+	CommonDataSourceClient
+}
+
+// ServiceDependenciesModel describes the data source data model.
+type ServiceDependenciesModel struct {
+	Dependencies []dependenciesModel `tfsdk:"dependencies"`
+	Service      types.String        `tfsdk:"service"`
+}
+
+type dependenciesModel struct {
+	Id     types.String `tfsdk:"id"`
+	Locked types.Bool   `tfsdk:"locked"`
+	Notes  types.String `tfsdk:"notes"`
+}
+
+func NewServiceDependenciesModel(serviceIdentifier string, dependencies []dependenciesModel) ServiceDependenciesModel {
+	return ServiceDependenciesModel{
+		Dependencies: dependencies,
+		Service:      types.StringValue(serviceIdentifier),
+	}
+}
+
+func (d *ServiceDependenciesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_dependencies"
+}
+
+func (d *ServiceDependenciesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Service Dependencies data source",
+
+		Attributes: map[string]schema.Attribute{
+			"dependencies": schema.ListNestedAttribute{
+				Description: "List of Service Dependencies of a service",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "The ID of the serviceDependency.",
+							Computed:    true,
+						},
+						"locked": schema.BoolAttribute{
+							Description: "Is the dependency locked by a service config?",
+							Computed:    true,
+						},
+						"notes": schema.StringAttribute{
+							Description: "Notes for service dependency.",
+							Optional:    true,
+						},
+					},
+				},
+				Computed: true,
+			},
+			"service": schema.StringAttribute{
+				Description: "The ID or alias of the service with the dependency.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (d *ServiceDependenciesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var (
+		dependencies      []dependenciesModel
+		err               error
+		service           *opslevel.Service
+		serviceIdentifier string
+		stateModel        ServiceDependenciesModel
+	)
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("service"), &serviceIdentifier)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Retrieve Service
+	if opslevel.IsID(serviceIdentifier) {
+		service, err = d.client.GetService(opslevel.ID(serviceIdentifier))
+	} else {
+		service, err = d.client.GetServiceWithAlias(serviceIdentifier)
+	}
+	if err != nil || service == nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read service, got error: %s", err))
+		return
+	}
+
+	// List Service Dependencies
+	result, _ := service.GetDependencies(d.client, nil)
+	if result == nil || len(result.Edges) == 0 {
+		dependencies = []dependenciesModel{}
+	} else {
+		for _, svcDependency := range result.Edges {
+			dependencies = append(dependencies, dependenciesModel{
+				Locked: types.BoolValue(svcDependency.Locked),
+				Id:     ComputedStringValue(string(svcDependency.Id)),
+				Notes:  ComputedStringValue(svcDependency.Notes),
+			})
+		}
+	}
+
+	stateModel = NewServiceDependenciesModel(serviceIdentifier, dependencies)
+
+	// Save data into Terraform state
+	tflog.Trace(ctx, "read an OpsLevel Service data source")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
+}

--- a/opslevel/provider.go
+++ b/opslevel/provider.go
@@ -239,6 +239,7 @@ func (p *OpslevelProvider) DataSources(context.Context) []func() datasource.Data
 		NewScorecardDataSource,
 		NewScorecardDataSourcesAll,
 		NewServiceDataSource,
+		NewServiceDependenciesDataSource,
 		NewServiceDataSourcesAll,
 		NewSystemDataSource,
 		NewSystemDataSourcesAll,

--- a/opslevel/resource_opslevel_integration_azure_resources.go
+++ b/opslevel/resource_opslevel_integration_azure_resources.go
@@ -50,7 +50,7 @@ type IntegrationAzureResourcesResourceModel struct {
 
 func NewIntegrationAzureResourcesResourceModel(ctx context.Context, azureResourcesIntegration opslevel.Integration, givenModel IntegrationAzureResourcesResourceModel) IntegrationAzureResourcesResourceModel {
 	resourceModel := IntegrationAzureResourcesResourceModel{
-		Aliases:        OptionalStringListValue(azureResourcesIntegration.Aliases),
+		Aliases:        OptionalStringListValue(azureResourcesIntegration.AzureResourcesIntegrationFragment.Aliases),
 		ClientId:       givenModel.ClientId,
 		ClientSecret:   givenModel.ClientSecret,
 		CreatedAt:      ComputedStringValue(azureResourcesIntegration.CreatedAt.Local().Format(time.RFC850)),
@@ -68,7 +68,7 @@ func NewIntegrationAzureResourcesResourceModel(ctx context.Context, azureResourc
 	if givenModel.TagsOverrideOwnership.IsNull() {
 		resourceModel.TagsOverrideOwnership = types.BoolNull()
 	} else {
-		resourceModel.TagsOverrideOwnership = types.BoolValue(azureResourcesIntegration.TagsOverrideOwnership)
+		resourceModel.TagsOverrideOwnership = types.BoolValue(azureResourcesIntegration.AzureResourcesIntegrationFragment.TagsOverrideOwnership)
 	}
 
 	return resourceModel


### PR DESCRIPTION
## Issues

[Add ability to get the dependencies and dependents of a given service via a datasource](https://github.com/OpsLevel/terraform-provider-opslevel/issues/345)

## Changelog

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Given this Terraform config file
```tf
data "opslevel_service_dependencies" "by_alias" {
  service = "sample_mobile_app"
}

data "opslevel_service_dependencies" "by_id" {
  service = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOA"
}

output "found_by_alias" {
  value = data.opslevel_service_dependencies.by_alias
}

output "found_by_id" {
  value = data.opslevel_service_dependencies.by_id
}
```

### Run `terraform plan`
```tf
data.opslevel_service_dependencies.by_id: Reading...
data.opslevel_service_dependencies.by_alias: Reading...
data.opslevel_service_dependencies.by_alias: Read complete after 1s
data.opslevel_service_dependencies.by_id: Read complete after 1s

Changes to Outputs:
  + found_by_alias = {
      + dependencies = [
          + {
              + id     = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZURlcGVuZGVuY3kvMzE4MjE0"
              + locked = false
              + notes  = null
            },
        ]
      + dependents   = []
      + service      = "sample_mobile_app"
    }
  + found_by_id    = {
      + dependencies = [
          + {
              + id     = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZURlcGVuZGVuY3kvMzE4MjE1"
              + locked = false
              + notes  = null
            },
        ]
      + dependents   = [
          + {
              + id     = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZURlcGVuZGVuY3kvMzE4MjE0"
              + locked = false
              + notes  = null
            },
        ]
      + service      = "Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS85MzMyOA"
    }

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```
