### PR TITLE
test opslevel_check_package_version resource

### DIFF
--- a/.changes/unreleased/Bugfix-20240829-100657.yaml
+++ b/.changes/unreleased/Bugfix-20240829-100657.yaml
@@ -1,3 +1,3 @@
 kind: Bugfix
-body: fix variable usage on "missing_package_result" field in "opslevel_check_package_version"
+body: fix to allow using terraform variables on "missing_package_result" field in "opslevel_check_package_version"
 time: 2024-08-29T10:06:57.811152-05:00

--- a/.changes/unreleased/Bugfix-20240829-100657.yaml
+++ b/.changes/unreleased/Bugfix-20240829-100657.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix variable usage on "missing_package_result" field in "opslevel_check_package_version"
+time: 2024-08-29T10:06:57.811152-05:00

--- a/examples/resources/opslevel_check_package_version/resource.tf
+++ b/examples/resources/opslevel_check_package_version/resource.tf
@@ -56,7 +56,9 @@ resource "opslevel_check_package_version" "example3" {
   name     = "foo"
   enabled  = true
   category = data.opslevel_rubric_category.security.id
+  filter   = data.opslevel_filter.tier1.id
   level    = data.opslevel_rubric_level.bronze.id
+  owner    = data.opslevel_team.devs.id
   notes    = "Optional additional info on why this check is run or how to fix it"
 
   package_constraint     = "matches_version"

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -170,10 +170,10 @@ func (r *CheckPackageVersionResource) ValidateConfig(ctx context.Context, req re
 			}
 		}
 	} else {
-		if !configModel.MissingPackageResult.IsNull() {
+		if !configModel.MissingPackageResult.IsUnknown() && !configModel.MissingPackageResult.IsNull() {
 			resp.Diagnostics.AddError("missing_package_result", "missing_package_result is only valid when package_constraint is 'matches_version'")
 		}
-		if !configModel.VersionConstraintPredicate.IsNull() {
+		if !configModel.VersionConstraintPredicate.IsUnknown() && !configModel.VersionConstraintPredicate.IsNull() {
 			resp.Diagnostics.AddError("version_constraint_predicate", "version_constraint_predicate is only valid when package_constraint is 'matches_version'")
 		}
 	}

--- a/tests/remote/check_package_version.tftest.hcl
+++ b/tests/remote/check_package_version.tftest.hcl
@@ -1,0 +1,261 @@
+variables {
+  resource_name = "opslevel_check_package_version"
+
+  # -- check_package_version fields --
+  # required fields
+  missing_package_result = "passed"
+  package_constraint     = "matches_version"
+  package_manager        = "docker"
+  package_name           = "foobar"
+
+  # optional fields
+  package_name_is_regex = null
+  version_constraint_predicate = {
+    type  = "does_not_match_regex"
+    value = "^$"
+  }
+
+  # -- check base fields --
+  # required fields
+  category = null
+  level    = null
+  name     = "TF Test Check package_version"
+
+  # optional fields
+  enable_on = null
+  enabled   = true
+  filter    = null
+  notes     = "Notes on package_version check"
+  owner     = null
+}
+
+run "from_filter_get_filter_id" {
+  command = plan
+
+  variables {
+    connective = null
+  }
+
+  module {
+    source = "./filter"
+  }
+}
+
+run "from_rubric_category_get_category_id" {
+  command = plan
+
+  variables {
+    name = ""
+  }
+
+  module {
+    source = "./rubric_category"
+  }
+}
+
+run "from_rubric_level_get_level_id" {
+  command = plan
+
+  variables {
+    description = null
+    index       = null
+    name        = ""
+  }
+
+  module {
+    source = "./rubric_level"
+  }
+}
+
+run "from_team_get_owner_id" {
+  command = plan
+
+  variables {
+    aliases          = null
+    name             = ""
+    parent           = null
+    responsibilities = null
+  }
+
+  module {
+    source = "./team"
+  }
+}
+
+run "resource_check_package_version_create_with_all_fields" {
+
+  variables {
+    category                     = run.from_rubric_category_get_category_id.first_category.id
+    enable_on                    = var.enable_on
+    enabled                      = var.enabled
+    filter                       = run.from_filter_get_filter_id.first_filter.id
+    level                        = run.from_rubric_level_get_level_id.greatest_level.id
+    missing_package_result       = var.missing_package_result
+    name                         = var.name
+    notes                        = var.notes
+    owner                        = run.from_team_get_owner_id.first_team.id
+    package_constraint           = var.package_constraint
+    package_manager              = var.package_manager
+    package_name                 = var.package_name
+    package_name_is_regex        = var.package_name_is_regex
+    version_constraint_predicate = var.version_constraint_predicate
+  }
+
+  module {
+    source = "./check_package_version"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_check_package_version.test.category),
+      can(opslevel_check_package_version.test.description),
+      can(opslevel_check_package_version.test.enable_on),
+      can(opslevel_check_package_version.test.enabled),
+      can(opslevel_check_package_version.test.filter),
+      can(opslevel_check_package_version.test.id),
+      can(opslevel_check_package_version.test.level),
+      can(opslevel_check_package_version.test.missing_package_result),
+      can(opslevel_check_package_version.test.name),
+      can(opslevel_check_package_version.test.notes),
+      can(opslevel_check_package_version.test.owner),
+      can(opslevel_check_package_version.test.package_constraint),
+      can(opslevel_check_package_version.test.package_manager),
+      can(opslevel_check_package_version.test.package_name),
+      can(opslevel_check_package_version.test.package_name_is_regex),
+      can(opslevel_check_package_version.test.version_constraint_predicate),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.category == var.category
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.category,
+      opslevel_check_package_version.test.category,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.enable_on == var.enable_on
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.enable_on,
+      opslevel_check_package_version.test.enable_on,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.enabled == var.enabled
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.enabled,
+      opslevel_check_package_version.test.enabled,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.filter == run.from_filter_get_filter_id.first_filter.id
+    error_message = format(
+      "expected '%v' but got '%v'",
+      run.from_filter_get_filter_id.first_filter.id,
+      opslevel_check_package_version.test.filter,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_check_package_version.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.level == var.level
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.level,
+      opslevel_check_package_version.test.level,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.missing_package_result == var.missing_package_result
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.missing_package_result,
+      opslevel_check_package_version.test.missing_package_result,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.name == var.name
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.name,
+      opslevel_check_package_version.test.name,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.notes == var.notes
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.notes,
+      opslevel_check_package_version.test.notes,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.owner == run.from_team_get_owner_id.first_team.id
+    error_message = format(
+      "expected '%v' but got '%v'",
+      run.from_team_get_owner_id.first_team.id,
+      opslevel_check_package_version.test.owner,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.package_constraint == var.package_constraint
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.package_constraint,
+      opslevel_check_package_version.test.package_constraint,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.package_manager == var.package_manager
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.package_manager,
+      opslevel_check_package_version.test.package_manager,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.package_name == var.package_name
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.package_name,
+      opslevel_check_package_version.test.package_name,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.package_name_is_regex == var.package_name_is_regex
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.package_name_is_regex,
+      opslevel_check_package_version.test.package_name_is_regex,
+    )
+  }
+
+  assert {
+    condition = opslevel_check_package_version.test.version_constraint_predicate == var.version_constraint_predicate
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.version_constraint_predicate,
+      opslevel_check_package_version.test.version_constraint_predicate,
+    )
+  }
+
+}

--- a/tests/remote/check_package_version.tftest.hcl
+++ b/tests/remote/check_package_version.tftest.hcl
@@ -155,10 +155,10 @@ run "resource_check_package_version_create_with_all_fields" {
   }
 
   assert {
-    condition = opslevel_check_package_version.test.filter == run.from_filter_get_filter_id.first_filter.id
+    condition = opslevel_check_package_version.test.filter == var.filter
     error_message = format(
       "expected '%v' but got '%v'",
-      run.from_filter_get_filter_id.first_filter.id,
+      var.filter,
       opslevel_check_package_version.test.filter,
     )
   }
@@ -205,10 +205,10 @@ run "resource_check_package_version_create_with_all_fields" {
   }
 
   assert {
-    condition = opslevel_check_package_version.test.owner == run.from_team_get_owner_id.first_team.id
+    condition = opslevel_check_package_version.test.owner == var.owner
     error_message = format(
       "expected '%v' but got '%v'",
-      run.from_team_get_owner_id.first_team.id,
+      var.owner,
       opslevel_check_package_version.test.owner,
     )
   }

--- a/tests/remote/check_package_version/base_variables.tf
+++ b/tests/remote/check_package_version/base_variables.tf
@@ -1,0 +1,1 @@
+../check_base/base_variables.tf

--- a/tests/remote/check_package_version/main.tf
+++ b/tests/remote/check_package_version/main.tf
@@ -1,0 +1,17 @@
+resource "opslevel_check_package_version" "test" {
+  category  = var.category
+  filter    = var.filter
+  enable_on = var.enable_on
+  enabled   = var.enabled
+  level     = var.level
+  name      = var.name
+  notes     = var.notes
+  owner     = var.owner
+
+  missing_package_result       = var.missing_package_result
+  package_constraint           = var.package_constraint
+  package_manager              = var.package_manager
+  package_name                 = var.package_name
+  package_name_is_regex        = var.package_name_is_regex
+  version_constraint_predicate = var.version_constraint_predicate
+}

--- a/tests/remote/check_package_version/variables.tf
+++ b/tests/remote/check_package_version/variables.tf
@@ -1,0 +1,35 @@
+variable "missing_package_result" {
+  type        = string
+  description = "The check result if the package isn't being used by a service. (Optional.)"
+  default     = null
+}
+
+variable "package_constraint" {
+  type        = string
+  description = "The package constraint the service is to be checked for. (Required.)"
+}
+
+variable "package_manager" {
+  type        = string
+  description = "The package manager (ecosystem) this package relates to. (Required.)"
+}
+
+variable "package_name" {
+  type        = string
+  description = "The name of the package to be checked. (Required.)"
+}
+
+variable "package_name_is_regex" {
+  type        = bool
+  description = "Whether or not the value in the package name field is a regular expression. (Optional.)"
+  default     = null
+}
+
+variable "version_constraint_predicate" {
+  type = object({
+    type  = string
+    value = optional(string)
+  })
+  description = "A condition that should be satisfied."
+  default     = null
+}


### PR DESCRIPTION
Resolves # [Add missing Terraform integration tests for opslevel_check_package_version](https://github.com/OpsLevel/team-platform/issues/455)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
