### PR TITLE
fix updating key and value of opslevel_tags

### DIFF
--- a/.changes/unreleased/Bugfix-20240903-092809.yaml
+++ b/.changes/unreleased/Bugfix-20240903-092809.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: allow updating key and value of opslevel_tag resources
+time: 2024-09-03T09:28:09.253798-05:00

--- a/tests/remote/tag.tftest.hcl
+++ b/tests/remote/tag.tftest.hcl
@@ -92,36 +92,35 @@ run "resource_tag_create_with_all_fields" {
 
 }
 
-# BUG: https://github.com/OpsLevel/team-platform/issues/460
-# run "resource_tag_update_key_and_value" {
+run "resource_tag_update_key_and_value" {
 
-#   variables {
-#     key                 = "${var.key}-updated"
-#     resource_identifier = run.from_team_module.first_team.id
-#     resource_type       = var.resource_type
-#     value               = "${var.value}-updated"
-#   }
+  variables {
+    key                 = "${var.key}-updated"
+    resource_identifier = run.from_team_module.first_team.id
+    resource_type       = var.resource_type
+    value               = "${var.value}-updated"
+  }
 
-#   module {
-#     source = "./tag"
-#   }
+  module {
+    source = "./tag"
+  }
 
-#   assert {
-#     condition = opslevel_tag.test.key == var.key
-#     error_message = format(
-#       "expected '%v' but got '%v'",
-#       var.key,
-#       opslevel_tag.test.key,
-#     )
-#   }
+  assert {
+    condition = opslevel_tag.test.key == var.key
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.key,
+      opslevel_tag.test.key,
+    )
+  }
 
-#   assert {
-#     condition = opslevel_tag.test.value == var.value
-#     error_message = format(
-#       "expected '%v' but got '%v'",
-#       var.value,
-#       opslevel_tag.test.value,
-#     )
-#   }
+  assert {
+    condition = opslevel_tag.test.value == var.value
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.value,
+      opslevel_tag.test.value,
+    )
+  }
 
-# }
+}


### PR DESCRIPTION
Resolves [#460](https://github.com/OpsLevel/team-platform/issues/460)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
