### PR TITLE
test opslevel_infrastructure resource

### DIFF
--- a/tests/remote/infrastructure.tftest.hcl
+++ b/tests/remote/infrastructure.tftest.hcl
@@ -1,0 +1,125 @@
+variables {
+  resource_name = "opslevel_infrastructure"
+
+  # required fields
+  data = jsonencode({
+    name                = "big-query"
+    external_id         = "example_2_1234"
+    zone                = "us-east-1"
+    engine              = "bigquery"
+    engine_version      = "1.28.0"
+    endpoint            = "https://console.cloud.google.com/..."
+    replica             = false
+    publicly_accessible = false
+    storage_size = {
+      unit  = "GB"
+      value = 700
+    }
+    storage_type = "gp3"
+    storage_iops = {
+      unit  = "per second"
+      value = 12000
+    }
+  })
+  owner  = null
+  schema = "Database"
+
+  # optional fields
+  aliases = ["foo", "bar", "baz"]
+  provider_data = {
+    account = "TF test acct"
+    name    = "google cloud"
+    type    = "BigQuery"
+    url     = "https://console.cloud.google.com/..."
+  }
+}
+
+run "from_team_module" {
+  command = plan
+
+  variables {
+    name = ""
+  }
+
+  module {
+    source = "./team"
+  }
+}
+
+run "resource_infrastructure_create_with_all_fields" {
+
+  variables {
+    aliases       = var.aliases
+    data          = var.data
+    owner         = run.from_team_module.first_team.id
+    provider_data = var.provider_data
+    schema        = var.schema
+  }
+
+  module {
+    source = "./infrastructure"
+  }
+
+  assert {
+    condition = alltrue([
+      can(opslevel_infrastructure.test.aliases),
+      can(opslevel_infrastructure.test.data),
+      can(opslevel_infrastructure.test.id),
+      can(opslevel_infrastructure.test.owner),
+      can(opslevel_infrastructure.test.provider_data),
+      can(opslevel_infrastructure.test.schema),
+    ])
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_infrastructure.test.aliases == var.aliases
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.aliases,
+      opslevel_infrastructure.test.aliases,
+    )
+  }
+
+  assert {
+    condition = opslevel_infrastructure.test.data == var.data
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.data,
+      opslevel_infrastructure.test.data,
+    )
+  }
+
+  assert {
+    condition     = startswith(opslevel_infrastructure.test.id, var.id_prefix)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
+  }
+
+  assert {
+    condition = opslevel_infrastructure.test.owner == var.owner
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.owner,
+      opslevel_infrastructure.test.owner,
+    )
+  }
+
+  assert {
+    condition = opslevel_infrastructure.test.provider_data == var.provider_data
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.provider_data,
+      opslevel_infrastructure.test.provider_data,
+    )
+  }
+
+  assert {
+    condition = opslevel_infrastructure.test.schema == var.schema
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.schema,
+      opslevel_infrastructure.test.schema,
+    )
+  }
+
+}

--- a/tests/remote/infrastructure/main.tf
+++ b/tests/remote/infrastructure/main.tf
@@ -1,0 +1,7 @@
+resource "opslevel_infrastructure" "test" {
+  aliases       = var.aliases
+  data          = var.data
+  owner         = var.owner
+  provider_data = var.provider_data
+  schema        = var.schema
+}

--- a/tests/remote/infrastructure/variables.tf
+++ b/tests/remote/infrastructure/variables.tf
@@ -1,0 +1,31 @@
+variable "aliases" {
+  type        = set(string)
+  description = "The aliases for the infrastructure resource."
+  default     = null
+}
+
+variable "data" {
+  type        = string
+  description = "The data of the infrastructure resource in JSON format."
+}
+
+variable "owner" {
+  type        = string
+  description = "The id of the team that owns the infrastructure resource. Does not support aliases!"
+}
+
+variable "provider_data" {
+  type = object({
+    account = string
+    name    = optional(string)
+    type    = optional(string)
+    url     = optional(string)
+  })
+  description = "The provider specific data for the infrastructure resource."
+  default     = null
+}
+
+variable "schema" {
+  type        = string
+  description = "The schema of the infrastructure resource that determines its data specification."
+}


### PR DESCRIPTION
Resolves # [Add missing Terraform integration tests for opslevel_infrastructure](https://github.com/OpsLevel/team-platform/issues/456)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
