### PR TITLE
fix updated_at field in opslevel_secret, add tests

### DIFF
--- a/.changes/unreleased/Bugfix-20240826-143918.yaml
+++ b/.changes/unreleased/Bugfix-20240826-143918.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: correctly set "updated_at" field in opslevel_secret
+time: 2024-08-26T14:39:18.036791-05:00

--- a/opslevel/resource_opslevel_secrets.go
+++ b/opslevel/resource_opslevel_secrets.go
@@ -45,6 +45,7 @@ func NewSecretResourceModel(secret opslevel.Secret, ownerIdentifier, sensitiveVa
 		CreatedAt: ComputedStringValue(secret.Timestamps.CreatedAt.Local().Format(time.RFC850)),
 		Id:        ComputedStringValue(string(secret.ID)),
 		Owner:     RequiredStringValue(ownerIdentifier),
+		UpdatedAt: ComputedStringValue(secret.Timestamps.UpdatedAt.Local().Format(time.RFC850)),
 		Value:     RequiredStringValue(sensitiveValue),
 	}
 }

--- a/tests/remote/secret.tftest.hcl
+++ b/tests/remote/secret.tftest.hcl
@@ -1,0 +1,114 @@
+variables {
+  resource_name = "opslevel_secret"
+
+  # required fields
+  alias = "tf_test_secret"
+  owner = null
+  value = "TFTestSecretValue"
+
+  # optional fields - none
+}
+
+
+run "from_team_module" {
+  command = plan
+
+  variables {
+    aliases          = null
+    name             = ""
+    parent           = null
+    responsibilities = null
+  }
+
+  module {
+    source = "./team"
+  }
+}
+
+run "resource_secret_create" {
+
+  variables {
+    alias = var.alias
+    owner = run.from_team_module.first_team.id
+    value = var.value
+  }
+
+  module {
+    source = "./secret"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_secret.test.alias),
+      can(opslevel_secret.test.created_at),
+      can(opslevel_secret.test.id),
+      can(opslevel_secret.test.owner),
+      can(opslevel_secret.test.updated_at),
+      can(opslevel_secret.test.value),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_secret.test.alias == var.alias
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.alias,
+      opslevel_secret.test.alias,
+    )
+  }
+
+  assert {
+    condition     = opslevel_secret.test.created_at != null && opslevel_secret.test.updated_at != null
+    error_message = "expected 'created_at' to be set"
+  }
+
+  assert {
+    condition     = opslevel_secret.test.created_at == opslevel_secret.test.updated_at
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition     = startswith(opslevel_secret.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_secret.test.owner == var.owner
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.owner,
+      opslevel_secret.test.owner,
+    )
+  }
+
+  assert {
+    condition     = opslevel_secret.test.value == var.value
+    error_message = "expected different secret value, not printing sensitive value"
+  }
+
+}
+
+run "resource_secret_update" {
+
+  variables {
+    alias = var.alias
+    owner = run.from_team_module.first_team.id
+    value = upper(var.value)
+  }
+
+  module {
+    source = "./secret"
+  }
+
+  assert {
+    condition     = opslevel_secret.test.created_at != opslevel_secret.test.updated_at
+    error_message = "expected 'created_at' and 'updated_at' to be different"
+  }
+
+  assert {
+    condition     = opslevel_secret.test.value == upper(var.value)
+    error_message = "expected different secret value, not printing sensitive value"
+  }
+
+}

--- a/tests/remote/secret/main.tf
+++ b/tests/remote/secret/main.tf
@@ -1,0 +1,5 @@
+resource "opslevel_secret" "test" {
+  alias = var.alias
+  owner = var.owner
+  value = var.value
+}

--- a/tests/remote/secret/variables.tf
+++ b/tests/remote/secret/variables.tf
@@ -1,0 +1,15 @@
+variable "alias" {
+  type        = string
+  description = "The alias for this secret. Can only be set at create time."
+}
+
+variable "owner" {
+  type        = string
+  description = "The owner of this secret."
+}
+
+variable "value" {
+  type        = string
+  description = "A sensitive value"
+  sensitive   = true
+}


### PR DESCRIPTION
Resolves # (part of) [Add Integration Tests](https://github.com/OpsLevel/team-platform/issues/445)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
