### PR TITLE
have service dependency note accept empty strings

### DIFF
--- a/.changes/unreleased/Bugfix-20241224-094342.yaml
+++ b/.changes/unreleased/Bugfix-20241224-094342.yaml
@@ -1,0 +1,3 @@
+kind: Bugfix
+body: have service dependency note accept empty strings
+time: 2024-12-24T09:43:42.873065-06:00

--- a/opslevel/resource_opslevel_service_dependency.go
+++ b/opslevel/resource_opslevel_service_dependency.go
@@ -41,10 +41,14 @@ type ServiceDependencyResourceModel struct {
 func NewServiceDependencyResourceModel(serviceDependency opslevel.ServiceDependency, givenModel ServiceDependencyResourceModel) (ServiceDependencyResourceModel, diag.Diagnostics) {
 	var diag diag.Diagnostics
 	serviceDependencyResourceModel := ServiceDependencyResourceModel{
-		Id:   ComputedStringValue(string(serviceDependency.Id)),
-		Note: OptionalStringValue(serviceDependency.Notes),
+		Id: ComputedStringValue(string(serviceDependency.Id)),
 	}
 
+	if givenModel.Note.IsNull() {
+		serviceDependencyResourceModel.Note = types.StringNull()
+	} else {
+		serviceDependencyResourceModel.Note = types.StringValue(serviceDependency.Notes)
+	}
 	dependsUpon := identifierFromServiceId(givenModel.DependsUpon.ValueString(), serviceDependency.DependsOn)
 	if dependsUpon == "" {
 		diag.AddError("opslevel client error", fmt.Sprintf("expected depends_upon '%s' got '%s'", givenModel.DependsUpon.ValueString(), dependsUpon))

--- a/tests/service_dependency.tftest.hcl
+++ b/tests/service_dependency.tftest.hcl
@@ -100,3 +100,22 @@ run "resource_service_dependency_update_does_force_recreate" {
   }
 
 }
+
+run "resource_service_dependency_update_note_empty_string" {
+
+  variables {
+    depends_upon = run.from_service_module.all.services[0].id
+    service      = run.from_service_module.all.services[1].id
+    note         = ""
+  }
+
+  module {
+    source = "./opslevel_modules/modules/service/dependency"
+  }
+
+  assert {
+    condition     = opslevel_service_dependency.this.note == ""
+    error_message = "expected note to be an empty string"
+  }
+
+}


### PR DESCRIPTION
Resolves #

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
