### PR TITLE
Add lockedStatus to PropertyDefinition

### DIFF
--- a/docs/data-sources/property_definition.md
+++ b/docs/data-sources/property_definition.md
@@ -36,6 +36,7 @@ output "pd_schema" {
 - `id` (String) The ID of this resource.
 - `name` (String) The display name of the property definition.
 - `property_display_status` (String) The display status of a custom property on service pages. (Options: 'visible' or 'hidden')
+- `locked_status` (String) Restricts what sources are able to assign values to this property. (Options: 'unlocked' or 'ui_locked')
 - `schema` (String) The schema of the property definition.
 
 

--- a/docs/data-sources/property_definitions.md
+++ b/docs/data-sources/property_definitions.md
@@ -44,6 +44,7 @@ Read-Only:
 - `id` (String) The ID of this resource.
 - `name` (String) The display name of the property definition.
 - `property_display_status` (String) The display status of a custom property on service pages. (Options: 'visible' or 'hidden')
+- `locked_status` (String) Restricts what sources are able to assign values to this property. (Options: 'unlocked' or 'ui_locked')
 - `schema` (String) The schema of the property definition.
 
 

--- a/docs/resources/property_definition.md
+++ b/docs/resources/property_definition.md
@@ -25,6 +25,7 @@ resource "opslevel_property_definition" "color_picker" {
   })
   allowed_in_config_files = false
   property_display_status = "visible"
+  locked_status = "unlocked"
 }
 ```
 
@@ -36,6 +37,7 @@ resource "opslevel_property_definition" "color_picker" {
 - `allowed_in_config_files` (Boolean) Whether or not the property is allowed to be set in opslevel.yml config files.
 - `name` (String) The display name of the property definition.
 - `property_display_status` (String) The display status of a custom property on service pages. One of `hidden`, `visible`
+- `locked_status` (String) Restricts what sources are able to assign values to this property. One of `unlocked` or `ui_locked`
 - `schema` (String) The schema of the property definition.
 
 ### Optional

--- a/examples/resources/opslevel_property_definition/resource.tf
+++ b/examples/resources/opslevel_property_definition/resource.tf
@@ -10,4 +10,5 @@ resource "opslevel_property_definition" "color_picker" {
   })
   allowed_in_config_files = false
   property_display_status = "visible"
+  locked_status = "unlocked"
 }

--- a/opslevel/datasource_opslevel_property_definition.go
+++ b/opslevel/datasource_opslevel_property_definition.go
@@ -38,6 +38,7 @@ type propertyDefinitionDataSourceWithFilterModel struct {
 	Identifier            types.String `tfsdk:"identifier"`
 	Name                  types.String `tfsdk:"name"`
 	PropertyDisplayStatus types.String `tfsdk:"property_display_status"`
+	LockedStatus          types.String `tfsdk:"locked_status"`
 	Schema                types.String `tfsdk:"schema"`
 }
 
@@ -49,6 +50,7 @@ func NewPropertyDefinitionDataSourceWithFilterModel(propertydefinition opslevel.
 		Identifier:            ComputedStringValue(identifier),
 		Name:                  ComputedStringValue(propertydefinition.Name),
 		PropertyDisplayStatus: ComputedStringValue(string(propertydefinition.PropertyDisplayStatus)),
+		LockedStatus:          ComputedStringValue(string(propertydefinition.LockedStatus)),
 		Schema:                ComputedStringValue(propertydefinition.Schema.ToJSON()),
 	}
 }

--- a/opslevel/datasource_opslevel_property_definitions_all.go
+++ b/opslevel/datasource_opslevel_property_definitions_all.go
@@ -36,6 +36,7 @@ func NewPropertyDefinitionDataSourcesAllModel(propertyDefinitions []opslevel.Pro
 			Id:                    ComputedStringValue(string(propertyDefinition.Id)),
 			Name:                  ComputedStringValue(propertyDefinition.Name),
 			PropertyDisplayStatus: ComputedStringValue(string(propertyDefinition.PropertyDisplayStatus)),
+			LockedStatus:          ComputedStringValue(string(propertyDefinition.LockedStatus)),
 			Schema:                ComputedStringValue(propertyDefinition.Schema.ToJSON()),
 		}
 		propDefinitionsModel = append(propDefinitionsModel, propDefinitionModel)
@@ -48,6 +49,7 @@ type propertyDefinitionDataSourceModel struct {
 	Id                    types.String `tfsdk:"id"`
 	Name                  types.String `tfsdk:"name"`
 	PropertyDisplayStatus types.String `tfsdk:"property_display_status"`
+	LockedStatus          types.String `tfsdk:"locked_status"`
 	Schema                types.String `tfsdk:"schema"`
 }
 
@@ -66,6 +68,10 @@ var propertyDefinitionSchemaAttrs = map[string]schema.Attribute{
 	},
 	"property_display_status": schema.StringAttribute{
 		MarkdownDescription: "The display status of a custom property on service pages. (Options: 'visible' or 'hidden')",
+		Computed:            true,
+	},
+	"locked_status": schema.StringAttribute{
+		MarkdownDescription: "Restricts what sources are able to assign values to this property. (Options: 'unlocked' or 'ui_locked')",
 		Computed:            true,
 	},
 	"schema": schema.StringAttribute{

--- a/opslevel/resource_opslevel_property_definition.go
+++ b/opslevel/resource_opslevel_property_definition.go
@@ -38,6 +38,7 @@ type PropertyDefinitionResourceModel struct {
 	Id                    types.String `tfsdk:"id"`
 	Name                  types.String `tfsdk:"name"`
 	PropertyDisplayStatus types.String `tfsdk:"property_display_status"`
+	LockedStatus          types.String `tfsdk:"locked_status"`
 	Schema                types.String `tfsdk:"schema"`
 }
 
@@ -48,6 +49,7 @@ func NewPropertyDefinitionResourceModel(definition opslevel.PropertyDefinition, 
 		Id:                    ComputedStringValue(string(definition.Id)),
 		Name:                  RequiredStringValue(definition.Name),
 		PropertyDisplayStatus: RequiredStringValue(string(definition.PropertyDisplayStatus)),
+		LockedStatus:          RequiredStringValue(string(definition.LockedStatus)),
 		Schema:                RequiredStringValue(definition.Schema.ToJSON()),
 	}
 
@@ -98,6 +100,16 @@ func (resource *PropertyDefinitionResource) Schema(ctx context.Context, req reso
 					stringvalidator.OneOf(opslevel.AllPropertyDisplayStatusEnum...),
 				},
 			},
+			"locked_status": schema.StringAttribute{
+				Description: fmt.Sprintf(
+					"Values for which lock is assigned to a property definition to restrict what sources can assign values to it. One of `%s`",
+					strings.Join(opslevel.AllPropertyLockedStatusEnum, "`, `"),
+				),
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(opslevel.AllPropertyLockedStatusEnum...),
+				},
+			},
 		},
 	}
 }
@@ -119,6 +131,7 @@ func (resource *PropertyDefinitionResource) Create(ctx context.Context, req reso
 		Description:           nullable(planModel.Description.ValueStringPointer()),
 		Name:                  nullable(planModel.Name.ValueStringPointer()),
 		PropertyDisplayStatus: asEnum[opslevel.PropertyDisplayStatusEnum](planModel.PropertyDisplayStatus.ValueString()),
+		LockedStatus:          asEnum[opslevel.PropertyLockedStatusEnum](planModel.LockedStatus.ValueString()),
 		Schema:                definitionSchema,
 	}
 	definition, err := resource.client.CreatePropertyDefinition(input)
@@ -172,6 +185,7 @@ func (resource *PropertyDefinitionResource) Update(ctx context.Context, req reso
 		Description:           nullable(planModel.Description.ValueStringPointer()),
 		Name:                  nullable(planModel.Name.ValueStringPointer()),
 		PropertyDisplayStatus: asEnum[opslevel.PropertyDisplayStatusEnum](planModel.PropertyDisplayStatus.ValueString()),
+		LockedStatus:          asEnum[opslevel.PropertyLockedStatusEnum](planModel.LockedStatus.ValueString()),
 		Schema:                definitionSchema,
 	}
 	definition, err := resource.client.UpdatePropertyDefinition(id, input)

--- a/tests/local/datasource_property_definition.tftest.hcl
+++ b/tests/local/datasource_property_definition.tftest.hcl
@@ -39,6 +39,11 @@ run "datasource_property_definition_mocked_fields" {
   }
 
   assert {
+    condition     = data.opslevel_property_definition.mock_property_definition.locked_status == "unlocked"
+    error_message = "wrong locked_status in mock opslevel_property_definition"
+  }
+
+  assert {
     condition = data.opslevel_property_definition.mock_property_definition.schema == jsonencode(
       {
         "$ref" : "#/$defs/MyProp",

--- a/tests/local/mock_datasource/property_definition.tfmock.hcl
+++ b/tests/local/mock_datasource/property_definition.tfmock.hcl
@@ -5,6 +5,7 @@ mock_data "opslevel_property_definition" {
     # id intentionally omitted - will be assigned a random string
     name                    = "mock-property-definition-name"
     property_display_status = "visible"
+    locked_status = "unlocked"
     # schema value result of running
     # 'jsonencode({ "$ref" : "#/$defs/MyProp", "$defs" : { "MyProp" : { "properties" : { "name" : { "type" : "string", "title" : "the new name", "description" : "The name of a friend", "default" : "alex", "examples" : ["joe", "lucy"] } }, "additionalProperties" : false, "type" : "object", "required" : ["name"] } } })'
     schema = "{\"$defs\":{\"MyProp\":{\"additionalProperties\":false,\"properties\":{\"name\":{\"default\":\"alex\",\"description\":\"The name of a friend\",\"examples\":[\"joe\",\"lucy\"],\"title\":\"the new name\",\"type\":\"string\"}},\"required\":[\"name\"],\"type\":\"object\"}},\"$ref\":\"#/$defs/MyProp\"}"

--- a/tests/local/mock_resource/property_definition.tfmock.hcl
+++ b/tests/local/mock_resource/property_definition.tfmock.hcl
@@ -1,5 +1,6 @@
 mock_resource "opslevel_property_definition" {
   defaults = {
     # id intentionally omitted - will be assigned a random string
+    locked_status = "unlocked"
   }
 }

--- a/tests/local/resource_property_definition.tftest.hcl
+++ b/tests/local/resource_property_definition.tftest.hcl
@@ -29,6 +29,12 @@ run "resource_property_definition" {
   }
 
   assert {
+    condition     = opslevel_property_definition.color_picker.locked_status == "unlocked"
+    error_message = "unexpected value for locked_status"
+  }
+
+
+  assert {
     condition = opslevel_property_definition.color_picker.schema == jsonencode({
       "type" : "string",
       "enum" : [

--- a/tests/local/resources.tf
+++ b/tests/local/resources.tf
@@ -111,6 +111,7 @@ resource "opslevel_property_definition" "color_picker" {
   })
   allowed_in_config_files = false
   property_display_status = "visible"
+  locked_status = "unlocked"
 }
 
 # Repository resources

--- a/tests/remote/property_assignment.tftest.hcl
+++ b/tests/remote/property_assignment.tftest.hcl
@@ -17,6 +17,7 @@ run "from_property_definition_module" {
     name                    = ""
     schema                  = jsonencode(null)
     property_display_status = "visible"
+    locked_status           = "unlocked"
   }
 
   module {

--- a/tests/remote/property_definition.tftest.hcl
+++ b/tests/remote/property_definition.tftest.hcl
@@ -6,6 +6,7 @@ variables {
   allowed_in_config_files = true
   name                    = "TF Test Property Definition"
   property_display_status = "visible"
+  locked_status           = "unlocked"
   schema                  = "{\"type\":\"boolean\"}"
 
   # optional fields
@@ -19,6 +20,7 @@ run "resource_property_definition_create_with_all_fields" {
     description             = var.description
     name                    = var.name
     property_display_status = var.property_display_status
+    locked_status           = var.locked_status
     schema                  = var.schema
   }
 
@@ -33,6 +35,7 @@ run "resource_property_definition_create_with_all_fields" {
       can(opslevel_property_definition.test.id),
       can(opslevel_property_definition.test.name),
       can(opslevel_property_definition.test.property_display_status),
+      can(opslevel_property_definition.test.locked_status),
       can(opslevel_property_definition.test.schema),
     ])
     error_message = replace(var.error_unexpected_resource_fields, "TYPE", var.property_definition_one)
@@ -61,6 +64,11 @@ run "resource_property_definition_create_with_all_fields" {
   assert {
     condition     = opslevel_property_definition.test.property_display_status == var.property_display_status
     error_message = "wrong property_display_status for opslevel_property_definition resource"
+  }
+
+  assert {
+    condition     = opslevel_property_definition.test.locked_status == var.locked_status
+    error_message = "wrong locked_status for opslevel_property_definition resource"
   }
 
   assert {
@@ -112,6 +120,7 @@ run "resource_property_definition_update_all_fields" {
     description             = "${var.description} updated"
     name                    = "${var.name} updated"
     property_display_status = "hidden"
+    locked_status           = "unlocked"
     schema                  = "{\"type\":\"string\"}"
   }
 
@@ -137,6 +146,11 @@ run "resource_property_definition_update_all_fields" {
   assert {
     condition     = opslevel_property_definition.test.property_display_status == var.property_display_status
     error_message = "wrong property_display_status for opslevel_property_definition resource"
+  }
+
+  assert {
+    condition     = opslevel_property_definition.test.locked_status == var.locked_status
+    error_message = "wrong locked_status for opslevel_property_definition resource"
   }
 
   assert {
@@ -178,6 +192,7 @@ run "datasource_property_definition_first" {
       can(data.opslevel_property_definition.first_property_definition_by_id.identifier),
       can(data.opslevel_property_definition.first_property_definition_by_id.name),
       can(data.opslevel_property_definition.first_property_definition_by_id.property_display_status),
+      can(data.opslevel_property_definition.first_property_definition_by_id.locked_status),
       can(data.opslevel_property_definition.first_property_definition_by_id.schema),
     ])
     error_message = replace(var.error_unexpected_datasource_fields, "TYPE", var.property_definition_one)

--- a/tests/remote/property_definition/variables.tf
+++ b/tests/remote/property_definition/variables.tf
@@ -19,6 +19,11 @@ variable "property_display_status" {
   description = "The display status of a custom property on service pages."
 }
 
+variable "locked_status" {
+  type        = string
+  description = "Restricts what sources are able to assign values to this property."
+}
+
 variable "schema" {
   type        = string
   description = "The schema of the property definition."


### PR DESCRIPTION
### Problem
Allows `PropertyDefinition.lockedStatus` to be configured using our Terraform Provider
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
