### PR TITLE
validate against ending slash on base_directory field in opslevel_service_repository

### DIFF
--- a/.changes/unreleased/Bugfix-20240830-094953.yaml
+++ b/.changes/unreleased/Bugfix-20240830-094953.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: correctly reject ending slash on base_directory field in opslevel_service_repository
+time: 2024-08-30T09:49:53.207297-05:00

--- a/examples/resources/opslevel_service_repository/resource.tf
+++ b/examples/resources/opslevel_service_repository/resource.tf
@@ -11,7 +11,7 @@ resource "opslevel_service_repository" "foo" {
   repository = data.opslevel_repository.foo.id
 
   name           = "Foo"
-  base_directory = "example/"
+  base_directory = "example"
 }
 
 resource "opslevel_service_repository" "bar" {
@@ -19,5 +19,5 @@ resource "opslevel_service_repository" "bar" {
   repository_alias = "github.com:example/bar"
 
   name           = "Bar"
-  base_directory = "example/subdir/"
+  base_directory = "example/subdir"
 }

--- a/opslevel/resource_opslevel_service_repository.go
+++ b/opslevel/resource_opslevel_service_repository.go
@@ -78,8 +78,8 @@ func (r *ServiceRepositoryResource) Schema(ctx context.Context, req resource.Sch
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[^\/].*`),
-						"path must not start with '/'",
+						regexp.MustCompile(`^[^\/].*[^\/]$`),
+						"path must not start or end with '/'",
 					),
 				},
 			},


### PR DESCRIPTION
Resolves #466 

### Problem

API truncates trailing slash of value set in `base_directory` field of `opslevel_service_repository`

### Solution

Add validation logic that prohibits a trailing slash on this field

### Given this Terraform config file (works - no trailing slash)
```tf
resource "opslevel_service_repository" "foo" {
  service    = data.opslevel_service.foo.id
  repository = data.opslevel_repository.foo.id

  name           = "Foo"
  base_directory = "example"
}
```

### The `terraform validate` output
```tf
Success! The configuration is valid.
```

### Given this Terraform config file (fails - has trailing slash)
```tf
resource "opslevel_service_repository" "foo" {
  service    = data.opslevel_service.foo.id
  repository = data.opslevel_repository.foo.id

  name           = "Foo"
  base_directory = "example/"
}
```

### The `terraform validate` output
```tf
Error: Invalid Attribute Value Match

  with opslevel_service_repository.foo,
  on main.tf line 14, in resource "opslevel_service_repository" "foo":
  14:   base_directory = "example/"

Attribute base_directory path must not start or end with '/', got: example/
```

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
