### PR TITLE
Update changie yaml to latest and then sync change kinds to terraform…

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -2,23 +2,24 @@ changesDir: .changes
 unreleasedDir: unreleased
 headerPath: header.tpl.md
 versionHeaderPath: ""
+versionFooterPath: ""
 changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## {{.Version}} - [{{.Time.Format "January 02, 2006"}}](https://github.com/OpsLevel/terraform-provider-opslevel/compare/{{.PreviousVersion}}...{{.Version}})'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}}'
+changeFormat: '* {{.Body}}'
+headerFormat: ""
+footerFormat: ""
 kinds:
-  - label: Bugfix
-  - label: Feature
-  - label: Security
-  - label: Refactor
-  - label: Deprecated
-  - label: Removed
-  - label: Docs
-  - label: Dependency
-newlines:
-  afterChangelogHeader: 1
-  afterKind: 1
-  afterChangelogVersion: 1
-  beforeKind: 1
-  endOfVersion: 1
+- label: Fixed
+  auto: patch
+- label: Added
+  auto: minor
+- label: Deprecated
+  auto: minor
+- label: Removed
+  auto: major
+- label: Security
+  auto: patch
+- label: Dependency
+  auto: patch


### PR DESCRIPTION
… release guidelines

Resolves #

### Problem

We need to adhere to hashicorps semver guidelines for our releases because our customers expect it.

### Solution

Sync changie kind's up to the guidlines - then we can easily determine the next version we should release at using `changie batch auto` in our release process.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
