### PR TITLE
Add graceful handling of missing service repository on service

### DIFF
--- a/.changes/unreleased/Fixed-20250502-101005.yaml
+++ b/.changes/unreleased/Fixed-20250502-101005.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Add graceful handling of missing service repository on service
+time: 2025-05-02T10:10:05.776455-05:00

--- a/opslevel/resource_opslevel_service_repository.go
+++ b/opslevel/resource_opslevel_service_repository.go
@@ -215,7 +215,8 @@ func (r *ServiceRepositoryResource) Read(ctx context.Context, req resource.ReadR
 		}
 	}
 	if serviceRepository == nil {
-		resp.Diagnostics.AddError("opslevel client error", "Unable to find service repository")
+		resp.Diagnostics.AddWarning("opslevel client error", "Unable to find service repository")
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), nil)...)
 		return
 	}
 


### PR DESCRIPTION
Resolves #573

### Problem

When a service respository goes missing we error instead of trying to recreate it

### Solution

In the read function nullify the ID so that terraform will try to re-create it.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
