### PR TITLE
test opslevel_tag resource

### DIFF
--- a/tests/remote/service_tag.tftest.hcl
+++ b/tests/remote/service_tag.tftest.hcl
@@ -3,7 +3,7 @@ variables {
 
   # required fields
   key   = "test-service-tag-key"
-  value = "test-service-tag-key"
+  value = "test-service-tag-value"
 
   # optional fields
   service       = null

--- a/tests/remote/tag.tftest.hcl
+++ b/tests/remote/tag.tftest.hcl
@@ -1,0 +1,127 @@
+variables {
+  resource_name = "opslevel_tag"
+
+  # required fields
+  key                 = "test-tag-key"
+  value               = "test-tag-value"
+  resource_identifier = null
+  resource_type       = "Team"
+
+  # optional fields - none
+}
+
+run "from_team_module" {
+  command = plan
+
+  variables {
+    aliases          = null
+    name             = ""
+    parent           = null
+    responsibilities = null
+  }
+
+  module {
+    source = "./team"
+  }
+}
+
+run "resource_tag_create_with_all_fields" {
+
+  variables {
+    key                 = var.key
+    resource_identifier = run.from_team_module.first_team.id
+    resource_type       = var.resource_type
+    value               = var.value
+  }
+
+  module {
+    source = "./tag"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_tag.test.key),
+      can(opslevel_tag.test.id),
+      can(opslevel_tag.test.resource_identifier),
+      can(opslevel_tag.test.resource_type),
+      can(opslevel_tag.test.value),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition     = startswith(opslevel_tag.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_tag.test.key == var.key
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.key,
+      opslevel_tag.test.key,
+    )
+  }
+
+  assert {
+    condition = opslevel_tag.test.resource_identifier == var.resource_identifier
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.resource_identifier,
+      opslevel_tag.test.resource_identifier,
+    )
+  }
+
+  assert {
+    condition = opslevel_tag.test.resource_type == var.resource_type
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.resource_type,
+      opslevel_tag.test.resource_type,
+    )
+  }
+
+  assert {
+    condition = opslevel_tag.test.value == var.value
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.value,
+      opslevel_tag.test.value,
+    )
+  }
+
+}
+
+# BUG: https://github.com/OpsLevel/team-platform/issues/460
+# run "resource_tag_update_key_and_value" {
+
+#   variables {
+#     key                 = "${var.key}-updated"
+#     resource_identifier = run.from_team_module.first_team.id
+#     resource_type       = var.resource_type
+#     value               = "${var.value}-updated"
+#   }
+
+#   module {
+#     source = "./tag"
+#   }
+
+#   assert {
+#     condition = opslevel_tag.test.key == var.key
+#     error_message = format(
+#       "expected '%v' but got '%v'",
+#       var.key,
+#       opslevel_tag.test.key,
+#     )
+#   }
+
+#   assert {
+#     condition = opslevel_tag.test.value == var.value
+#     error_message = format(
+#       "expected '%v' but got '%v'",
+#       var.value,
+#       opslevel_tag.test.value,
+#     )
+#   }
+
+# }

--- a/tests/remote/tag/main.tf
+++ b/tests/remote/tag/main.tf
@@ -1,0 +1,6 @@
+resource "opslevel_tag" "test" {
+  key                 = var.key
+  resource_identifier = var.resource_identifier
+  resource_type       = var.resource_type
+  value               = var.value
+}

--- a/tests/remote/tag/variables.tf
+++ b/tests/remote/tag/variables.tf
@@ -1,0 +1,19 @@
+variable "key" {
+  type        = string
+  description = "The key of the tag."
+}
+
+variable "resource_identifier" {
+  type        = string
+  description = "The id or human-friendly, unique identifier of the resource this tag belongs to."
+}
+
+variable "resource_type" {
+  type        = string
+  description = "The resource type that the tag applies to."
+}
+
+variable "value" {
+  type        = string
+  description = "The value of the tag."
+}


### PR DESCRIPTION
Resolves # [Add missing Terraform integration tests for opslevel_tag](https://github.com/OpsLevel/team-platform/issues/458)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
