### PR TITLE
Add icon settings to component type resource

### DIFF
--- a/opslevel/resource_opslevel_component_type.go
+++ b/opslevel/resource_opslevel_component_type.go
@@ -134,11 +134,11 @@ func (s ComponentTypeResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"color": schema.StringAttribute{
-						Description: "The color of the icon.",
+						Description: "The color, represented as a hexcode, for the icon.",
 						Required:    true,
 					},
 					"name": schema.StringAttribute{
-						Description: "The name of the icon.",
+						Description: "The name of the icon in Phosphor icons for Vue, e.g. `PhBird`. See https://phosphoricons.com/ for a full list.",
 						Required:    true,
 						Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllComponentTypeIconEnum...)},
 					},

--- a/opslevel/resource_opslevel_component_type.go
+++ b/opslevel/resource_opslevel_component_type.go
@@ -115,11 +115,11 @@ func (s ComponentTypeResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			"name": schema.StringAttribute{
-				Description: "The name of the component type.",
+				Description: "The unique name of the component type.",
 				Required:    true,
 			},
 			"alias": schema.StringAttribute{
-				Description: "The alias of the component type.",
+				Description: "The unique alias of the component type.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -130,7 +130,7 @@ func (s ComponentTypeResource) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:    true,
 			},
 			"icon": schema.SingleNestedAttribute{
-				Description: "The icon of the component type.",
+				Description: "The icon associated with the component type",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"color": schema.StringAttribute{
@@ -150,11 +150,11 @@ func (s ComponentTypeResource) Schema(ctx context.Context, req resource.SchemaRe
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
-							Description: "The name of the property.",
+							Description: "The name of the property definition.",
 							Required:    true,
 						},
 						"description": schema.StringAttribute{
-							Description: "The description of the property.",
+							Description: "The description of the property definition.",
 							Optional:    true,
 						},
 						"allowed_in_config_files": schema.BoolAttribute{
@@ -173,7 +173,7 @@ func (s ComponentTypeResource) Schema(ctx context.Context, req resource.SchemaRe
 							},
 						},
 						"locked_status": schema.StringAttribute{
-							Description: "The locked status of the property.",
+							Description: "Restricts what sources are able to assign values to this property.",
 							Optional:    true,
 							Computed:    true,
 							Default:     stringdefault.StaticString(string(opslevel.PropertyLockedStatusEnumUILocked)),


### PR DESCRIPTION
Resolves #

### Problem

There is currently no ability to specify the icon for a component type

### Solution

Add this ability like this

```tf
resource "opslevel_component_type" "mobile" {
  ...
  icon = {
    color = "#f759ab"
    name  = "PhDeviceMobile"
  }
  ...
}
```

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
