### PR TITLE
fix import service_repository, accepts aliases or id

### DIFF
--- a/.changes/unreleased/Bugfix-20241107-140256.yaml
+++ b/.changes/unreleased/Bugfix-20241107-140256.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: fix terraform import opslevel_service_repository resource, accepts aliases or id
+time: 2024-11-07T14:02:56.048787-06:00

--- a/examples/resources/opslevel_service_repository/import.sh
+++ b/examples/resources/opslevel_service_repository/import.sh
@@ -1,1 +1,4 @@
 terraform import opslevel_service_repository.example Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mg:Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MDI0
+terraform import opslevel_service_repository.example Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS84Mg:github.com:my-org/my-repo
+terraform import opslevel_service_repository.example example_alias:github.com:my-org/my-repo
+terraform import opslevel_service_repository.example example_alias:Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS82MDI0

--- a/opslevel/resource_opslevel_service_repository.go
+++ b/opslevel/resource_opslevel_service_repository.go
@@ -328,7 +328,7 @@ func (r *ServiceRepositoryResource) ImportState(ctx context.Context, req resourc
 	}
 	if foundRepoIdentifier == "" {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf(
-			"Unable to get service dependency of service '%s' dependent upon '%s'",
+			"Unable to find service '%s' with repository '%s'",
 			serviceIdentifier,
 			repoIdentifier,
 		))


### PR DESCRIPTION
Resolves [#537](https://github.com/OpsLevel/team-platform/issues/537)

### Problem

`terraform import` on `opslevel_service_repository` was not working

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

Fix `terraform import` on `opslevel_service_repository` and also have it accept aliases or ids

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
