### PR TITLE
ownership_tag_keys field on opslevel_integration_aws cannot be empty,…

### DIFF
--- a/.changes/unreleased/Refactor-20240822-152940.yaml
+++ b/.changes/unreleased/Refactor-20240822-152940.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: ownership_tag_keys field on opslevel_integration_aws resource can be null, but not empty
+time: 2024-08-22T15:29:40.77516-05:00

--- a/opslevel/resource_opslevel_integration_aws.go
+++ b/opslevel/resource_opslevel_integration_aws.go
@@ -79,7 +79,7 @@ func (r *IntegrationAwsResource) Schema(ctx context.Context, req resource.Schema
 			},
 			"ownership_tag_keys": schema.ListAttribute{
 				ElementType: types.StringType,
-				Description: "An Array of tag keys used to associate ownership from an integration. Max 5",
+				Description: "Allow tags imported from AWS to override ownership set in OpsLevel directly",
 				Optional:    true,
 				Computed:    true,
 				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{types.StringValue("owner")})),

--- a/opslevel/resource_opslevel_integration_azure_resources.go
+++ b/opslevel/resource_opslevel_integration_azure_resources.go
@@ -124,6 +124,10 @@ func (r *IntegrationAzureResourcesResource) Schema(ctx context.Context, req reso
 					setvalidator.SizeBetween(1, 5),
 				},
 			},
+			"ownership_tag_overrides": schema.BoolAttribute{
+				Description: "Allow tags imported from Azure to override ownership set in OpsLevel directly.",
+				Optional:    true,
+			},
 			"subscription_id": schema.StringAttribute{
 				MarkdownDescription: "The subscription OpsLevel uses to access the Azure account. [Microsoft's docs on regex pattern for ID](https://learn.microsoft.com/en-us/rest/api/defenderforcloud/tasks/get-subscription-level-task?view=rest-defenderforcloud-2015-06-01-preview&tabs=HTTP#uri-parameters)",
 				Required:            true,
@@ -136,10 +140,6 @@ func (r *IntegrationAzureResourcesResource) Schema(ctx context.Context, req reso
 						fmt.Sprintf("expected ID matching regex pattern: ' %s '", AzureIdRegexPattern),
 					),
 				},
-			},
-			"ownership_tag_overrides": schema.BoolAttribute{
-				Description: "Allow tags imported from Azure to override ownership set in OpsLevel directly.",
-				Optional:    true,
 			},
 			"tenant_id": schema.StringAttribute{
 				MarkdownDescription: "The tenant OpsLevel uses to access the Azure account. [Microsoft's docs on regex pattern for ID](https://learn.microsoft.com/en-us/rest/api/defenderforcloud/tasks/get-subscription-level-task?view=rest-defenderforcloud-2015-06-01-preview&tabs=HTTP#uri-parameters)",

--- a/tests/remote/integration_aws.tftest.hcl
+++ b/tests/remote/integration_aws.tftest.hcl
@@ -1,0 +1,115 @@
+variables {
+  resource_name = "opslevel_integration_aws"
+
+  # required fields
+  external_id             = "194c7dfc-3a3f-4b0a-b898-578ce7e8f6dc"
+  iam_role                = "arn:aws:iam::994866125780:user/opslevel-test"
+  ownership_tag_overrides = false
+  name                    = "TF Test AWS Integration"
+
+  # optional fields
+  ownership_tag_keys = ["one", "two", "three", "four", "five"]
+}
+
+run "resource_integration_aws_create_with_all_fields" {
+
+  variables {
+    external_id             = var.external_id
+    iam_role                = var.iam_role
+    ownership_tag_keys      = var.ownership_tag_keys
+    ownership_tag_overrides = var.ownership_tag_overrides
+    name                    = var.name
+  }
+
+  module {
+    source = "./integration_aws"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_integration_aws.test.external_id),
+      can(opslevel_integration_aws.test.iam_role),
+      can(opslevel_integration_aws.test.id),
+      can(opslevel_integration_aws.test.ownership_tag_keys),
+      can(opslevel_integration_aws.test.ownership_tag_overrides),
+      can(opslevel_integration_aws.test.name),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_integration_aws.test.external_id == var.external_id
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.external_id,
+      opslevel_integration_aws.test.external_id,
+    )
+  }
+
+  assert {
+    condition = opslevel_integration_aws.test.iam_role == var.iam_role
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.iam_role,
+      opslevel_integration_aws.test.iam_role,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_integration_aws.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_integration_aws.test.ownership_tag_keys == var.ownership_tag_keys
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.ownership_tag_keys,
+      opslevel_integration_aws.test.ownership_tag_keys,
+    )
+  }
+
+  assert {
+    condition = opslevel_integration_aws.test.ownership_tag_overrides == var.ownership_tag_overrides
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.ownership_tag_overrides,
+      opslevel_integration_aws.test.ownership_tag_overrides,
+    )
+  }
+
+  assert {
+    condition = opslevel_integration_aws.test.name == var.name
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.name,
+      opslevel_integration_aws.test.name,
+    )
+  }
+
+}
+
+run "resource_integration_aws_ownership_tag_keys_default_value" {
+
+  variables {
+    external_id             = var.external_id
+    iam_role                = var.iam_role
+    ownership_tag_keys      = null
+    ownership_tag_overrides = var.ownership_tag_overrides
+    name                    = var.name
+  }
+
+  module {
+    source = "./integration_aws"
+  }
+
+  assert {
+    condition = opslevel_integration_aws.test.ownership_tag_keys == tolist(["owner"])
+    error_message = format(
+      "expected '%v' but got '%v'",
+      tolist(["owner"]),
+      opslevel_integration_aws.test.ownership_tag_keys,
+    )
+  }
+
+}

--- a/tests/remote/integration_aws/main.tf
+++ b/tests/remote/integration_aws/main.tf
@@ -1,0 +1,7 @@
+resource "opslevel_integration_aws" "test" {
+  name                    = var.name
+  iam_role                = var.iam_role
+  external_id             = var.external_id
+  ownership_tag_overrides = var.ownership_tag_overrides
+  ownership_tag_keys      = var.ownership_tag_keys
+}

--- a/tests/remote/integration_aws/variables.tf
+++ b/tests/remote/integration_aws/variables.tf
@@ -1,0 +1,25 @@
+variable "external_id" {
+  type        = string
+  description = "The External ID defined in the trust relationship to ensure OpsLevel is the only third party assuming this role (See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html for more details)."
+}
+
+variable "iam_role" {
+  type        = string
+  description = "The IAM role OpsLevel uses in order to access the AWS account."
+}
+
+variable "ownership_tag_keys" {
+  type        = list(string)
+  description = "An Array of tag keys used to associate ownership from an integration. Max 5"
+  default     = null
+}
+
+variable "ownership_tag_overrides" {
+  type        = bool
+  description = "Allow tags imported from AWS to override ownership set in OpsLevel directly."
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the integration."
+}

--- a/tests/remote/integration_azure_resources.tftest.hcl
+++ b/tests/remote/integration_azure_resources.tftest.hcl
@@ -1,0 +1,130 @@
+variables {
+  resource_name = "opslevel_integration_azure_resources"
+
+  # required fields
+  client_id       = "XXX_CLIENT_ID_XXX"
+  client_secret   = "XXX_CLIENT_SECRET_XXX"
+  name            = "TF Test azure_resources Integration"
+  subscription_id = "01234567-0123-0123-0123-012345678901"
+  tenant_id       = "98765432-9876-9876-9876-987654321098"
+
+  # optional fields
+  ownership_tag_keys      = toset(["one", "two", "three", "four", "five"])
+  ownership_tag_overrides = true
+}
+
+run "resource_integration_azure_resources_create_with_all_fields" {
+
+  variables {
+    client_id               = var.client_id
+    client_secret           = var.client_secret
+    ownership_tag_keys      = var.ownership_tag_keys
+    ownership_tag_overrides = var.ownership_tag_overrides
+    name                    = var.name
+    subscription_id         = var.subscription_id
+    tenant_id               = var.tenant_id
+  }
+
+  module {
+    source = "./integration_azure_resources"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_integration_azure_resources.test.aliases),
+      can(opslevel_integration_azure_resources.test.client_id),
+      can(opslevel_integration_azure_resources.test.client_secret),
+      can(opslevel_integration_azure_resources.test.created_at),
+      can(opslevel_integration_azure_resources.test.id),
+      can(opslevel_integration_azure_resources.test.installed_at),
+      can(opslevel_integration_azure_resources.test.name),
+      can(opslevel_integration_azure_resources.test.ownership_tag_keys),
+      can(opslevel_integration_azure_resources.test.ownership_tag_overrides),
+      can(opslevel_integration_azure_resources.test.subscription_id),
+      can(opslevel_integration_azure_resources.test.tenant_id),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition     = opslevel_integration_azure_resources.test.client_secret == var.client_secret
+    error_message = "expected different client_secret, not printing sensitive value"
+  }
+
+  assert {
+    condition = opslevel_integration_azure_resources.test.client_id == var.client_id
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.client_id,
+      opslevel_integration_azure_resources.test.client_id,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_integration_azure_resources.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_integration_azure_resources.test.ownership_tag_keys == toset(var.ownership_tag_keys)
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.ownership_tag_keys,
+      opslevel_integration_azure_resources.test.ownership_tag_keys,
+    )
+  }
+
+  assert {
+    condition = opslevel_integration_azure_resources.test.ownership_tag_overrides == var.ownership_tag_overrides
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.ownership_tag_overrides,
+      opslevel_integration_azure_resources.test.ownership_tag_overrides,
+    )
+  }
+
+  assert {
+    condition = opslevel_integration_azure_resources.test.name == var.name
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.name,
+      opslevel_integration_azure_resources.test.name,
+    )
+  }
+
+  assert {
+    condition = opslevel_integration_azure_resources.test.subscription_id == var.subscription_id
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.subscription_id,
+      opslevel_integration_azure_resources.test.subscription_id,
+    )
+  }
+
+  assert {
+    condition = opslevel_integration_azure_resources.test.tenant_id == var.tenant_id
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.tenant_id,
+      opslevel_integration_azure_resources.test.tenant_id,
+    )
+  }
+
+}
+
+run "resource_integration_azure_resources_unset_optional_fields" {
+
+  variables {
+    ownership_tag_keys = null
+  }
+
+  module {
+    source = "./integration_azure_resources"
+  }
+
+  assert {
+    condition     = opslevel_integration_azure_resources.test.ownership_tag_keys == null
+    error_message = var.error_expected_null_field
+  }
+
+}

--- a/tests/remote/integration_azure_resources/main.tf
+++ b/tests/remote/integration_azure_resources/main.tf
@@ -1,0 +1,10 @@
+resource "opslevel_integration_azure_resources" "test" {
+  client_id               = var.client_id
+  client_secret           = var.client_secret
+  name                    = var.name
+  ownership_tag_keys      = var.ownership_tag_keys
+  ownership_tag_overrides = var.ownership_tag_overrides
+  subscription_id         = var.subscription_id
+  tenant_id               = var.tenant_id
+}
+

--- a/tests/remote/integration_azure_resources/variables.tf
+++ b/tests/remote/integration_azure_resources/variables.tf
@@ -1,0 +1,37 @@
+variable "client_id" {
+  type        = string
+  description = "The client id OpsLevel uses to access the Azure account."
+}
+
+variable "client_secret" {
+  type        = string
+  sensitive   = true
+  description = "The client secret OpsLevel uses to access the Azure account."
+}
+
+variable "name" {
+  type        = string
+  description = "The name of the integration."
+}
+
+variable "ownership_tag_keys" {
+  type        = list(string)
+  description = "An Array of tag keys used to associate ownership from an integration. Max 5"
+  default     = null
+}
+
+variable "ownership_tag_overrides" {
+  type        = bool
+  description = "Allow tags imported from AWS to override ownership set in OpsLevel directly."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "The subscription OpsLevel uses to access the Azure account."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "The tenant OpsLevel uses to access the Azure account."
+}
+

--- a/tests/remote/integration_google_cloud.tftest.hcl
+++ b/tests/remote/integration_google_cloud.tftest.hcl
@@ -141,3 +141,25 @@ run "resource_integration_google_cloud_with_empty_optional_fields" {
     error_message = replace(var.error_wrong_value, "TYPE", "opslevel_integration_google_cloud")
   }
 }
+
+run "resource_integration_google_cloud_ownership_tag_keys_default_value" {
+
+  variables {
+    name               = "GCP Integration Default Ownership Tag Keys"
+    ownership_tag_keys = null
+  }
+
+  module {
+    source = "./integration_google_cloud"
+  }
+
+  assert {
+    condition = opslevel_integration_google_cloud.test.ownership_tag_keys == tolist(["owner"])
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.ownership_tag_keys,
+      opslevel_integration_google_cloud.test.ownership_tag_keys,
+    )
+  }
+
+}


### PR DESCRIPTION
Resolves [Add missing tests](https://github.com/OpsLevel/team-platform/issues/445) (partially)

### Problem

Missing test

### Solution

Add tests for:
- `opslevel_integration_aws`
- `opslevel_integration_azure_resources`

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [X] I have run this code, and it appears to resolve the stated issue.
- [X] This PR does not reduce total test coverage
- [X] This PR has no user interface changes or has already received approval from product management to change the interface.
- [X] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
