### PR TITLE
fix predicate validation to accept interpolated values on predicate v…

### DIFF
--- a/.changes/unreleased/Bugfix-20241002-090048.yaml
+++ b/.changes/unreleased/Bugfix-20241002-090048.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix predicate validation to accept interpolated values on value field
+time: 2024-10-02T09:00:48.502724-05:00

--- a/opslevel/resource_opslevel_check_base.go
+++ b/opslevel/resource_opslevel_check_base.go
@@ -93,7 +93,7 @@ var predicateType = map[string]attr.Type{
 
 func (p PredicateModel) Validate() error {
 	// Skip validation for now, when input variables or for loops are used
-	if p.Type.IsUnknown() || p.Type.IsNull() {
+	if p.Type.IsNull() || p.Type.IsUnknown() || p.Value.IsUnknown() {
 		return nil
 	}
 	predicate := opslevel.Predicate{


### PR DESCRIPTION
Resolves [#496](https://github.com/OpsLevel/terraform-provider-opslevel/issues/496)

### Problem

Validation on predicate's `value` fields incorrectly fails. Computed values (i.e. locals and interpolated strings) should be accepted but they currently throw an error instead.
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Accept "unknown" values for this `value` field during validation
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
