### PR TITLE
Missing the schema version for repo grep check

### DIFF
--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -94,6 +94,7 @@ func (r *CheckRepositoryGrepResource) Schema(ctx context.Context, req resource.S
 	predicateSchema.Required = true
 
 	resp.Schema = schema.Schema{
+		Version: 1,
 		// This description is used by the documentation generator and the language server.
 		MarkdownDescription: "Check Repository Grep Resource",
 


### PR DESCRIPTION
## Issues

This check type has a state upgrader but doesn't have a schema version.  This might break newly created checks with 1.2.x when they try to upgrade to this version.  But it is what it is at this point.  We'll have to recommend people delete and recreate repo grep checks made with 1.2.x
