### PR TITLE
Fix bad docs

### DIFF
--- a/docs/resources/scorecard.md
+++ b/docs/resources/scorecard.md
@@ -42,7 +42,7 @@ resource "opslevel_scorecard" "my_scorecard" {
 // Example of how to assign a check to a scorecard
 resource "opslevel_check_manual" "my_check" {
   name                    = "My check that uses a scorecard"
-  category                = opslevel_scorecard.my_scorecard.id
+  category                = opslevel_scorecard.my_scorecard.categories[0]
   level                   = data.opslevel_rubric_level.bronze.id
   update_requires_comment = true
 }


### PR DESCRIPTION
Resolves #

### Problem

The current documentation example for adding checks to a scorecard uses the wrong ID for the check creation

### Solution

Fix the documentation example to use the category id for creating a check

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
