### PR TITLE
opslevel_service_tag accepts service or service_alias, not both, test…

### DIFF
--- a/.changes/unreleased/Refactor-20240823-145222.yaml
+++ b/.changes/unreleased/Refactor-20240823-145222.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: opslevel_service_tag only accepts "service" field or "service_alias" field, not both
+time: 2024-08-23T14:52:22.18332-05:00

--- a/opslevel/resource_opslevel_service_tag.go
+++ b/opslevel/resource_opslevel_service_tag.go
@@ -79,7 +79,7 @@ func (serviceTagResource *ServiceTagResource) Schema(ctx context.Context, req re
 				Optional:    true,
 				Validators: []validator.String{
 					IdStringValidator(),
-					stringvalidator.AtLeastOneOf(path.MatchRoot("service"),
+					stringvalidator.ExactlyOneOf(path.MatchRoot("service"),
 						path.MatchRoot("service_alias")),
 				},
 				PlanModifiers: []planmodifier.String{

--- a/tests/remote/repository/outputs.tf
+++ b/tests/remote/repository/outputs.tf
@@ -1,0 +1,3 @@
+output "first_repository" {
+  value = data.opslevel_repository.first_repo_by_id
+}

--- a/tests/remote/repository/variables.tf
+++ b/tests/remote/repository/variables.tf
@@ -6,4 +6,5 @@ variable "identifier" {
 variable "owner_id" {
   type        = string
   description = "The id of the owner of the repository."
+  default     = null
 }

--- a/tests/remote/service/main.tf
+++ b/tests/remote/service/main.tf
@@ -4,6 +4,10 @@ data "opslevel_service" "first_service_by_id" {
   id = data.opslevel_services.all.services[0].id
 }
 
+data "opslevel_service" "last_service" {
+  id = element(data.opslevel_services.all.services, length(data.opslevel_services.all.services) - 1).id
+}
+
 resource "opslevel_service" "test" {
   aliases                       = var.aliases
   api_document_path             = var.api_document_path

--- a/tests/remote/service/outputs.tf
+++ b/tests/remote/service/outputs.tf
@@ -1,3 +1,7 @@
 output "first_service" {
   value = data.opslevel_service.first_service_by_id
 }
+
+output "last_service" {
+  value = data.opslevel_service.last_service
+}

--- a/tests/remote/service/outputs.tf
+++ b/tests/remote/service/outputs.tf
@@ -1,0 +1,3 @@
+output "first_service" {
+  value = data.opslevel_service.first_service_by_id
+}

--- a/tests/remote/service/variables.tf
+++ b/tests/remote/service/variables.tf
@@ -1,45 +1,37 @@
 variable "aliases" {
   type        = list(string)
   description = "A list of human-friendly, unique identifiers for the service."
-
-  validation {
-    condition     = var.aliases == null ? true : var.aliases == distinct(var.aliases)
-    error_message = "expected aliases to be unique"
-  }
+  default     = []
 }
 
 variable "api_document_path" {
   type        = string
   description = "The relative path from which to fetch the API document. If null, the API document is fetched from the account's default path."
-
-  validation {
-    condition = var.api_document_path == null ? true : anytrue([
-      endswith(var.api_document_path, ".json"),
-      endswith(var.api_document_path, ".yaml"),
-      endswith(var.api_document_path, ".yml"),
-    ])
-    error_message = "expected api_document_path to end with '.json', '.yaml', or '.yml'"
-  }
+  default     = null
 }
 
 variable "description" {
   type        = string
   description = "A brief description of the service."
+  default     = null
 }
 
 variable "framework" {
   type        = string
   description = "The primary software development framework that the service uses."
+  default     = null
 }
 
 variable "language" {
   type        = string
   description = "The primary programming language that the service is written in."
+  default     = null
 }
 
 variable "lifecycle_alias" {
   type        = string
   description = "The lifecycle stage of the service."
+  default     = null
 }
 
 variable "name" {
@@ -50,32 +42,35 @@ variable "name" {
 variable "owner" {
   type        = string
   description = "The team that owns the service. ID or Alias may be used."
+  default     = null
+}
+
+variable "parent" {
+  type        = string
+  description = "The id or alias of the parent system of this service"
+  default     = null
 }
 
 variable "preferred_api_document_source" {
   type        = string
   description = "The API document source used to determine the displayed document. If null, defaults to PUSH."
-
-  validation {
-    condition = var.preferred_api_document_source == null ? true : contains([
-      "PULL",
-      "PUSH",
-    ], var.preferred_api_document_source)
-    error_message = "expected preferred_api_document_source to be 'PULL' or 'PUSH'"
-  }
+  default     = null
 }
 
 variable "product" {
   type        = string
   description = "A product is an application that your end user interacts with. Multiple services can work together to power a single product."
+  default     = null
 }
 
 variable "tags" {
   type        = set(string)
   description = "A list of unique tags applied to the service."
+  default     = []
 }
 
 variable "tier_alias" {
   type        = string
   description = "The software tier that the service belongs to."
+  default     = null
 }

--- a/tests/remote/service_dependency.tftest.hcl
+++ b/tests/remote/service_dependency.tftest.hcl
@@ -1,0 +1,97 @@
+variables {
+  resource_name = "opslevel_service_dependency"
+
+  # required fields
+  depends_upon = "<id or alias of service>"
+  service      = null
+
+  # optional fields
+  note = "Testing service dependency resource in Terraform"
+}
+
+run "from_service_module" {
+  command = plan
+
+  variables {
+    name = ""
+  }
+
+  module {
+    source = "./service"
+  }
+}
+
+run "resource_service_dependency_create_with_service_id" {
+
+  variables {
+    depends_upon = run.from_service_module.first_service.id
+    service      = run.from_service_module.last_service.id
+    note         = var.note
+  }
+
+  module {
+    source = "./service_dependency"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_service_dependency.test.depends_upon),
+      can(opslevel_service_dependency.test.id),
+      can(opslevel_service_dependency.test.note),
+      can(opslevel_service_dependency.test.service),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_service_dependency.test.depends_upon == var.depends_upon
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.depends_upon,
+      opslevel_service_dependency.test.depends_upon,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_service_dependency.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_service_dependency.test.note == var.note
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.note,
+      opslevel_service_dependency.test.note,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_dependency.test.service == var.service
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.service,
+      opslevel_service_dependency.test.service,
+    )
+  }
+
+}
+
+run "resource_service_dependency_update_unset_optional_fields" {
+
+  variables {
+    depends_upon = run.from_service_module.first_service.id
+    service      = run.from_service_module.last_service.id
+    note         = null
+  }
+
+  module {
+    source = "./service_dependency"
+  }
+
+  assert {
+    condition     = opslevel_service_dependency.test.note == null
+    error_message = var.error_expected_null_field
+  }
+
+}

--- a/tests/remote/service_dependency/main.tf
+++ b/tests/remote/service_dependency/main.tf
@@ -1,0 +1,5 @@
+resource "opslevel_service_dependency" "test" {
+  depends_upon = var.depends_upon
+  note         = var.note
+  service      = var.service
+}

--- a/tests/remote/service_dependency/variables.tf
+++ b/tests/remote/service_dependency/variables.tf
@@ -1,0 +1,15 @@
+variable "depends_upon" {
+  type        = string
+  description = "The ID or alias of the service that is depended upon."
+}
+
+variable "note" {
+  type        = string
+  description = "Notes for service dependency."
+  default     = ""
+}
+
+variable "service" {
+  type        = string
+  description = "The ID or alias of the service with the dependency."
+}

--- a/tests/remote/service_repository.tftest.hcl
+++ b/tests/remote/service_repository.tftest.hcl
@@ -1,0 +1,209 @@
+variables {
+  resource_name = "opslevel_service_repository"
+
+  # required fields
+
+  # optional fields
+  base_directory   = null
+  name             = null
+  repository       = null
+  repository_alias = null
+  service          = null
+  service_alias    = null
+}
+
+run "from_repository_module" {
+  command = plan
+
+  variables {
+    identifier = ""
+  }
+
+  module {
+    source = "./repository"
+  }
+}
+
+run "from_service_module" {
+  command = plan
+
+  variables {
+    name = ""
+  }
+
+  module {
+    source = "./service"
+  }
+}
+
+run "resource_service_repository_create_with_ids" {
+
+  variables {
+    base_directory   = "base/path"
+    name             = "TF test service repository"
+    repository       = run.from_repository_module.first_repository.id
+    repository_alias = null
+    service          = run.from_service_module.first_service.id
+    service_alias    = null
+  }
+
+  module {
+    source = "./service_repository"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_service_repository.test.base_directory),
+      can(opslevel_service_repository.test.id),
+      can(opslevel_service_repository.test.name),
+      can(opslevel_service_repository.test.repository),
+      can(opslevel_service_repository.test.repository_alias),
+      can(opslevel_service_repository.test.service),
+      can(opslevel_service_repository.test.service_alias),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.base_directory == var.base_directory
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.base_directory,
+      opslevel_service_repository.test.base_directory,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_service_repository.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.name == var.name
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.name,
+      opslevel_service_repository.test.name,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.repository == var.repository
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.repository,
+      opslevel_service_repository.test.repository,
+    )
+  }
+
+  assert {
+    condition     = opslevel_service_repository.test.repository_alias == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.service == var.service
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.service,
+      opslevel_service_repository.test.service,
+    )
+  }
+
+  assert {
+    condition     = opslevel_service_repository.test.service_alias == null
+    error_message = var.error_expected_null_field
+  }
+
+}
+
+run "resource_service_repository_create_with_aliases" {
+
+  variables {
+    base_directory   = "base/path"
+    name             = "TF test service repository"
+    repository       = null
+    repository_alias = run.from_repository_module.first_repository.alias
+    service          = null
+    service_alias    = run.from_service_module.first_service.aliases[0]
+  }
+
+  module {
+    source = "./service_repository"
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.base_directory == var.base_directory
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.base_directory,
+      opslevel_service_repository.test.base_directory,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.name == var.name
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.name,
+      opslevel_service_repository.test.name,
+    )
+  }
+
+  assert {
+    condition     = opslevel_service_repository.test.repository == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.repository_alias == var.repository_alias
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.repository_alias,
+      opslevel_service_repository.test.repository_alias,
+    )
+  }
+
+  assert {
+    condition     = opslevel_service_repository.test.service == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_service_repository.test.service_alias == var.service_alias
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.service_alias,
+      opslevel_service_repository.test.service_alias,
+    )
+  }
+
+}
+
+run "resource_service_repository_update_unset_optional_fields" {
+
+  variables {
+    base_directory   = null
+    name             = "TF test service repository"
+    repository       = null
+    repository_alias = run.from_repository_module.first_repository.alias
+    service          = null
+    service_alias    = run.from_service_module.first_service.aliases[0]
+  }
+
+  module {
+    source = "./service_repository"
+  }
+
+  assert {
+    condition     = opslevel_service_repository.test.base_directory == null
+    error_message = var.error_expected_null_field
+  }
+
+  # TODO: unable to unset 'name' field for now
+  # assert {
+  #   condition     = opslevel_service_repository.test.name == null
+  #   error_message = var.error_expected_null_field
+  # }
+
+}

--- a/tests/remote/service_repository/main.tf
+++ b/tests/remote/service_repository/main.tf
@@ -1,0 +1,8 @@
+resource "opslevel_service_repository" "test" {
+  base_directory   = var.base_directory
+  name             = var.name
+  repository       = var.repository
+  repository_alias = var.repository_alias
+  service          = var.service
+  service_alias    = var.service_alias
+}

--- a/tests/remote/service_repository/variables.tf
+++ b/tests/remote/service_repository/variables.tf
@@ -1,0 +1,36 @@
+variable "base_directory" {
+  type        = string
+  description = "The directory in the repository containing opslevel.yml."
+  default     = null
+}
+
+variable "name" {
+  type        = string
+  description = "The name displayed in the UI for the service repository."
+  default     = null
+}
+
+variable "repository" {
+  type        = string
+  description = "The id of the repository that this will be added to."
+  default     = null
+}
+
+variable "repository_alias" {
+  type        = string
+  description = "The alias of the repository that this will be added to."
+  default     = null
+}
+
+variable "service" {
+  type        = string
+  description = "The id of the service that this will be added to."
+  default     = null
+}
+
+variable "service_alias" {
+  type        = string
+  description = "The alias of the service that this will be added to."
+  default     = null
+}
+

--- a/tests/remote/service_tag.tftest.hcl
+++ b/tests/remote/service_tag.tftest.hcl
@@ -1,0 +1,133 @@
+variables {
+  resource_name = "opslevel_service_tag"
+
+  # required fields
+  key   = "test-service-tag-key"
+  value = "test-service-tag-key"
+
+  # optional fields
+  service       = null
+  service_alias = null
+}
+
+run "from_service_module" {
+  command = plan
+
+  variables {
+    name = ""
+  }
+
+  module {
+    source = "./service"
+  }
+}
+
+run "resource_service_tag_create_with_service_id" {
+
+  variables {
+    key           = var.key
+    service       = run.from_service_module.first_service.id
+    service_alias = null
+    value         = var.value
+  }
+
+  module {
+    source = "./service_tag"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_service_tag.test.key),
+      can(opslevel_service_tag.test.id),
+      can(opslevel_service_tag.test.service),
+      can(opslevel_service_tag.test.service_alias),
+      can(opslevel_service_tag.test.value),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition     = startswith(opslevel_service_tag.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_service_tag.test.key == var.key
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.key,
+      opslevel_service_tag.test.key,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_tag.test.service == var.service
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.service,
+      opslevel_service_tag.test.service,
+    )
+  }
+
+  assert {
+    condition     = opslevel_service_tag.test.service_alias == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_service_tag.test.value == var.value
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.value,
+      opslevel_service_tag.test.value,
+    )
+  }
+
+}
+
+run "resource_service_tag_create_with_service_alias" {
+
+  variables {
+    key           = var.key
+    service       = null
+    service_alias = run.from_service_module.first_service.aliases[0]
+    value         = var.value
+  }
+
+  module {
+    source = "./service_tag"
+  }
+
+  assert {
+    condition = opslevel_service_tag.test.key == var.key
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.key,
+      opslevel_service_tag.test.key,
+    )
+  }
+
+  assert {
+    condition     = opslevel_service_tag.test.service == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_service_tag.test.service_alias == var.service_alias
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.service_alias,
+      opslevel_service_tag.test.service_alias,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_tag.test.value == var.value
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.value,
+      opslevel_service_tag.test.value,
+    )
+  }
+
+}

--- a/tests/remote/service_tag/main.tf
+++ b/tests/remote/service_tag/main.tf
@@ -1,0 +1,6 @@
+resource "opslevel_service_tag" "test" {
+  key           = var.key
+  value         = var.value
+  service       = var.service
+  service_alias = var.service_alias
+}

--- a/tests/remote/service_tag/variables.tf
+++ b/tests/remote/service_tag/variables.tf
@@ -1,0 +1,21 @@
+variable "key" {
+  type        = string
+  description = "The tag's key."
+}
+
+variable "service" {
+  type        = string
+  description = "The id of the service that this will be added to."
+  default     = null
+}
+
+variable "service_alias" {
+  type        = string
+  description = "The alias of the service that this will be added to."
+  default     = null
+}
+
+variable "value" {
+  type        = string
+  description = "The tag's value."
+}


### PR DESCRIPTION
Resolves # [Add missing tests](https://github.com/OpsLevel/team-platform/issues/445) (partially)

### Problem

Add integration tests for:
- [x] opslevel_service_dependency
- [x] opslevel_service_repository
- [x] opslevel_service_tag

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
