### PR TITLE
opslevel_users datasource can filter out deactivated users

### DIFF
--- a/.changes/unreleased/Feature-20240815-220023.yaml
+++ b/.changes/unreleased/Feature-20240815-220023.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: opslevel_users datasource can filter out deactivated users
+time: 2024-08-15T22:00:23.213997-05:00

--- a/examples/data-sources/opslevel_users/data-source.tf
+++ b/examples/data-sources/opslevel_users/data-source.tf
@@ -1,7 +1,15 @@
 data "opslevel_users" "all" {}
 
+data "opslevel_users" "only_active" {
+  ignore_deactivated = true
+}
+
 output "all" {
   value = data.opslevel_users.all.users
+}
+
+output "only_active" {
+  value = data.opslevel_users.only_active.users
 }
 
 output "user_emails" {


### PR DESCRIPTION
## Issues

[As an End User, I can use filtering on the account users listing](https://github.com/OpsLevel/team-platform/issues/202)

## Changelog

`opslevel_users` datasource can filter out deactivated users via an optional `ignore_deactivated` bool

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

### Given this Terraform config file
```tf
data "opslevel_users" "all" {}

data "opslevel_users" "only_active" {
  ignore_deactivated = true
}

output "all" {
  value = length(data.opslevel_users.all.users)
}

output "only_active" {
  value = length(data.opslevel_users.only_active.users)
}
```

### List count of all users and active users, `terraform plan`
```tf
data.opslevel_users.only_active: Reading...
data.opslevel_users.all: Reading...
data.opslevel_users.all: Read complete after 1s
data.opslevel_users.only_active: Read complete after 1s

Changes to Outputs:
  + all         = 4
  + only_active = 3

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.
```