### PR TITLE
opslevel_property_assignment tests added

### DIFF
--- a/tests/remote/property_assignment.tftest.hcl
+++ b/tests/remote/property_assignment.tftest.hcl
@@ -1,0 +1,114 @@
+variables {
+  resource_name = "opslevel_property_assignment"
+
+  # required fields
+  definition = null
+  owner      = null
+
+  # optional fields
+  value = jsonencode(true)
+}
+
+run "from_property_definition_module" {
+  command = plan
+
+  variables {
+    allowed_in_config_files = false
+    name                    = ""
+    schema                  = jsonencode(null)
+    property_display_status = "visible"
+  }
+
+  module {
+    source = "./property_definition"
+  }
+}
+
+run "from_service_module" {
+  command = plan
+
+  variables {
+    name = ""
+  }
+
+  module {
+    source = "./service"
+  }
+}
+
+run "resource_property_assignment_create_with_all_fields" {
+
+  variables {
+    definition = run.from_property_definition_module.first_property_definitions.id
+    owner      = run.from_service_module.first_service.id
+    value      = var.value
+  }
+
+  module {
+    source = "./property_assignment"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_property_assignment.test.definition),
+      can(opslevel_property_assignment.test.id),
+      can(opslevel_property_assignment.test.locked),
+      can(opslevel_property_assignment.test.owner),
+      can(opslevel_property_assignment.test.value),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_property_assignment.test.definition == var.definition
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.definition,
+      opslevel_property_assignment.test.definition,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_property_assignment.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_property_assignment.test.owner == var.owner
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.owner,
+      opslevel_property_assignment.test.owner,
+    )
+  }
+
+  assert {
+    condition = opslevel_property_assignment.test.value == var.value
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.value,
+      opslevel_property_assignment.test.value,
+    )
+  }
+
+}
+
+# BUG: unable to unset 'value' field
+# run "resource_property_assignment_update_unset_optional_fields" {
+
+#   variables {
+#     definition = run.from_property_definition_module.first_property_definitions.id
+#     owner      = run.from_service_module.first_service.id
+#     value      = null
+#   }
+
+#   module {
+#     source = "./property_assignment"
+#   }
+
+#   assert {
+#     condition     = opslevel_property_assignment.test.value == null
+#     error_message = var.error_expected_null_field
+#   }
+
+# }

--- a/tests/remote/property_assignment.tftest.hcl
+++ b/tests/remote/property_assignment.tftest.hcl
@@ -93,7 +93,7 @@ run "resource_property_assignment_create_with_all_fields" {
 
 }
 
-# BUG: unable to unset 'value' field
+# BUG: unable to unset 'value' field - see [issue](https://github.com/OpsLevel/team-platform/issues/452)
 # run "resource_property_assignment_update_unset_optional_fields" {
 
 #   variables {

--- a/tests/remote/property_assignment/main.tf
+++ b/tests/remote/property_assignment/main.tf
@@ -1,0 +1,5 @@
+resource "opslevel_property_assignment" "test" {
+  definition = var.definition
+  owner      = var.owner
+  value      = var.value
+}

--- a/tests/remote/property_assignment/variables.tf
+++ b/tests/remote/property_assignment/variables.tf
@@ -1,0 +1,15 @@
+variable "definition" {
+  type        = string
+  description = "The custom property definition's ID or alias."
+}
+
+variable "owner" {
+  type        = string
+  description = "The ID or alias of the entity (currently only supports service) that the property has been assigned to."
+}
+
+variable "value" {
+  type        = string
+  description = "The value of the custom property (must be a valid JSON value or null or object)."
+  default     = null
+}

--- a/tests/remote/property_definition/outputs.tf
+++ b/tests/remote/property_definition/outputs.tf
@@ -1,0 +1,3 @@
+output "first_property_definitions" {
+  value = data.opslevel_property_definition.first_property_definition_by_id
+}

--- a/tests/remote/property_definition/variables.tf
+++ b/tests/remote/property_definition/variables.tf
@@ -6,6 +6,7 @@ variable "allowed_in_config_files" {
 variable "description" {
   type        = string
   description = "The description of the property definition."
+  default     = null
 }
 
 variable "name" {
@@ -16,22 +17,9 @@ variable "name" {
 variable "property_display_status" {
   type        = string
   description = "The display status of a custom property on service pages."
-
-  validation {
-    condition = var.property_display_status == null ? true : contains([
-      "hidden",
-      "visible",
-    ], var.property_display_status)
-    error_message = "expected property_display_status to be 'hidden' or 'visible'"
-  }
 }
 
 variable "schema" {
   type        = string
   description = "The schema of the property definition."
-
-  validation {
-    condition     = var.schema == null ? true : can(jsondecode(var.schema))
-    error_message = "expected schema to be valid JSON"
-  }
 }


### PR DESCRIPTION
Resolves # (part of) [Add Integration Tests](https://github.com/OpsLevel/team-platform/issues/445)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
