### PR TITLE
note field on service_dependency correctly takes empty string

### DIFF
--- a/.changes/unreleased/Bugfix-20241121-081407.yaml
+++ b/.changes/unreleased/Bugfix-20241121-081407.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: '"note" field on service_dependency correctly takes empty string'
+time: 2024-11-21T08:14:07.471282-06:00

--- a/opslevel/resource_opslevel_service_dependency.go
+++ b/opslevel/resource_opslevel_service_dependency.go
@@ -117,13 +117,16 @@ func (r *ServiceDependencyResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	serviceDependency, err := r.client.CreateServiceDependency(opslevel.ServiceDependencyCreateInput{
+	serviceDependencyCreateInput := opslevel.ServiceDependencyCreateInput{
 		DependencyKey: opslevel.ServiceDependencyKey{
 			DestinationIdentifier: opslevel.NewIdentifier(planModel.DependsUpon.ValueString()),
 			SourceIdentifier:      opslevel.NewIdentifier(planModel.Service.ValueString()),
 		},
-		Notes: planModel.Note.ValueStringPointer(),
-	})
+	}
+	if !planModel.Note.IsNull() && !planModel.Note.IsUnknown() {
+		serviceDependencyCreateInput.Notes = planModel.Note.ValueStringPointer()
+	}
+	serviceDependency, err := r.client.CreateServiceDependency(serviceDependencyCreateInput)
 	if err != nil || serviceDependency == nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("Unable to create serviceDependency, got error: %s", err))
 		return
@@ -200,7 +203,7 @@ func extractServiceDependency(id string, serviceDependencies opslevel.ServiceDep
 
 func (r *ServiceDependencyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	resp.Diagnostics.AddError("terraform plugin error",
-		"property assignments should never be updated, only replaced.\nplease file a bug report including your .tf file at: github.com/OpsLevel/terraform-provider-opslevel")
+		"service dependencies should never be updated, only replaced.\nplease file a bug report including your .tf file at: github.com/OpsLevel/terraform-provider-opslevel")
 }
 
 func (r *ServiceDependencyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Resolves #

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
