### PR TITLE
team contacts list added to opslevel_team datasources

### DIFF
--- a/.changes/unreleased/Feature-20240821-131503.yaml
+++ b/.changes/unreleased/Feature-20240821-131503.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: team contacts list added to opslevel_team datasources
+time: 2024-08-21T13:15:03.611021-05:00

--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -3,10 +3,15 @@ package opslevel
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/opslevel/opslevel-go/v2024"
 )
@@ -26,6 +31,7 @@ type TeamDataSource struct {
 // teamDataSourceModel describes the data source data model.
 type teamDataSourceModel struct {
 	Alias       types.String      `tfsdk:"alias"`
+	Contacts    types.List        `tfsdk:"contacts"`
 	Id          types.String      `tfsdk:"id"`
 	Members     []teamMemberModel `tfsdk:"members"`
 	Name        types.String      `tfsdk:"name"`
@@ -33,7 +39,99 @@ type teamDataSourceModel struct {
 	ParentId    types.String      `tfsdk:"parent_id"`
 }
 
+type teamContactModel struct {
+	Address     types.String `tfsdk:"address"`
+	DisplayName types.String `tfsdk:"display_name"`
+	DisplayType types.String `tfsdk:"display_yype"`
+	ExternalId  types.String `tfsdk:"external_id"`
+	Id          types.String `tfsdk:"id"`
+	IsDefault   types.Bool   `tfsdk:"is_default"`
+	Type        types.String `tfsdk:"type"`
+}
+
+func (tcm teamContactModel) schemaAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"address": schema.StringAttribute{
+			Description: "The contact address. Examples: 'support@company.com' for type email, 'https://opslevel.com' for type web.",
+			Computed:    true,
+		},
+		"display_name": schema.StringAttribute{
+			Description: "The name shown in the UI for the contact.",
+			Computed:    true,
+		},
+		"display_type": schema.StringAttribute{
+			Description: "The type shown in the UI for the contact.",
+			Computed:    true,
+		},
+		"external_id": schema.StringAttribute{
+			Description: "The remote identifier of the contact method.",
+			Computed:    true,
+		},
+		"id": schema.StringAttribute{
+			Description: "The unique identifier for the contact.",
+			Computed:    true,
+		},
+		"is_default": schema.BoolAttribute{
+			Description: "Indicates if this address is a team's default for the given type.",
+			Computed:    true,
+		},
+		"type": schema.StringAttribute{
+			Description: fmt.Sprintf("The method of contact. One of [`%s`].",
+				strings.Join(opslevel.AllContactType, "`, `"),
+			),
+			Computed: true,
+			Validators: []validator.String{
+				stringvalidator.OneOf(opslevel.AllContactType...),
+			},
+		},
+	}
+}
+
+func newTeamContactModel(contact opslevel.Contact) teamContactModel {
+	return teamContactModel{
+		Address:     ComputedStringValue(contact.Address),
+		DisplayName: ComputedStringValue(contact.DisplayName),
+		DisplayType: ComputedStringValue(contact.DisplayType),
+		ExternalId:  ComputedStringValue(contact.ExternalId),
+		Id:          ComputedStringValue(string(contact.Id)),
+		IsDefault:   types.BoolValue(contact.IsDefault),
+		Type:        ComputedStringValue(string(contact.Type)),
+	}
+}
+
+func (tcm teamContactModel) asObjectValue() basetypes.ObjectValue {
+	attrValues := map[string]attr.Value{
+		"address":      tcm.Address,
+		"display_name": tcm.DisplayName,
+		"display_type": tcm.DisplayType,
+		"external_id":  tcm.ExternalId,
+		"id":           tcm.Id,
+		"is_default":   tcm.IsDefault,
+		"type":         tcm.Type,
+	}
+	return types.ObjectValueMust(teamContactAttrs(), attrValues)
+}
+
+func teamContactAttrs() map[string]attr.Type {
+	return map[string]attr.Type{
+		"address":      types.StringType,
+		"display_name": types.StringType,
+		"display_type": types.StringType,
+		"external_id":  types.StringType,
+		"id":           types.StringType,
+		"is_default":   types.BoolType,
+		"type":         types.StringType,
+	}
+}
+
 var teamDatasourceSchemaAttrs = map[string]schema.Attribute{
+	"contacts": schema.ListNestedAttribute{
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: teamContactModel{}.schemaAttributes(),
+		},
+		Description: "The contacts for the team.",
+		Computed:    true,
+	},
 	"name": schema.StringAttribute{
 		Description: "The name of the Team.",
 		Computed:    true,
@@ -100,6 +198,16 @@ func newTeamDataSourceModel(team opslevel.Team) teamDataSourceModel {
 		Name:        ComputedStringValue(team.Name),
 		ParentAlias: ComputedStringValue(team.ParentTeam.Alias),
 		ParentId:    ComputedStringValue(string(team.ParentTeam.Id)),
+	}
+	teamContactAttrTypes := teamContactAttrs()
+	if len(team.Contacts) == 0 {
+		teamDataSourceModel.Contacts = types.ListNull(types.ObjectType{AttrTypes: teamContactAttrTypes})
+	} else {
+		teamContactModels := []attr.Value{}
+		for _, contact := range team.Contacts {
+			teamContactModels = append(teamContactModels, newTeamContactModel(contact).asObjectValue())
+		}
+		teamDataSourceModel.Contacts = types.ListValueMust(types.ObjectType{AttrTypes: teamContactAttrTypes}, teamContactModels)
 	}
 	if team.Memberships != nil {
 		teamDataSourceModel.Members = newTeamMembersAllModel(team.Memberships.Nodes)

--- a/opslevel/datasource_opslevel_team.go
+++ b/opslevel/datasource_opslevel_team.go
@@ -49,42 +49,40 @@ type teamContactModel struct {
 	Type        types.String `tfsdk:"type"`
 }
 
-func (tcm teamContactModel) schemaAttributes() map[string]schema.Attribute {
-	return map[string]schema.Attribute{
-		"address": schema.StringAttribute{
-			Description: "The contact address. Examples: 'support@company.com' for type email, 'https://opslevel.com' for type web.",
-			Computed:    true,
+var teamContactsNestedSchemaAttrs = map[string]schema.Attribute{
+	"address": schema.StringAttribute{
+		Description: "The contact address. Examples: 'support@company.com' for type email, 'https://opslevel.com' for type web.",
+		Computed:    true,
+	},
+	"display_name": schema.StringAttribute{
+		Description: "The name shown in the UI for the contact.",
+		Computed:    true,
+	},
+	"display_type": schema.StringAttribute{
+		Description: "The type shown in the UI for the contact.",
+		Computed:    true,
+	},
+	"external_id": schema.StringAttribute{
+		Description: "The remote identifier of the contact method.",
+		Computed:    true,
+	},
+	"id": schema.StringAttribute{
+		Description: "The unique identifier for the contact.",
+		Computed:    true,
+	},
+	"is_default": schema.BoolAttribute{
+		Description: "Indicates if this address is a team's default for the given type.",
+		Computed:    true,
+	},
+	"type": schema.StringAttribute{
+		Description: fmt.Sprintf("The method of contact. One of [`%s`].",
+			strings.Join(opslevel.AllContactType, "`, `"),
+		),
+		Computed: true,
+		Validators: []validator.String{
+			stringvalidator.OneOf(opslevel.AllContactType...),
 		},
-		"display_name": schema.StringAttribute{
-			Description: "The name shown in the UI for the contact.",
-			Computed:    true,
-		},
-		"display_type": schema.StringAttribute{
-			Description: "The type shown in the UI for the contact.",
-			Computed:    true,
-		},
-		"external_id": schema.StringAttribute{
-			Description: "The remote identifier of the contact method.",
-			Computed:    true,
-		},
-		"id": schema.StringAttribute{
-			Description: "The unique identifier for the contact.",
-			Computed:    true,
-		},
-		"is_default": schema.BoolAttribute{
-			Description: "Indicates if this address is a team's default for the given type.",
-			Computed:    true,
-		},
-		"type": schema.StringAttribute{
-			Description: fmt.Sprintf("The method of contact. One of [`%s`].",
-				strings.Join(opslevel.AllContactType, "`, `"),
-			),
-			Computed: true,
-			Validators: []validator.String{
-				stringvalidator.OneOf(opslevel.AllContactType...),
-			},
-		},
-	}
+	},
 }
 
 func newTeamContactModel(contact opslevel.Contact) teamContactModel {
@@ -127,7 +125,7 @@ func teamContactAttrs() map[string]attr.Type {
 var teamDatasourceSchemaAttrs = map[string]schema.Attribute{
 	"contacts": schema.ListNestedAttribute{
 		NestedObject: schema.NestedAttributeObject{
-			Attributes: teamContactModel{}.schemaAttributes(),
+			Attributes: teamContactsNestedSchemaAttrs,
 		},
 		Description: "The contacts for the team.",
 		Computed:    true,

--- a/tests/remote/team.tftest.hcl
+++ b/tests/remote/team.tftest.hcl
@@ -170,6 +170,7 @@ run "datasource_team_first" {
   assert {
     condition = alltrue([
       can(data.opslevel_team.first_team_by_id.alias),
+      can(data.opslevel_team.first_team_by_id.contacts),
       can(data.opslevel_team.first_team_by_id.id),
       can(data.opslevel_team.first_team_by_id.members),
       can(data.opslevel_team.first_team_by_id.name),


### PR DESCRIPTION
## Issues

Part of [Add ability to query the slack channel ID of a contact method that is a slack channel](https://github.com/OpsLevel/team-platform/issues/298)

## Changelog

Add team Contact data to `opslevel_team` and `opslevel_teams` datasources

- [X] List your changes here
- [X] Make a `changie` entry

## Tophatting

```tf
# main.tf
data "opslevel_team" "test" {
  alias = "engineering"
}

output "team_contacts" {
  value = data.opslevel_team.test.contacts
}
```

### Output
```tf
data.opslevel_team.test: Reading...
data.opslevel_team.test: Read complete after 0s [id=Z2lkOi8vb3BzbGV2ZWwvVGVhbS8xMDI0Mg]

Changes to Outputs:
  + team_contacts = [
      + {
          + address      = "#engineering"
          + display_name = "Slack Channel"
          + display_type = "Secondary"
          + external_id  = "<redacted>"
          + id           = "Z2lk<redacted>"
          + is_default   = true
          + type         = "slack"
        },
    ]

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

```