### PR TITLE
predicate block validation no longer fails when value needs computing

### DIFF
--- a/.changes/unreleased/Bugfix-20240827-152208.yaml
+++ b/.changes/unreleased/Bugfix-20240827-152208.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: predicate block validation no longer fails when value needs computing
+time: 2024-08-27T15:22:08.243516-05:00

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -83,7 +83,7 @@ func NewFilterPredicateModel(filterPredicate *opslevel.FilterPredicate) FilterPr
 func (fp FilterPredicateModel) Validate() error {
 	// Key and Value are required fields, but may be unknown at validation time
 	// Creating multiple predicates with a 'for_each' is one example
-	if fp.Key.IsUnknown() || fp.Value.IsUnknown() {
+	if fp.Key.IsUnknown() || fp.KeyData.IsUnknown() || fp.Type.IsUnknown() || fp.Value.IsUnknown() {
 		return nil
 	}
 	opslevelFilterPredicate := opslevel.FilterPredicate{


### PR DESCRIPTION
Resolves # [opslevel_filter resource with properties FilterPredicate bug](https://github.com/OpsLevel/terraform-provider-opslevel/issues/433)

### Problem

The `key_data` and `value` fields in `predicate` blocks fail validation when the value is not known at plan time.
For example, if the value needs computing (from state)

### Solution

Ease validation logic to not raise errors when these values are specifically "unknown"

### Given this Terraform config file
```tf
resource "opslevel_property_definition" "test" { ... }

resource "opslevel_filter" "test" {
  name = "Test Filter"

  predicate {
    key      = "properties"
    type     = "satisfies_jq_expression"
    key_data = opslevel_property_definition.test.id
    value    = ". == ${jsonencode("workload")}"
  }
}
```

### The `terraform validate` output
```bash
Success! The configuration is valid.
```

### Checklist

- [X] I have run this code, and it appears to resolve the stated issue.
- [X] This PR does not reduce total test coverage
- [X] This PR has no user interface changes or has already received approval from product management to change the interface.
- [X] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
