### PR TITLE
correctly update missing_package_result field in package version check

### DIFF
--- a/.changes/unreleased/Bugfix-20241022-094434.yaml
+++ b/.changes/unreleased/Bugfix-20241022-094434.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: correctly update missing_package_result field in opslevel_check_package_version
+time: 2024-10-22T09:44:34.996018-05:00

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -301,7 +301,7 @@ func (r *CheckPackageVersionResource) Update(ctx context.Context, req resource.U
 	}
 
 	if planModel.MissingPackageResult.IsNull() {
-		input.MissingPackageResult = opslevel.NewNull[opslevel.CheckResultStatusEnum]()
+		input.MissingPackageResult = opslevel.NewNullOf[opslevel.CheckResultStatusEnum]()
 	} else {
 		input.MissingPackageResult = opslevel.NewNullableFrom(opslevel.CheckResultStatusEnum(planModel.MissingPackageResult.ValueString()))
 	}

--- a/opslevel/resource_opslevel_check_package_version.go
+++ b/opslevel/resource_opslevel_check_package_version.go
@@ -144,7 +144,11 @@ func (r *CheckPackageVersionResource) Schema(ctx context.Context, req resource.S
 
 func (r *CheckPackageVersionResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	var configModel CheckPackageVersionResourceModel
-	packageVersionPossiblePredicateTypes := []opslevel.PredicateTypeEnum{opslevel.PredicateTypeEnumSatisfiesVersionConstraint, opslevel.PredicateTypeEnumMatchesRegex, opslevel.PredicateTypeEnumDoesNotMatchRegex}
+	packageVersionPossiblePredicateTypes := []opslevel.PredicateTypeEnum{
+		opslevel.PredicateTypeEnumDoesNotMatchRegex,
+		opslevel.PredicateTypeEnumMatchesRegex,
+		opslevel.PredicateTypeEnumSatisfiesVersionConstraint,
+	}
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
 	if resp.Diagnostics.HasError() {
@@ -152,10 +156,10 @@ func (r *CheckPackageVersionResource) ValidateConfig(ctx context.Context, req re
 	}
 
 	if configModel.PackageConstraint.ValueString() == string(opslevel.PackageConstraintEnumMatchesVersion) {
-		if configModel.MissingPackageResult.IsNull() {
+		if configModel.MissingPackageResult.IsNull() && !configModel.MissingPackageResult.IsUnknown() {
 			resp.Diagnostics.AddError("missing_package_result", "missing_package_result is required when package_constraint is 'matches_version'")
 		}
-		if configModel.VersionConstraintPredicate.IsNull() {
+		if configModel.VersionConstraintPredicate.IsNull() && !configModel.VersionConstraintPredicate.IsUnknown() {
 			resp.Diagnostics.AddError("version_constraint_predicate", "version_constraint_predicate is required when package_constraint is 'matches_version'")
 		}
 		if !configModel.VersionConstraintPredicate.IsNull() {
@@ -296,10 +300,10 @@ func (r *CheckPackageVersionResource) Update(ctx context.Context, req resource.U
 		input.EnableOn = &iso8601.Time{Time: enabledOn}
 	}
 
-	if !planModel.MissingPackageResult.IsNull() {
-		input.MissingPackageResult = opslevel.RefOf(opslevel.CheckResultStatusEnum(planModel.MissingPackageResult.ValueString()))
-	} else if !stateModel.MissingPackageResult.IsNull() { // Then Unset
-		input.MissingPackageResult = opslevel.RefOf(opslevel.CheckResultStatusEnum(""))
+	if planModel.MissingPackageResult.IsNull() {
+		input.MissingPackageResult = opslevel.NewNull[opslevel.CheckResultStatusEnum]()
+	} else {
+		input.MissingPackageResult = opslevel.NewNullableFrom(opslevel.CheckResultStatusEnum(planModel.MissingPackageResult.ValueString()))
 	}
 
 	if !planModel.PackageNameIsRegex.IsNull() {

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -36,7 +36,7 @@ func OptionalStringValue(value string) basetypes.StringValue {
 // Returns value from config as a string OR null if the value is not set/explicitly set to null (supports empty strings)
 func NullableStringConfigValue(s types.String) *opslevel.Nullable[string] {
 	if s.IsNull() {
-		return opslevel.NewNull[string]()
+		return opslevel.NewNull()
 	}
 	return opslevel.NewNullableFrom(s.ValueString())
 }

--- a/opslevel/terraform_type_conversions.go
+++ b/opslevel/terraform_type_conversions.go
@@ -36,7 +36,7 @@ func OptionalStringValue(value string) basetypes.StringValue {
 // Returns value from config as a string OR null if the value is not set/explicitly set to null (supports empty strings)
 func NullableStringConfigValue(s types.String) *opslevel.Nullable[string] {
 	if s.IsNull() {
-		return opslevel.NewNull()
+		return opslevel.NewNull[string]()
 	}
 	return opslevel.NewNullableFrom(s.ValueString())
 }

--- a/tests/check_has_recent_deploy.tftest.hcl
+++ b/tests/check_has_recent_deploy.tftest.hcl
@@ -1,5 +1,5 @@
 variables {
-  check_has_recent_deploy = "opslevel_check_has_recent_deploy"
+  resource_name = "opslevel_check_has_recent_deploy"
 
   # -- check_has_recent_deploy fields --
   # required fields
@@ -63,7 +63,7 @@ run "resource_check_has_recent_deploy_create_with_all_fields" {
       can(opslevel_check_has_recent_deploy.this.notes),
       can(opslevel_check_has_recent_deploy.this.owner),
     ])
-    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.check_has_recent_deploy)
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
   }
 
   assert {
@@ -104,7 +104,7 @@ run "resource_check_has_recent_deploy_create_with_all_fields" {
 
   assert {
     condition     = startswith(opslevel_check_has_recent_deploy.this.id, var.id_prefix)
-    error_message = replace(var.error_wrong_id, "TYPE", var.check_has_recent_deploy)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
   }
 
   assert {
@@ -389,7 +389,7 @@ run "resource_check_has_recent_deploy_set_all_fields" {
 
   assert {
     condition     = startswith(opslevel_check_has_recent_deploy.this.id, var.id_prefix)
-    error_message = replace(var.error_wrong_id, "TYPE", var.check_has_recent_deploy)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
   }
 
   assert {

--- a/tests/check_has_recent_deploy.tftest.hcl
+++ b/tests/check_has_recent_deploy.tftest.hcl
@@ -238,12 +238,11 @@ run "resource_check_has_recent_deploy_unset_optional_fields" {
 run "delete_check_has_recent_deploy_outside_of_terraform" {
 
   variables {
-    resource_id   = run.resource_check_has_recent_deploy_create_with_all_fields.this.id
-    resource_type = "check"
+    command = "delete check ${run.resource_check_has_recent_deploy_create_with_all_fields.this.id}"
   }
 
   module {
-    source = "./provisioner"
+    source = "./cli"
   }
 }
 

--- a/tests/check_manual.tftest.hcl
+++ b/tests/check_manual.tftest.hcl
@@ -260,12 +260,11 @@ run "resource_check_manual_unset_optional_fields" {
 run "delete_check_manual_outside_of_terraform" {
 
   variables {
-    resource_id   = run.resource_check_manual_create_with_all_fields.this.id
-    resource_type = "check"
+    command = "delete check ${run.resource_check_manual_create_with_all_fields.this.id}"
   }
 
   module {
-    source = "./provisioner"
+    source = "./cli"
   }
 }
 

--- a/tests/check_manual.tftest.hcl
+++ b/tests/check_manual.tftest.hcl
@@ -1,5 +1,5 @@
 variables {
-  check_manual = "opslevel_check_manual"
+  resource_name = "opslevel_check_manual"
 
   # -- check_manual fields --
   # required fields
@@ -71,7 +71,7 @@ run "resource_check_manual_create_with_all_fields" {
       can(opslevel_check_manual.this.update_frequency),
       can(opslevel_check_manual.this.update_requires_comment),
     ])
-    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.check_manual)
+    error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
   }
 
   assert {
@@ -103,7 +103,7 @@ run "resource_check_manual_create_with_all_fields" {
 
   assert {
     condition     = startswith(opslevel_check_manual.this.id, var.id_prefix)
-    error_message = replace(var.error_wrong_id, "TYPE", var.check_manual)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
   }
 
   assert {
@@ -171,7 +171,7 @@ run "resource_check_manual_create_with_all_fields" {
 
 }
 
-run "resource_check_manual_update_unset_optional_fields" {
+run "resource_check_manual_unset_optional_fields" {
 
   variables {
     # other fields from file scoped variables block
@@ -205,7 +205,7 @@ run "resource_check_manual_update_unset_optional_fields" {
 
   assert {
     condition     = opslevel_check_manual.this.enabled == false
-    error_message = "expected 'false' default for 'enabled' in opslevel_check_has_recent_deploy resource"
+    error_message = "expected 'false' default for 'enabled' in opslevel_check_manual resource"
   }
 
   assert {
@@ -312,7 +312,7 @@ run "resource_check_manual_create_with_required_fields" {
 
   assert {
     condition     = opslevel_check_manual.this.enabled == false
-    error_message = "expected 'false' default for 'enabled' in opslevel_check_has_recent_deploy resource"
+    error_message = "expected 'false' default for 'enabled' in opslevel_check_manual resource"
   }
 
   assert {
@@ -407,7 +407,7 @@ run "resource_check_manual_set_all_fields" {
 
   assert {
     condition     = startswith(opslevel_check_manual.this.id, var.id_prefix)
-    error_message = replace(var.error_wrong_id, "TYPE", var.check_manual)
+    error_message = replace(var.error_wrong_id, "TYPE", var.resource_name)
   }
 
   assert {

--- a/tests/check_package_version.tftest.hcl
+++ b/tests/check_package_version.tftest.hcl
@@ -339,12 +339,11 @@ run "resource_check_package_version_unset_optional_fields" {
 run "delete_check_package_version_outside_of_terraform" {
 
   variables {
-    resource_id   = run.resource_check_package_version_create_with_all_fields.this.id
-    resource_type = "check"
+    command = "delete check ${run.resource_check_package_version_create_with_all_fields.this.id}"
   }
 
   module {
-    source = "./provisioner"
+    source = "./cli"
   }
 }
 


### PR DESCRIPTION
Resolves #

🎗️ Relies on this [terraform-opslevel-modules PR](https://github.com/OpsLevel/terraform-opslevel-modules/pull/34)
🎗️ Relies on this [opslevel-go PR](https://github.com/OpsLevel/opslevel-go/pull/485)

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
