### PR TITLE
Add missing webhook url field

### DIFF
--- a/opslevel/resource_opslevel_integration_endpoint.go
+++ b/opslevel/resource_opslevel_integration_endpoint.go
@@ -32,16 +32,18 @@ type IntegrationEndpointResource struct {
 
 // IntegrationEndpointResourceModel describes the Integration Endpoint managed resource.
 type IntegrationEndpointResourceModel struct {
-	Id   types.String `tfsdk:"id"`
-	Name types.String `tfsdk:"name"`
-	Type types.String `tfsdk:"type"`
+	Id         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	Type       types.String `tfsdk:"type"`
+	WebhookURL types.String `tfsdk:"webhook_url"`
 }
 
 func NewIntegrationEndpointResourceModel(integrationEndpoint opslevel.Integration, givenModel IntegrationEndpointResourceModel) IntegrationEndpointResourceModel {
 	return IntegrationEndpointResourceModel{
-		Id:   ComputedStringValue(string(integrationEndpoint.Id)),
-		Name: RequiredStringValue(integrationEndpoint.Name),
-		Type: RequiredStringValue(givenModel.Type.ValueString()),
+		Id:         ComputedStringValue(string(integrationEndpoint.Id)),
+		Name:       RequiredStringValue(integrationEndpoint.Name),
+		Type:       RequiredStringValue(givenModel.Type.ValueString()),
+		WebhookURL: ComputedStringValue(*integrationEndpoint.WebhookURL),
 	}
 }
 
@@ -78,6 +80,10 @@ func (r *IntegrationEndpointResource) Schema(ctx context.Context, req resource.S
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"webhook_url": schema.StringAttribute{
+				Description: "The endpoint to send events via webhook (if applicable).",
+				Computed:    true,
 			},
 		},
 	}

--- a/tests/integration_endpoint.tftest.hcl
+++ b/tests/integration_endpoint.tftest.hcl
@@ -240,6 +240,7 @@ run "resource_integration_endpoint_create_deploy_type" {
       can(opslevel_integration_endpoint.this.id),
       can(opslevel_integration_endpoint.this.name),
       can(opslevel_integration_endpoint.this.type),
+      can(opslevel_integration_endpoint.this.webhook_url),
     ])
     error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.resource_name)
   }


### PR DESCRIPTION
Resolves #

### Problem

The new endpoint integration doesn't expose the webhook url to send events to

### Solution

Add that as a computed field so the customer can get at it and use it

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [X] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
