### PR TITLE
gracefully handle Terraform state drift when resources deleted in UI

### DIFF
--- a/.changes/unreleased/Bugfix-20241008-112140.yaml
+++ b/.changes/unreleased/Bugfix-20241008-112140.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: gracefully handle Terraform state drift when resources deleted in UI
+time: 2024-10-08T11:21:40.580864-05:00

--- a/opslevel/common.go
+++ b/opslevel/common.go
@@ -140,6 +140,10 @@ func getDatasourceFilter(validFieldNames []string) schema.SingleNestedBlock {
 	}
 }
 
+func stateResourceMissingMessage(resourceType string) string {
+	return fmt.Sprintf("'%s' from Terraform state not found in OpsLevel!\n\nPlease try 'terraform plan -refresh-only' to detected changes outside of Terraform", resourceType)
+}
+
 func flattenTag(tag opslevel.Tag) string {
 	return fmt.Sprintf("%s:%s", tag.Key, tag.Value)
 }

--- a/opslevel/resource_opslevel_check_alert_source_usage.go
+++ b/opslevel/resource_opslevel_check_alert_source_usage.go
@@ -245,7 +245,8 @@ func (r *CheckAlertSourceUsageResource) Read(ctx context.Context, req resource.R
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check alert source usage, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_alert_source_usage"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckAlertSourceUsageResourceModel(ctx, *data, planModel)
@@ -321,7 +322,7 @@ func (r *CheckAlertSourceUsageResource) Delete(ctx context.Context, req resource
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check alert source usage, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_alert_source_usage"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check alert source usage resource")

--- a/opslevel/resource_opslevel_check_custom_event.go
+++ b/opslevel/resource_opslevel_check_custom_event.go
@@ -169,7 +169,8 @@ func (r *CheckCustomEventResource) Read(ctx context.Context, req resource.ReadRe
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check custom event, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_custom_event"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckCustomEventResourceModel(ctx, *data, planModel)
@@ -236,7 +237,7 @@ func (r *CheckCustomEventResource) Delete(ctx context.Context, req resource.Dele
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check custom event, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_custom_event"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check custom event resource")

--- a/opslevel/resource_opslevel_check_git_branch_protection.go
+++ b/opslevel/resource_opslevel_check_git_branch_protection.go
@@ -132,7 +132,8 @@ func (r *CheckGitBranchProtectionResource) Read(ctx context.Context, req resourc
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check git branch protection, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_git_branch_protection"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckGitBranchProtectionResourceModel(ctx, *data, planModel)
@@ -193,7 +194,7 @@ func (r *CheckGitBranchProtectionResource) Delete(ctx context.Context, req resou
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check git branch protection, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_git_branch_protection"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check git branch protection resource")

--- a/opslevel/resource_opslevel_check_has_documentation.go
+++ b/opslevel/resource_opslevel_check_has_documentation.go
@@ -159,7 +159,8 @@ func (r *CheckHasDocumentationResource) Read(ctx context.Context, req resource.R
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check has documentation, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_has_documentation"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckHasDocumentationResourceModel(ctx, *data, planModel)
@@ -224,7 +225,7 @@ func (r *CheckHasDocumentationResource) Delete(ctx context.Context, req resource
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check has documentation, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_has_documentation"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check has documentation resource")

--- a/opslevel/resource_opslevel_check_has_recent_deploy.go
+++ b/opslevel/resource_opslevel_check_has_recent_deploy.go
@@ -140,7 +140,8 @@ func (r *CheckHasRecentDeployResource) Read(ctx context.Context, req resource.Re
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check has recent deploy, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_has_recent_deploy"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckHasRecentDeployResourceModel(ctx, *data, planModel)
@@ -203,7 +204,7 @@ func (r *CheckHasRecentDeployResource) Delete(ctx context.Context, req resource.
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check has recent deploy, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_has_recent_deploy"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check has recent deploy resource")

--- a/opslevel/resource_opslevel_check_manual.go
+++ b/opslevel/resource_opslevel_check_manual.go
@@ -268,7 +268,8 @@ func (r *CheckManualResource) Read(ctx context.Context, req resource.ReadRequest
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check manual, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_manual"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckManualResourceModel(ctx, *data, planModel)
@@ -337,7 +338,7 @@ func (r *CheckManualResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check manual, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_manual"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check manual resource")

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -250,7 +250,8 @@ func (r *CheckPackageVersionResource) Read(ctx context.Context, req resource.Rea
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check package_version, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_package_version"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckPackageVersionResourceModel(ctx, *data, planModel)
@@ -341,7 +342,7 @@ func (r *CheckPackageVersionResource) Delete(ctx context.Context, req resource.D
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check package_version, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_package_version"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check package_version resource")

--- a/opslevel/resource_opslevel_check_repository_file.go
+++ b/opslevel/resource_opslevel_check_repository_file.go
@@ -267,7 +267,8 @@ func (r *CheckRepositoryFileResource) Read(ctx context.Context, req resource.Rea
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check repository file, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_file"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckRepositoryFileResourceModel(ctx, *data, planModel)
@@ -347,7 +348,7 @@ func (r *CheckRepositoryFileResource) Delete(ctx context.Context, req resource.D
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check repository file, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_file"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check repository file resource")

--- a/opslevel/resource_opslevel_check_repository_grep.go
+++ b/opslevel/resource_opslevel_check_repository_grep.go
@@ -250,7 +250,8 @@ func (r *CheckRepositoryGrepResource) Read(ctx context.Context, req resource.Rea
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check repository grep, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_grep"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckRepositoryGrepResourceModel(ctx, *data, planModel)
@@ -318,7 +319,7 @@ func (r *CheckRepositoryGrepResource) Delete(ctx context.Context, req resource.D
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check repository grep, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_grep"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check repository grep resource")

--- a/opslevel/resource_opslevel_check_repository_integrated.go
+++ b/opslevel/resource_opslevel_check_repository_integrated.go
@@ -130,7 +130,8 @@ func (r *CheckRepositoryIntegratedResource) Read(ctx context.Context, req resour
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check repository integrated, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_integrated"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckRepositoryIntegratedResourceModel(ctx, *data, planModel)
@@ -191,7 +192,7 @@ func (r *CheckRepositoryIntegratedResource) Delete(ctx context.Context, req reso
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check repository integrated, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_integrated"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check repository integrated resource")

--- a/opslevel/resource_opslevel_check_repository_search.go
+++ b/opslevel/resource_opslevel_check_repository_search.go
@@ -251,7 +251,8 @@ func (r *CheckRepositorySearchResource) Read(ctx context.Context, req resource.R
 
 	data, err := r.client.GetCheck(asID(currentStateModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check repository search, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_search"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	verifiedStateModel, diags := NewCheckRepositorySearchResourceModel(ctx, *data, currentStateModel)
@@ -322,7 +323,7 @@ func (r *CheckRepositorySearchResource) Delete(ctx context.Context, req resource
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check repository search, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_repository_search"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check repository search resource")

--- a/opslevel/resource_opslevel_check_service_configuration.go
+++ b/opslevel/resource_opslevel_check_service_configuration.go
@@ -130,7 +130,8 @@ func (r *CheckServiceConfigurationResource) Read(ctx context.Context, req resour
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check service configuration, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_configuration"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckServiceConfigurationResourceModel(ctx, *data, planModel)
@@ -191,7 +192,7 @@ func (r *CheckServiceConfigurationResource) Delete(ctx context.Context, req reso
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check service configuration, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_configuration"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check service configuration resource")

--- a/opslevel/resource_opslevel_check_service_dependency.go
+++ b/opslevel/resource_opslevel_check_service_dependency.go
@@ -130,7 +130,8 @@ func (r *CheckServiceDependencyResource) Read(ctx context.Context, req resource.
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check service dependency, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_dependency"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckServiceDependencyResourceModel(ctx, *data, planModel)
@@ -191,7 +192,7 @@ func (r *CheckServiceDependencyResource) Delete(ctx context.Context, req resourc
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check service dependency, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_dependency"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check service dependency resource")

--- a/opslevel/resource_opslevel_check_service_ownership.go
+++ b/opslevel/resource_opslevel_check_service_ownership.go
@@ -290,7 +290,8 @@ func (r *CheckServiceOwnershipResource) Read(ctx context.Context, req resource.R
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check service ownership, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_ownership"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckServiceOwnershipResourceModel(ctx, *data, planModel)
@@ -369,7 +370,7 @@ func (r *CheckServiceOwnershipResource) Delete(ctx context.Context, req resource
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check service ownership, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_ownership"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check service ownership resource")

--- a/opslevel/resource_opslevel_check_service_property.go
+++ b/opslevel/resource_opslevel_check_service_property.go
@@ -261,7 +261,8 @@ func (r *CheckServicePropertyResource) Read(ctx context.Context, req resource.Re
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check service property, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_property"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckServicePropertyResourceModel(ctx, *data, planModel)
@@ -345,7 +346,7 @@ func (r *CheckServicePropertyResource) Delete(ctx context.Context, req resource.
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check service property, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_service_property"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check service property resource")

--- a/opslevel/resource_opslevel_check_tag_defined.go
+++ b/opslevel/resource_opslevel_check_tag_defined.go
@@ -240,7 +240,8 @@ func (r *CheckTagDefinedResource) Read(ctx context.Context, req resource.ReadReq
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check tag defined, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_tag_defined"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckTagDefinedResourceModel(ctx, *data, planModel)
@@ -317,7 +318,7 @@ func (r *CheckTagDefinedResource) Delete(ctx context.Context, req resource.Delet
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check tag defined, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_tag_defined"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check tag defined resource")

--- a/opslevel/resource_opslevel_check_tool_usage.go
+++ b/opslevel/resource_opslevel_check_tool_usage.go
@@ -338,7 +338,8 @@ func (r *CheckToolUsageResource) Read(ctx context.Context, req resource.ReadRequ
 
 	data, err := r.client.GetCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read check tool usage, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_tool_usage"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewCheckToolUsageResourceModel(ctx, *data, planModel)
@@ -450,7 +451,7 @@ func (r *CheckToolUsageResource) Delete(ctx context.Context, req resource.Delete
 
 	err := r.client.DeleteCheck(asID(planModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete check tool usage, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_check_tool_usage"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a check tool usage resource")

--- a/opslevel/resource_opslevel_domain.go
+++ b/opslevel/resource_opslevel_domain.go
@@ -132,7 +132,8 @@ func (r *DomainResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	resource, err := r.client.GetDomain(stateModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read domain, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_domain"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	readDomainResourceModel := NewDomainResourceModel(ctx, *resource, stateModel)
@@ -179,7 +180,7 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	err := r.client.DeleteDomain(data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete domain, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_domain"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a domain resource")

--- a/opslevel/resource_opslevel_filter.go
+++ b/opslevel/resource_opslevel_filter.go
@@ -301,7 +301,8 @@ func (r *FilterResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	filter, err := r.client.GetFilter(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read filter, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_filter"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	verifiedStateModel, diags := NewFilterResourceModel(ctx, *filter, stateModel)
@@ -370,7 +371,7 @@ func (r *FilterResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	err := r.client.DeleteFilter(opslevel.ID(planModel.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete filter, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_filter"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a filter resource")

--- a/opslevel/resource_opslevel_infra.go
+++ b/opslevel/resource_opslevel_infra.go
@@ -299,7 +299,8 @@ func (r *InfrastructureResource) Read(ctx context.Context, req resource.ReadRequ
 
 	infrastructure, err := r.client.GetInfrastructure(stateModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read infrastructure, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_infrastructure"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	readInfrastructureResourceModel := NewInfrastructureResourceModel(ctx, *infrastructure, stateModel)
@@ -361,7 +362,7 @@ func (r *InfrastructureResource) Delete(ctx context.Context, req resource.Delete
 
 	err := r.client.DeleteInfrastructure(stateModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete infrastructure, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_infrastructure"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a infrastructure resource")

--- a/opslevel/resource_opslevel_integration_aws.go
+++ b/opslevel/resource_opslevel_integration_aws.go
@@ -150,7 +150,8 @@ func (r *IntegrationAwsResource) Read(ctx context.Context, req resource.ReadRequ
 
 	awsIntegration, err := r.client.GetIntegration(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read AWS integration, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_integration_aws"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -205,7 +206,7 @@ func (r *IntegrationAwsResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	if err := r.client.DeleteIntegration(data.Id.ValueString()); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete AWS integration, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_integration_aws"))
 		return
 	}
 	tflog.Trace(ctx, "deleted an AWS integration resource")

--- a/opslevel/resource_opslevel_integration_azure_resources.go
+++ b/opslevel/resource_opslevel_integration_azure_resources.go
@@ -210,7 +210,8 @@ func (r *IntegrationAzureResourcesResource) Read(ctx context.Context, req resour
 
 	azureResourcesIntegration, err := r.client.GetIntegration(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read Azure Resources integration, got error: '%s'", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_integration_azure_resources"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -265,7 +266,7 @@ func (r *IntegrationAzureResourcesResource) Delete(ctx context.Context, req reso
 	}
 
 	if err := r.client.DeleteIntegration(data.Id.ValueString()); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete Azure Resources integration, got error: '%s'", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_integration_azure_resources"))
 		return
 	}
 	tflog.Trace(ctx, "deleted an Azure Resources integration")

--- a/opslevel/resource_opslevel_integration_google_cloud.go
+++ b/opslevel/resource_opslevel_integration_google_cloud.go
@@ -223,7 +223,8 @@ func (r *integrationGoogleCloudResource) Read(ctx context.Context, req resource.
 
 	readIntegration, err := r.client.GetIntegration(asID(stateModel.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read Google Cloud integration, got error: '%s'", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_integration_google_cloud"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -282,7 +283,7 @@ func (r *integrationGoogleCloudResource) Delete(ctx context.Context, req resourc
 	}
 
 	if err := r.client.DeleteIntegration(data.Id.ValueString()); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete Google Cloud integration, got error: '%s'", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_integration_google_cloud"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a Google Cloud integration")

--- a/opslevel/resource_opslevel_property_definition.go
+++ b/opslevel/resource_opslevel_property_definition.go
@@ -147,7 +147,8 @@ func (resource *PropertyDefinitionResource) Read(ctx context.Context, req resour
 	id := stateModel.Id.ValueString()
 	definition, err := resource.client.GetPropertyDefinition(id)
 	if err != nil || definition == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read definition with id '%s', got error: %s", id, err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_property_definition"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -202,7 +203,7 @@ func (resource *PropertyDefinitionResource) Delete(ctx context.Context, req reso
 	id := planModel.Id.ValueString()
 	err := resource.client.DeletePropertyDefinition(id)
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to delete definition (%s), got error: %s", id, err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_property_definition"))
 		return
 	}
 	tflog.Trace(ctx, fmt.Sprintf("deleted a definition resource with id '%s'", id))

--- a/opslevel/resource_opslevel_repository.go
+++ b/opslevel/resource_opslevel_repository.go
@@ -139,7 +139,8 @@ func (r *RepositoryResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	readRepository, err := r.client.GetRepository(opslevel.ID(planModel.Id.ValueString()))
 	if err != nil || readRepository == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read repository, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_repository"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	stateModel := NewRepositoryResourceModel(ctx, *readRepository)
@@ -149,14 +150,8 @@ func (r *RepositoryResource) Read(ctx context.Context, req resource.ReadRequest,
 	case string(readRepository.Id), readRepository.DefaultAlias:
 		stateModel.Identifier = planModel.Identifier
 	default:
-		resp.Diagnostics.AddError(
-			"opslevel client error",
-			fmt.Sprintf("given repository identifier '%s' did not match found repository's id '%s' or alias '%s'",
-				planModel.Identifier.ValueString(),
-				string(readRepository.Id),
-				readRepository.DefaultAlias,
-			),
-		)
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_repository"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/opslevel/resource_opslevel_rubric_category.go
+++ b/opslevel/resource_opslevel_rubric_category.go
@@ -102,7 +102,8 @@ func (r *RubricCategoryResource) Read(ctx context.Context, req resource.ReadRequ
 
 	rubricCategory, err := r.client.GetCategory(opslevel.ID(data.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read rubric category, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_rubric_category"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	readRubricCategoryResourceModel := NewRubricCategoryResourceModel(*rubricCategory)
@@ -145,7 +146,7 @@ func (r *RubricCategoryResource) Delete(ctx context.Context, req resource.Delete
 
 	err := r.client.DeleteCategory(opslevel.ID(data.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete rubric category, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_rubric_category"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a rubric category resource")

--- a/opslevel/resource_opslevel_rubric_level.go
+++ b/opslevel/resource_opslevel_rubric_level.go
@@ -125,7 +125,8 @@ func (r *RubricLevelResource) Read(ctx context.Context, req resource.ReadRequest
 
 	rubricLevel, err := r.client.GetLevel(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read rubric level, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_rubric_level"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	readRubricLevelResourceModel := NewRubricLevelResourceModel(*rubricLevel, stateModel)
@@ -169,7 +170,7 @@ func (r *RubricLevelResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	err := r.client.DeleteLevel(opslevel.ID(data.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete rubric level, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_rubric_level"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a rubric level resource")

--- a/opslevel/resource_opslevel_scorecard.go
+++ b/opslevel/resource_opslevel_scorecard.go
@@ -184,7 +184,8 @@ func (r *ScorecardResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	readScorecard, err := r.client.GetScorecard(stateModel.Id.ValueString())
 	if err != nil || readScorecard == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read scorecard, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_scorecard"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	categoryIds, err := getScorecardCategoyIds(r.client, *readScorecard)
@@ -238,7 +239,7 @@ func (r *ScorecardResource) Delete(ctx context.Context, req resource.DeleteReque
 
 	_, err := r.client.DeleteScorecard(data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete scorecard, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_scorecard"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a scorecard resource")

--- a/opslevel/resource_opslevel_secrets.go
+++ b/opslevel/resource_opslevel_secrets.go
@@ -131,7 +131,8 @@ func (r *SecretResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	secret, err := r.client.GetSecret(data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read secret, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_secret"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	readSecretResourceModel := NewSecretResourceModel(*secret, data.Owner.ValueString(), data.Value.ValueString())
@@ -174,7 +175,7 @@ func (r *SecretResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	err := r.client.DeleteSecret(data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete secret, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_secret"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a secret resource")

--- a/opslevel/resource_opslevel_service.go
+++ b/opslevel/resource_opslevel_service.go
@@ -324,7 +324,8 @@ func (r *ServiceResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	service, err := r.client.GetService(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read service, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -486,7 +487,7 @@ func (r *ServiceResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	err := r.client.DeleteService(stateModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete service, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a service resource")

--- a/opslevel/resource_opslevel_service_dependency.go
+++ b/opslevel/resource_opslevel_service_dependency.go
@@ -145,18 +145,21 @@ func (r *ServiceDependencyResource) Read(ctx context.Context, req resource.ReadR
 		service, err = r.client.GetServiceWithAlias(serviceIdentifier)
 	}
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read service, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_dependency"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
 	dependencies, err := service.GetDependencies(r.client, nil)
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to get service dependencies, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_dependency"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	extractedServiceDependency := extractServiceDependency(planModel.Id.ValueString(), *dependencies)
 	if extractedServiceDependency == nil {
-		resp.Diagnostics.AddError("opslevel client error", "Unable to extract service dependency")
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_dependency"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -194,7 +197,7 @@ func (r *ServiceDependencyResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	if err := r.client.DeleteServiceDependency(opslevel.ID(planModel.Id.ValueString())); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete service dependency, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_dependency"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a serviceDependency resource")

--- a/opslevel/resource_opslevel_service_repository.go
+++ b/opslevel/resource_opslevel_service_repository.go
@@ -203,7 +203,8 @@ func (r *ServiceRepositoryResource) Read(ctx context.Context, req resource.ReadR
 		service, err = r.client.GetServiceWithAlias(currentStateModel.ServiceAlias.ValueString())
 	}
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read service, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_repository"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -285,7 +286,7 @@ func (r *ServiceRepositoryResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	if err := r.client.DeleteServiceRepository(opslevel.ID(planModel.Id.ValueString())); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete service repository, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_repository"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a ServiceRepository resource")

--- a/opslevel/resource_opslevel_service_tag.go
+++ b/opslevel/resource_opslevel_service_tag.go
@@ -156,12 +156,14 @@ func (serviceTagResource *ServiceTagResource) Read(ctx context.Context, req reso
 		service, err = serviceTagResource.client.GetServiceWithAlias(serviceIdentifier)
 	}
 	if err != nil || service == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read service (%s), got error: %s", serviceIdentifier, err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_tag"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	_, err = service.GetTags(serviceTagResource.client, nil)
 	if err != nil || service.Tags == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read tags on service (%s), got error: %s", serviceIdentifier, err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_tag"))
+		resp.State.RemoveResource(ctx)
 	}
 	var serviceTag *opslevel.Tag
 	for _, readTag := range service.Tags.Nodes {
@@ -171,7 +173,8 @@ func (serviceTagResource *ServiceTagResource) Read(ctx context.Context, req reso
 		}
 	}
 	if serviceTag == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("service tag (with key '%s') not found on service (%s)", data.Key.ValueString(), serviceIdentifier))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_tag"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -232,7 +235,7 @@ func (serviceTagResource *ServiceTagResource) Delete(ctx context.Context, req re
 
 	err := serviceTagResource.client.DeleteTag(opslevel.ID(data.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to delete service tag (with id '%s'), got error: %s", data.Id.ValueString(), err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_tag"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a service tag resource")

--- a/opslevel/resource_opslevel_service_tool.go
+++ b/opslevel/resource_opslevel_service_tool.go
@@ -178,7 +178,8 @@ func (r *ServiceToolResource) Read(ctx context.Context, req resource.ReadRequest
 		service, err = r.client.GetServiceWithAlias(currentStateModel.ServiceAlias.ValueString())
 	}
 	if err != nil || service == nil || string(service.Id) == "" {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read service, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_tool"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -196,7 +197,8 @@ func (r *ServiceToolResource) Read(ctx context.Context, req resource.ReadRequest
 		}
 	}
 	if serviceTool == nil || string(serviceTool.Id) == "" {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to find tool with id '%s' on service with id '%s'", id, service.Id))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_tool"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -243,7 +245,7 @@ func (r *ServiceToolResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	if err := r.client.DeleteTool(opslevel.ID(planModel.Id.ValueString())); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete service tool, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_service_tool"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a serviceTool resource")

--- a/opslevel/resource_opslevel_system.go
+++ b/opslevel/resource_opslevel_system.go
@@ -143,7 +143,8 @@ func (r *SystemResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	readSystem, err := r.client.GetSystem(stateModel.Id.ValueString())
 	if err != nil || readSystem == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read system, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_system"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	verifiedStateModel := NewSystemResourceModel(*readSystem, stateModel)
@@ -194,7 +195,7 @@ func (r *SystemResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	if err := r.client.DeleteSystem(planModel.Id.ValueString()); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete system, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_system"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a system resource")

--- a/opslevel/resource_opslevel_tag.go
+++ b/opslevel/resource_opslevel_tag.go
@@ -149,7 +149,8 @@ func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	resourceType := opslevel.TaggableResource(planModel.TargetType.ValueString())
 	data, err := r.client.GetTaggableResource(resourceType, resourceId)
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read tag, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_tag"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	tags, err := data.GetTags(r.client, nil)
@@ -160,13 +161,8 @@ func (r *TagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	id := planModel.Id.ValueString()
 	tag, err := tags.GetTagById(*opslevel.NewID(id))
 	if err != nil || tag == nil {
-		resp.Diagnostics.AddError("opslevel client error",
-			fmt.Sprintf("Tag '%s' for type %s with id '%s' not found. %s",
-				id,
-				data.ResourceType(),
-				data.ResourceId(),
-				err,
-			))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_tag"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -212,7 +208,7 @@ func (r *TagResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 
 	err := r.client.DeleteTag(asID(data.Id))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete tag, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_tag"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a tag resource")

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -195,7 +195,11 @@ func (teamResource *TeamResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	team, err := teamResource.client.GetTeam(opslevel.ID(stateModel.Id.ValueString()))
-	if err != nil || team == nil {
+	if team == nil && opslevel.HasBadHttpStatus(err) {
+		resp.Diagnostics.AddError("HTTP status error", fmt.Sprintf("unable to read team, got error: %s", err))
+		return
+	}
+	if err != nil {
 		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team"))
 		resp.State.RemoveResource(ctx)
 		return

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -196,7 +196,8 @@ func (teamResource *TeamResource) Read(ctx context.Context, req resource.ReadReq
 
 	team, err := teamResource.client.GetTeam(opslevel.ID(stateModel.Id.ValueString()))
 	if err != nil || team == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read team, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	err = team.Hydrate(teamResource.client)
@@ -311,7 +312,7 @@ func (teamResource *TeamResource) Delete(ctx context.Context, req resource.Delet
 
 	err := teamResource.client.DeleteTeam(data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to delete team, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a team resource")

--- a/opslevel/resource_opslevel_team.go
+++ b/opslevel/resource_opslevel_team.go
@@ -195,13 +195,12 @@ func (teamResource *TeamResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	team, err := teamResource.client.GetTeam(opslevel.ID(stateModel.Id.ValueString()))
-	if team == nil && opslevel.HasBadHttpStatus(err) {
-		resp.Diagnostics.AddError("HTTP status error", fmt.Sprintf("unable to read team, got error: %s", err))
+	if (team == nil || team.Id == "") && opslevel.HasNotFoundError(err) {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	if err != nil {
-		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team"))
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError("Error", fmt.Sprintf("unable to read team, got error: %s", err))
 		return
 	}
 	err = team.Hydrate(teamResource.client)

--- a/opslevel/resource_opslevel_team_contact.go
+++ b/opslevel/resource_opslevel_team_contact.go
@@ -135,7 +135,8 @@ func (teamContactResource *TeamContactResource) Read(ctx context.Context, req re
 		team, err = teamContactResource.client.GetTeamWithAlias(teamIdentifier)
 	}
 	if err != nil || team == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read team (%s), got error: %s", teamIdentifier, err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team_contact"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	err = team.Hydrate(teamContactResource.client)
@@ -151,7 +152,8 @@ func (teamContactResource *TeamContactResource) Read(ctx context.Context, req re
 		}
 	}
 	if teamContact == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("team contact (with ID '%s') not found on team (%s)", contactID, teamIdentifier))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team_contact"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -199,7 +201,7 @@ func (teamContactResource *TeamContactResource) Delete(ctx context.Context, req 
 
 	err := teamContactResource.client.RemoveContact(contactID)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to remove team contact (with id '%s'), got error: %s", contactID, err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team_contact"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a team contact resource")

--- a/opslevel/resource_opslevel_team_tag.go
+++ b/opslevel/resource_opslevel_team_tag.go
@@ -163,7 +163,8 @@ func (teamTagResource *TeamTagResource) Read(ctx context.Context, req resource.R
 		team, err = teamTagResource.client.GetTeamWithAlias(teamIdentifier)
 	}
 	if err != nil || team == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read team (%s), got error: %s", teamIdentifier, err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team_tag"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	_, err = team.GetTags(teamTagResource.client, nil)
@@ -178,7 +179,8 @@ func (teamTagResource *TeamTagResource) Read(ctx context.Context, req resource.R
 		}
 	}
 	if teamTag == nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("team tag (with key '%s') not found on team (%s)", data.Key.ValueString(), teamIdentifier))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team_tag"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -239,7 +241,7 @@ func (teamTagResource *TeamTagResource) Delete(ctx context.Context, req resource
 
 	err := teamTagResource.client.DeleteTag(opslevel.ID(data.Id.ValueString()))
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("unable to delete team tag (with id '%s'), got error: %s", data.Id.ValueString(), err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_team_tag"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a team tag resource")

--- a/opslevel/resource_opslevel_trigger_definition.go
+++ b/opslevel/resource_opslevel_trigger_definition.go
@@ -228,7 +228,8 @@ func (r *TriggerDefinitionResource) Read(ctx context.Context, req resource.ReadR
 
 	triggerDefinition, err := r.client.GetTriggerDefinition(planModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read trigger definition, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_trigger_definition"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -295,7 +296,7 @@ func (r *TriggerDefinitionResource) Delete(ctx context.Context, req resource.Del
 
 	err := r.client.DeleteTriggerDefinition(planModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete trigger definition, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_trigger_definition"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a trigger definition resource")

--- a/opslevel/resource_opslevel_user.go
+++ b/opslevel/resource_opslevel_user.go
@@ -143,7 +143,8 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	user, err := r.client.GetUser(stateModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read user, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_user"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -192,7 +193,7 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	err := r.client.DeleteUser(data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete user, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_user"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a user resource")

--- a/opslevel/resource_opslevel_webhook_action.go
+++ b/opslevel/resource_opslevel_webhook_action.go
@@ -152,7 +152,8 @@ func (r *WebhookActionResource) Read(ctx context.Context, req resource.ReadReque
 
 	webhookAction, err := r.client.GetCustomAction(stateModel.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to read webhookAction, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_webhook_action"))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 	readWebhookActionResourceModel := NewWebhookActionResourceModel(*webhookAction, stateModel)
@@ -208,7 +209,7 @@ func (r *WebhookActionResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	if err := r.client.DeleteWebhookAction(data.Id.ValueString()); err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete webhookAction, got error: %s", err))
+		resp.Diagnostics.AddWarning("State drift", stateResourceMissingMessage("opslevel_webhook_action"))
 		return
 	}
 	tflog.Trace(ctx, "deleted a webhook action resource")


### PR DESCRIPTION
Resolves [#508](https://github.com/OpsLevel/team-platform/issues/508)

### Problem

Terraform managed resources can also be deleted in the UI. When this happens the provider throws an error instead of updating the state to reflect reality.

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Replace the "resource not found" errors with helpful warnings and also remove missing resources from state only.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
