### PR TITLE
add region_override field to opslevel_aws_integration resource

### DIFF
--- a/.changes/unreleased/Feature-20241007-131137.yaml
+++ b/.changes/unreleased/Feature-20241007-131137.yaml
@@ -1,4 +1,3 @@
 kind: Feature
-body: can override aws regions with "region_override" field on opslevel_aws_integration
-  resource
+body: can override aws regions with "region_override" field on opslevel_aws_integration resource
 time: 2024-10-07T13:11:37.315799-05:00

--- a/.changes/unreleased/Feature-20241007-131137.yaml
+++ b/.changes/unreleased/Feature-20241007-131137.yaml
@@ -1,0 +1,4 @@
+kind: Feature
+body: can override aws regions with "region_override" field on opslevel_aws_integration
+  resource
+time: 2024-10-07T13:11:37.315799-05:00

--- a/examples/resources/opslevel_integration_aws/resource.tf
+++ b/examples/resources/opslevel_integration_aws/resource.tf
@@ -97,4 +97,5 @@ resource "opslevel_integration_aws" "dev" {
   external_id             = random_string.external_id.result
   ownership_tag_overrides = true
   ownership_tag_keys      = ["owner", "team", "group"]
+  region_override         = ["eu-west-1", "us-east-1"]
 }

--- a/opslevel/resource_opslevel_integration_aws.go
+++ b/opslevel/resource_opslevel_integration_aws.go
@@ -126,18 +126,20 @@ func (r *IntegrationAwsResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.Append(diags...)
 		return
 	}
-	regionOverride, diags := ListValueToStringSlice(ctx, planModel.RegionOverride)
-	if diags != nil && diags.HasError() {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
 	input := opslevel.AWSIntegrationInput{
 		Name:                 planModel.Name.ValueStringPointer(),
 		IAMRole:              planModel.IamRole.ValueStringPointer(),
 		ExternalID:           planModel.ExternalID.ValueStringPointer(),
 		OwnershipTagOverride: planModel.OwnershipTagOverrides.ValueBoolPointer(),
 		OwnershipTagKeys:     ownershipTagKeys,
-		RegionOverride:       &regionOverride,
+	}
+	if !planModel.RegionOverride.IsNull() && !planModel.RegionOverride.IsUnknown() {
+		regionOverride, diags := ListValueToStringSlice(ctx, planModel.RegionOverride)
+		if diags != nil && diags.HasError() {
+			resp.Diagnostics.Append(diags...)
+			return
+		}
+		input.RegionOverride = &regionOverride
 	}
 
 	awsIntegration, err := r.client.CreateIntegrationAWS(input)

--- a/tests/remote/integration_aws/main.tf
+++ b/tests/remote/integration_aws/main.tf
@@ -4,4 +4,5 @@ resource "opslevel_integration_aws" "this" {
   external_id             = var.external_id
   ownership_tag_overrides = var.ownership_tag_overrides
   ownership_tag_keys      = var.ownership_tag_keys
+  region_override         = var.region_override
 }

--- a/tests/remote/integration_aws/variables.tf
+++ b/tests/remote/integration_aws/variables.tf
@@ -24,3 +24,9 @@ variable "name" {
   type        = string
   description = "The name of the integration."
 }
+
+variable "region_override" {
+  type        = list(string)
+  description = "Overrides the AWS region(s) that will be synchronized by this integration."
+  default     = null
+}

--- a/tests/remote/integration_aws_all.tftest.hcl
+++ b/tests/remote/integration_aws_all.tftest.hcl
@@ -9,6 +9,7 @@ variables {
   # optional fields
   ownership_tag_overrides = false
   ownership_tag_keys      = ["one", "two", "three", "four", "five"]
+  region_override         = ["eu-west-1", "us-east-1"]
 
   # default values - computed from API
   default_ownership_tag_keys      = tolist(["owner"])
@@ -29,6 +30,7 @@ run "resource_integration_aws_create_with_all_fields" {
       can(opslevel_integration_aws.this.ownership_tag_keys),
       can(opslevel_integration_aws.this.ownership_tag_overrides),
       can(opslevel_integration_aws.this.name),
+      can(opslevel_integration_aws.this.region_override),
     ])
     error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
   }
@@ -83,6 +85,15 @@ run "resource_integration_aws_create_with_all_fields" {
     )
   }
 
+  assert {
+    condition = opslevel_integration_aws.this.region_override == var.region_override
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.region_override,
+      opslevel_integration_aws.this.region_override,
+    )
+  }
+
 }
 
 run "resource_integration_aws_unset_ownership_tag_keys" {
@@ -123,6 +134,23 @@ run "resource_integration_aws_unset_ownership_tag_overrides" {
       var.default_ownership_tag_overrides,
       opslevel_integration_aws.this.ownership_tag_overrides,
     )
+  }
+
+}
+
+run "resource_integration_aws_unset_region_override" {
+
+  variables {
+    region_override = null
+  }
+
+  module {
+    source = "./integration_aws"
+  }
+
+  assert {
+    condition     = opslevel_integration_aws.this.region_override == null
+    error_message = var.error_expected_null_field
   }
 
 }

--- a/tests/remote/integration_aws_min.tftest.hcl
+++ b/tests/remote/integration_aws_min.tftest.hcl
@@ -9,6 +9,7 @@ variables {
   # optional fields
   ownership_tag_overrides = null
   ownership_tag_keys      = null
+  region_override         = null
 
   # default values - computed from API
   default_ownership_tag_keys      = tolist(["owner"])
@@ -71,6 +72,11 @@ run "resource_integration_aws_create_with_required_fields" {
     )
   }
 
+  assert {
+    condition     = opslevel_integration_aws.this.region_override == null
+    error_message = var.error_expected_null_field
+  }
+
 }
 
 run "resource_integration_aws_set_ownership_tag_keys" {
@@ -115,3 +121,24 @@ run "resource_integration_aws_set_ownership_tag_overrides" {
 
 }
 
+
+run "resource_integration_aws_set_region_override" {
+
+  variables {
+    region_override = ["eu-west-1", "us-east-1"]
+  }
+
+  module {
+    source = "./integration_aws"
+  }
+
+  assert {
+    condition = opslevel_integration_aws.this.region_override == var.region_override
+    error_message = format(
+      "expected '%v' but got '%v'",
+      var.region_override,
+      opslevel_integration_aws.this.region_override,
+    )
+  }
+
+}


### PR DESCRIPTION
Resolves [#505](https://github.com/OpsLevel/team-platform/issues/505)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
