### PR TITLE
test opslevel_service_tool resource

### DIFF
--- a/tests/remote/service_tool.tftest.hcl
+++ b/tests/remote/service_tool.tftest.hcl
@@ -1,0 +1,173 @@
+variables {
+  resource_name = "opslevel_service_tool"
+
+  # required fields
+  category = "observability"
+  name     = "TF Test Service Tool"
+  url      = "https://example.com"
+
+  # optional fields
+  environment   = "production"
+  service       = null
+  service_alias = null
+}
+
+run "from_service_module" {
+  command = plan
+
+  variables {
+    name = ""
+  }
+
+  module {
+    source = "./service"
+  }
+}
+
+run "resource_service_tool_create_with_service_id" {
+
+  variables {
+    category      = var.category
+    environment   = var.environment
+    name          = var.name
+    service       = run.from_service_module.first_service.id
+    service_alias = null
+    url           = var.url
+  }
+
+  module {
+    source = "./service_tool"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_service_tool.test.category),
+      can(opslevel_service_tool.test.environment),
+      can(opslevel_service_tool.test.id),
+      can(opslevel_service_tool.test.name),
+      can(opslevel_service_tool.test.service),
+      can(opslevel_service_tool.test.service_alias),
+      can(opslevel_service_tool.test.url),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.category == var.category
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.category,
+      opslevel_service_tool.test.category,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.environment == var.environment
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.environment,
+      opslevel_service_tool.test.environment,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_service_tool.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.name == var.name
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.name,
+      opslevel_service_tool.test.name,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.service == var.service
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.service,
+      opslevel_service_tool.test.service,
+    )
+  }
+
+  assert {
+    condition     = opslevel_service_tool.test.service_alias == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.url == var.url
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.url,
+      opslevel_service_tool.test.url,
+    )
+  }
+
+}
+
+run "resource_service_tool_create_with_service_alias" {
+
+  variables {
+    category      = var.category
+    environment   = var.environment
+    name          = var.name
+    service       = null
+    service_alias = run.from_service_module.first_service.aliases[0]
+    url           = var.url
+  }
+
+  module {
+    source = "./service_tool"
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.category == var.category
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.category,
+      opslevel_service_tool.test.category,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.environment == var.environment
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.environment,
+      opslevel_service_tool.test.environment,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_service_tool.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition     = opslevel_service_tool.test.service == null
+    error_message = var.error_expected_null_field
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.service_alias == var.service_alias
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.service_alias,
+      opslevel_service_tool.test.service_alias,
+    )
+  }
+
+  assert {
+    condition = opslevel_service_tool.test.url == var.url
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.url,
+      opslevel_service_tool.test.url,
+    )
+  }
+
+}

--- a/tests/remote/service_tool/main.tf
+++ b/tests/remote/service_tool/main.tf
@@ -1,0 +1,8 @@
+resource "opslevel_service_tool" "test" {
+  category      = var.category
+  environment   = var.environment
+  name          = var.name
+  service       = var.service
+  service_alias = var.service_alias
+  url           = var.url
+}

--- a/tests/remote/service_tool/variables.tf
+++ b/tests/remote/service_tool/variables.tf
@@ -1,0 +1,32 @@
+variable "category" {
+  type        = string
+  description = "The category that the tool belongs to."
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment that the tool belongs to."
+  default     = null
+}
+
+variable "name" {
+  type        = string
+  description = "The display name of the tool."
+}
+
+variable "service" {
+  type        = string
+  description = "The id of the service that this will be added to."
+  default     = null
+}
+
+variable "service_alias" {
+  type        = string
+  description = "The alias of the service that this will be added to."
+  default     = null
+}
+
+variable "url" {
+  type        = string
+  description = "The URL of the tool."
+}


### PR DESCRIPTION
Resolves # [Add missing Terraform integration tests for opslevel_service_tool](https://github.com/OpsLevel/team-platform/issues/457)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
