### PR TITLE
Improve docs and error handling

### DIFF
--- a/opslevel/resource_opslevel_property_assignment.go
+++ b/opslevel/resource_opslevel_property_assignment.go
@@ -78,14 +78,14 @@ func (resource *PropertyAssignmentResource) Schema(ctx context.Context, req reso
 				},
 			},
 			"owner": schema.StringAttribute{
-				Description: "The ID or alias of the entity (currently only supports service) that the property has been assigned to.",
+				Description: "The ID or alias of the entity that the property has been assigned to.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"value": schema.StringAttribute{
-				Description: "The value of the custom property (must be a valid JSON value or null or object).",
+				Description: "The value of the custom property (must be a valid JSON value or null).",
 				Optional:    true,
 				Validators: []validator.String{
 					JsonStringValidator(),
@@ -142,6 +142,10 @@ func (resource *PropertyAssignmentResource) Read(ctx context.Context, req resour
 	assignment, err := resource.client.GetProperty(owner, definition)
 	if err != nil {
 		resp.Diagnostics.AddError("opslevel client error", fmt.Sprintf("unable to read property assignment '%s' on service '%s', got error: %s", definition, owner, err))
+		return
+	}
+	if assignment == nil {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 


### PR DESCRIPTION
Resolves #

### Problem

The documentation states that property assignment only works on the default "service" component type.

### Solution

Fix the documentation after confirming it works

### Given this Terraform config file
```tf
resource "opslevel_property_assignment" "environment" {
  definition = "account_url"
  owner      = "gitlab"
  value      = jsonencode("hello")
}
```

### The `terraform apply` output
```bash
  # opslevel_property_assignment.environment will be created
  + resource "opslevel_property_assignment" "environment" {
      + definition = "pii"
      + id         = (known after apply)
      + locked     = (known after apply)
      + owner      = "gitlab"
      + value      = "true"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
opslevel_property_assignment.environment: Creating...
opslevel_property_assignment.environment: Creation complete after 1s [id=Z2lkOi8vb3BzbGV2ZWwvU2VydmljZS8yNzQ3NTU:Z2lkOi8vb3BzbGV2ZWwvUHJvcGVydGllczo6RGVmaW5pdGlvbi8xMTk4]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```

### Checklist

- [x] I have run this code, and it appears to resolve the stated issue.
- [x] This PR does not reduce total test coverage
- [x] This PR has no user interface changes or has already received approval from product management to change the interface.
- [x] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
