### PR TITLE
support import opslevel_property_assignment and opslevel_property_def…

### DIFF
--- a/.changes/unreleased/Bugfix-20240819-161150.yaml
+++ b/.changes/unreleased/Bugfix-20240819-161150.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: support import opslevel_property_assignment and opslevel_property_definition
+time: 2024-08-19T16:11:50.166472-05:00

--- a/opslevel/resource_opslevel_property_assignment.go
+++ b/opslevel/resource_opslevel_property_assignment.go
@@ -138,8 +138,11 @@ func (resource *PropertyAssignmentResource) Read(ctx context.Context, req resour
 	definition := planModel.Definition.ValueString()
 	owner := planModel.Owner.ValueString()
 	assignment, err := resource.client.GetProperty(owner, definition)
-	if err != nil || assignment == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read property assignment (%s) on service (%s), got error: %s", definition, owner, err))
+	if err != nil {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read property assignment '%s' on service '%s', got error: %s", definition, owner, err))
+		return
+	} else if assignment == nil || string(assignment.Definition.Id) == "" {
+		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("property assignment '%s' not found on service '%s'", definition, owner))
 		return
 	}
 	value := *assignment.Value

--- a/opslevel/resource_opslevel_property_definition.go
+++ b/opslevel/resource_opslevel_property_definition.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -17,7 +18,10 @@ import (
 	"github.com/opslevel/opslevel-go/v2024"
 )
 
-var _ resource.ResourceWithConfigure = &PropertyDefinitionResource{}
+var (
+	_ resource.ResourceWithConfigure   = &PropertyDefinitionResource{}
+	_ resource.ResourceWithImportState = &PropertyDefinitionResource{}
+)
 
 type PropertyDefinitionResource struct {
 	CommonResourceClient
@@ -202,4 +206,8 @@ func (resource *PropertyDefinitionResource) Delete(ctx context.Context, req reso
 		return
 	}
 	tflog.Trace(ctx, fmt.Sprintf("deleted a definition resource with id '%s'", id))
+}
+
+func (r *PropertyDefinitionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
## Issues

[opslevel_property_definition is not importable](https://github.com/OpsLevel/terraform-provider-opslevel/issues/441)

## Changelog

Support importing `opslevel_property_assignment` and `opslevel_property_definition`

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

<!-- paste in CLI output, log messages or screenshots showing your change works -->

<!-- Typical Terraform CRUD workflow

### Given this Terraform config file
```tf
# main.tf
```

### Create the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Update the Terraform config file
```tf
# main.tf - with changes
```

### Update the `opslevel_<resource>` resource, `terraform apply`
```tf
# copy paste CLI outputs here
```

### Destroy the `opslevel_<resource>` resource, `terraform destroy`
```tf
# copy paste CLI outputs here
```

-->
