### PR TITLE
Add field "System" to datasource "opslevel_service"

### DIFF
--- a/.changes/unreleased/Added-20250502-093814.yaml
+++ b/.changes/unreleased/Added-20250502-093814.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add field "System" to datasource "opslevel_service"
+time: 2025-05-02T09:38:14.684655-05:00

--- a/opslevel/datasource_opslevel_service.go
+++ b/opslevel/datasource_opslevel_service.go
@@ -3,6 +3,7 @@ package opslevel
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -27,23 +28,24 @@ type ServiceDataSource struct {
 
 // ServiceDataSourceModel describes the data source data model.
 type ServiceDataSourceModel struct {
-	Alias                      types.String    `tfsdk:"alias"`
-	Aliases                    types.List      `tfsdk:"aliases"`
-	ApiDocumentPath            types.String    `tfsdk:"api_document_path"`
-	Description                types.String    `tfsdk:"description"`
-	Framework                  types.String    `tfsdk:"framework"`
-	Id                         types.String    `tfsdk:"id"`
-	Language                   types.String    `tfsdk:"language"`
-	LifecycleAlias             types.String    `tfsdk:"lifecycle_alias"`
-	Name                       types.String    `tfsdk:"name"`
-	Owner                      types.String    `tfsdk:"owner"`
-	OwnerId                    types.String    `tfsdk:"owner_id"`
-	PreferredApiDocumentSource types.String    `tfsdk:"preferred_api_document_source"`
-	Product                    types.String    `tfsdk:"product"`
-	Properties                 []propertyModel `tfsdk:"properties"`
-	Repositories               types.List      `tfsdk:"repositories"`
-	Tags                       types.List      `tfsdk:"tags"`
-	TierAlias                  types.String    `tfsdk:"tier_alias"`
+	Alias                      types.String          `tfsdk:"alias"`
+	Aliases                    types.List            `tfsdk:"aliases"`
+	ApiDocumentPath            types.String          `tfsdk:"api_document_path"`
+	Description                types.String          `tfsdk:"description"`
+	Framework                  types.String          `tfsdk:"framework"`
+	Id                         types.String          `tfsdk:"id"`
+	Language                   types.String          `tfsdk:"language"`
+	LifecycleAlias             types.String          `tfsdk:"lifecycle_alias"`
+	Name                       types.String          `tfsdk:"name"`
+	Owner                      types.String          `tfsdk:"owner"`
+	OwnerId                    types.String          `tfsdk:"owner_id"`
+	PreferredApiDocumentSource types.String          `tfsdk:"preferred_api_document_source"`
+	Product                    types.String          `tfsdk:"product"`
+	Properties                 []propertyModel       `tfsdk:"properties"`
+	Repositories               types.List            `tfsdk:"repositories"`
+	System                     systemDataSourceModel `tfsdk:"system"`
+	Tags                       types.List            `tfsdk:"tags"`
+	TierAlias                  types.String          `tfsdk:"tier_alias"`
 }
 
 type propertyModel struct {
@@ -209,6 +211,14 @@ func (d *ServiceDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				Description: "List of repositories connected to the service.",
 				Computed:    true,
 			},
+			"system": schema.ObjectAttribute{
+				Description: "The isystem that the service belongs to.",
+				Computed:    true,
+				AttributeTypes: map[string]attr.Type{
+					"aliases": types.ListType{ElemType: types.StringType},
+					"id":      types.StringType,
+				},
+			},
 			"tags": schema.ListAttribute{
 				ElementType: types.StringType,
 				Description: "A list of tags applied to the service.",
@@ -246,6 +256,19 @@ func (d *ServiceDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	stateModel := NewServiceDataSourceModel(ctx, service, planModel.Alias.ValueString())
+
+	system, err := service.GetSystem(d.client, nil)
+	if err != nil {
+		diags.AddAttributeError(
+			path.Root("system"),
+			"OpsLevel Client Error",
+			fmt.Sprintf("unable to read System for service, got error: %s", err),
+		)
+		return
+	}
+	if system != nil {
+		stateModel.System = newSystemDataSourceModel(*system)
+	}
 
 	// NOTE: service's hydrate does not populate properties
 	properties, err := service.GetProperties(d.client, nil)


### PR DESCRIPTION
Resolves #567

### Problem

There is no System information on the service datasource

### Solution

Add the field by requesting the system information for the service

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
