### PR TITLE
rename test resources to match upstream changes

### DIFF
--- a/tests/filter.tftest.hcl
+++ b/tests/filter.tftest.hcl
@@ -22,21 +22,21 @@ run "resource_filter_create_with_all_fields" {
 
   assert {
     condition = alltrue([
-      can(opslevel_filter.test.connective),
-      can(opslevel_filter.test.id),
-      can(opslevel_filter.test.name),
-      can(opslevel_filter.test.predicate),
+      can(opslevel_filter.this.connective),
+      can(opslevel_filter.this.id),
+      can(opslevel_filter.this.name),
+      can(opslevel_filter.this.predicate),
     ])
     error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.filter_one)
   }
 
   assert {
-    condition     = opslevel_filter.test.connective == var.connective
+    condition     = opslevel_filter.this.connective == var.connective
     error_message = "wrong connective of opslevel_filter resource"
   }
 
   assert {
-    condition     = opslevel_filter.test.name == var.name
+    condition     = opslevel_filter.this.name == var.name
     error_message = replace(var.error_wrong_name, "TYPE", var.filter_one)
   }
 
@@ -53,7 +53,7 @@ run "resource_filter_create_with_all_fields" {
 #  }
 #
 #  assert {
-#    condition     = opslevel_filter.test.predicate_list == null
+#    condition     = opslevel_filter.this.predicate_list == null
 #    error_message = var.error_expected_null_field
 #  }
 #
@@ -72,17 +72,17 @@ run "resource_filter_update_set_all_fields" {
   }
 
   assert {
-    condition     = opslevel_filter.test.connective == var.connective
+    condition     = opslevel_filter.this.connective == var.connective
     error_message = "wrong connective of opslevel_filter resource"
   }
 
   assert {
-    condition     = opslevel_filter.test.name == var.name
+    condition     = opslevel_filter.this.name == var.name
     error_message = replace(var.error_wrong_name, "TYPE", var.filter_one)
   }
 
   #assert {
-  #  condition     = opslevel_filter.test.predicate_list == var.predicate_list
+  #  condition     = opslevel_filter.this.predicate_list == var.predicate_list
   #  error_message = "wrong predicate_list of opslevel_filter resource"
   #}
 

--- a/tests/team.tftest.hcl
+++ b/tests/team.tftest.hcl
@@ -42,38 +42,38 @@ run "resource_team_create_with_all_fields" {
 
   assert {
     condition = alltrue([
-      can(opslevel_team.test.aliases),
-      can(opslevel_team.test.id),
-      can(opslevel_team.test.member),
-      can(opslevel_team.test.name),
-      can(opslevel_team.test.parent),
-      can(opslevel_team.test.responsibilities),
+      can(opslevel_team.this.aliases),
+      can(opslevel_team.this.id),
+      can(opslevel_team.this.member),
+      can(opslevel_team.this.name),
+      can(opslevel_team.this.parent),
+      can(opslevel_team.this.responsibilities),
     ])
     error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.team_one)
   }
 
   assert {
-    condition     = opslevel_team.test.aliases == toset(var.aliases)
+    condition     = opslevel_team.this.aliases == toset(var.aliases)
     error_message = "wrong aliases for opslevel_team resource"
   }
 
   assert {
-    condition     = startswith(opslevel_team.test.id, var.id_prefix)
+    condition     = startswith(opslevel_team.this.id, var.id_prefix)
     error_message = replace(var.error_wrong_id, "TYPE", var.team_one)
   }
 
   assert {
-    condition     = opslevel_team.test.name == var.name
+    condition     = opslevel_team.this.name == var.name
     error_message = replace(var.error_wrong_name, "TYPE", var.team_one)
   }
 
   assert {
-    condition     = opslevel_team.test.parent == var.parent
+    condition     = opslevel_team.this.parent == var.parent
     error_message = "wrong parent for opslevel_team resource"
   }
 
   assert {
-    condition     = opslevel_team.test.responsibilities == var.responsibilities
+    condition     = opslevel_team.this.responsibilities == var.responsibilities
     error_message = "wrong responsibilities for opslevel_team resource"
   }
 
@@ -91,7 +91,7 @@ run "resource_team_create_with_empty_optional_fields" {
   }
 
   assert {
-    condition     = opslevel_team.test.responsibilities == ""
+    condition     = opslevel_team.this.responsibilities == ""
     error_message = var.error_expected_empty_string
   }
 
@@ -110,17 +110,17 @@ run "resource_team_update_unset_optional_fields" {
   }
 
   assert {
-    condition     = opslevel_team.test.aliases == null
+    condition     = opslevel_team.this.aliases == null
     error_message = var.error_expected_null_field
   }
 
   assert {
-    condition     = opslevel_team.test.parent == null
+    condition     = opslevel_team.this.parent == null
     error_message = var.error_expected_null_field
   }
 
   assert {
-    condition     = opslevel_team.test.responsibilities == null
+    condition     = opslevel_team.this.responsibilities == null
     error_message = var.error_expected_null_field
   }
 
@@ -140,22 +140,22 @@ run "resource_team_update_set_all_fields" {
   }
 
   assert {
-    condition     = opslevel_team.test.aliases == toset(var.aliases)
+    condition     = opslevel_team.this.aliases == toset(var.aliases)
     error_message = "wrong aliases for opslevel_team resource"
   }
 
   assert {
-    condition     = opslevel_team.test.name == var.name
+    condition     = opslevel_team.this.name == var.name
     error_message = replace(var.error_wrong_name, "TYPE", var.team_one)
   }
 
   assert {
-    condition     = opslevel_team.test.parent == var.parent
+    condition     = opslevel_team.this.parent == var.parent
     error_message = "wrong parent for opslevel_team resource"
   }
 
   assert {
-    condition     = opslevel_team.test.responsibilities == var.responsibilities
+    condition     = opslevel_team.this.responsibilities == var.responsibilities
     error_message = "wrong responsibilities for opslevel_team resource"
   }
 

--- a/tests/user.tftest.hcl
+++ b/tests/user.tftest.hcl
@@ -26,37 +26,37 @@ run "resource_user_create_with_all_fields" {
 
   assert {
     condition = alltrue([
-      can(opslevel_user.test.email),
-      can(opslevel_user.test.id),
-      can(opslevel_user.test.name),
-      can(opslevel_user.test.role),
-      can(opslevel_user.test.skip_welcome_email),
+      can(opslevel_user.this.email),
+      can(opslevel_user.this.id),
+      can(opslevel_user.this.name),
+      can(opslevel_user.this.role),
+      can(opslevel_user.this.skip_welcome_email),
     ])
     error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.user_one)
   }
 
   assert {
-    condition     = opslevel_user.test.email == var.email
+    condition     = opslevel_user.this.email == var.email
     error_message = "wrong email for opslevel_user resource"
   }
 
   assert {
-    condition     = startswith(opslevel_user.test.id, var.id_prefix)
+    condition     = startswith(opslevel_user.this.id, var.id_prefix)
     error_message = replace(var.error_wrong_id, "TYPE", var.user_one)
   }
 
   assert {
-    condition     = opslevel_user.test.name == var.name
+    condition     = opslevel_user.this.name == var.name
     error_message = replace(var.error_wrong_name, "TYPE", var.user_one)
   }
 
   assert {
-    condition     = opslevel_user.test.role == var.role
+    condition     = opslevel_user.this.role == var.role
     error_message = "wrong role for opslevel_user resource"
   }
 
   assert {
-    condition     = opslevel_user.test.skip_welcome_email == var.skip_welcome_email
+    condition     = opslevel_user.this.skip_welcome_email == var.skip_welcome_email
     error_message = "wrong email for opslevel_user resource"
   }
 
@@ -73,7 +73,7 @@ run "resource_user_update_unset_fields_return_default_value" {
   }
 
   assert {
-    condition     = opslevel_user.test.skip_welcome_email == true
+    condition     = opslevel_user.this.skip_welcome_email == true
     error_message = "expected 'true' default for skip_welcome_email in opslevel_user resource"
   }
 
@@ -93,22 +93,22 @@ run "resource_user_update_set_all_fields" {
   }
 
   assert {
-    condition     = opslevel_user.test.email == var.email
+    condition     = opslevel_user.this.email == var.email
     error_message = "wrong email for opslevel_user resource"
   }
 
   assert {
-    condition     = opslevel_user.test.name == var.name
+    condition     = opslevel_user.this.name == var.name
     error_message = replace(var.error_wrong_name, "TYPE", var.user_one)
   }
 
   assert {
-    condition     = opslevel_user.test.role == var.role
+    condition     = opslevel_user.this.role == var.role
     error_message = "wrong role for opslevel_user resource"
   }
 
   assert {
-    condition     = opslevel_user.test.skip_welcome_email == var.skip_welcome_email
+    condition     = opslevel_user.this.skip_welcome_email == var.skip_welcome_email
     error_message = "wrong skip_welcome_email for opslevel_user resource"
   }
 


### PR DESCRIPTION
Resolves #

### Problem

Tests based on [terraform-opslevel-modules](https://github.com/OpsLevel/terraform-opslevel-modules/) modules fail after upstream renames
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Update names in tests. Run `task test-release` and `task test-unreleased` ✅ 
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
