### PR TITLE
draft attempt at avoiding breaks on runs due to lost tags on services

### DIFF
--- a/opslevel/resource_opslevel_service_tag.go
+++ b/opslevel/resource_opslevel_service_tag.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/opslevel/opslevel-go/v2024"
 )
 
 var _ resource.ResourceWithConfigure = &ServiceTagResource{}
@@ -171,8 +170,11 @@ func (serviceTagResource *ServiceTagResource) Read(ctx context.Context, req reso
 		}
 	}
 	if serviceTag == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("service tag (with key '%s') not found on service (%s)", data.Key.ValueString(), serviceIdentifier))
-		return
+		// some changes to the opslevel_service resource wipe out it's tags managed by the opslevel_service_tag standalone resource
+		// this behavior has been observed countless times, with no visible traces of tag changes on state, plans, or actions.
+		// simply re-creating a service tag if it's found to be nil/lost instead of throwing out errors and breaking runs would be preferred for service tags specifically
+		// resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("service tag (with key '%s') not found on service (%s)", data.Key.ValueString(), serviceIdentifier))
+		// return
 	}
 
 	readServiceResourceModel := NewServiceTagResourceModel(*serviceTag)

--- a/opslevel/resource_opslevel_service_tag.go
+++ b/opslevel/resource_opslevel_service_tag.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/opslevel/opslevel-go/v2024"
 )
 
 var _ resource.ResourceWithConfigure = &ServiceTagResource{}


### PR DESCRIPTION
Resolves #

### Problem

Some type of changes/updates to the `opslevel_service` resource have been found to also wipe clean the service's list of tags that are managed via the standalone `opslevel_service_tag` resource. This in turn forces future terraform runs to break constantly as the provider currently throws an error whenever it detects lost tags (stateful resource not present).

there are no visible traces of tag changes on any previous runs, no prompts on plans, no prompts on applies, no nothing that would indicate a service's tags being altered with. i did however spot a pattern that all missing tags were found on services that were modified on previous runs (ie: ownership changes, etc,) - not one modification tag related, yet tags were deleted.

### Solution

While the solution would be to find out what's happening in the background, where most probably, this issue has to do with the opslevel API calls doing more than it should. im now more interested in getting this to working state and got no time to investigate it properly.

This issue specifically happening on service tags, im arguing that such a resource should instead be prompted for an automatic re-creation rather than breaking anything on a given run. Tags are not business crucial, and chances are, if you set the tags via a standalone resource (`opslevel_service_tag`), you also control its value on that very same resource constantly, hence why im requesting we change the current error throwing behaviour to simply flag the tag as lost/no longer existent and prompt it for re-creation constantly upon identifying them as lost - continuing the run.


NOTE: this is but a draft PR to point out what's happening and argue for my proposition, the changes on the PR were not tested, i simply believe that commenting those lines out would prompt for the tags re-creation based on a short code read and my limited understanding.


### Given this Terraform config file
```tf
resource "opslevel_service" "mw" {
  for_each = local.apps

  name            = each.value.name
  lifecycle_alias = data.opslevel_lifecycle.mw.alias
  tier_alias      = data.opslevel_tier.mw.alias

  owner = contains(local.squad_names, each.value.owner) ? opslevel_team.mw[each.value.owner].id : null

  depends_on = [opslevel_team.mw]

  lifecycle {
    // ignore changes to everything but ownership and service name to allow teams to customize their services without conflicts.
    ignore_changes = [
      framework, lifecycle_alias, tier_alias, aliases, tags,
      api_document_path, product, preferred_api_document_source,
    ]
  }
}

resource "opslevel_service_tag" "redis" {
  for_each = { for k, v in local.key_tech_info : k => v if tobool(v.uses_redis) }

  key     = "redis"
  value   = each.value.uses_redis
  service = opslevel_service.mw[each.key].id
}
```

### The `terraform apply` output

this would be the run before the error happens, with a simple ownership change:
```bash
  # opslevel_service.mw["classifier"] will be updated in-place
  ~ resource "opslevel_service" "mw" {
        id                            = "redacted"
        name                          = "classifier"
      ~ owner                         = "redacted" -> (known after apply)
        # (7 unchanged attributes hidden)
    }
```

followed by this error on the next run:
```bash
│ Error: opslevel client error
│ 
│   with opslevel_service_tag.redis["classifier"],
│   on service_tags.tf line 44, in resource "opslevel_service_tag" "redis":
│   44: resource "opslevel_service_tag" "redis" {
│ 
│ service tag (with key 'redis') not found on service
│ (redacted)
╵
```

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
