### PR TITLE
Add ability to create property checks for custom components

### DIFF
--- a/.changes/unreleased/Added-20250819-141449.yaml
+++ b/.changes/unreleased/Added-20250819-141449.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add field "component_type" to "opslevel_check_service_property" so you can create property checks for custom components
+time: 2025-08-19T14:14:49.641762-04:00


### PR DESCRIPTION
Resolves #605

### Problem

Unable to create property checks for custom componets

### Solution

The is the case because you need to specify `component_type` when you choose a property definition thats on a custom componet type.  opslevel-go already had the functionality it just wasn't exposed to the schema of the terraform resource.

example (note the `component_type` field):
```tf
resource "opslevel_check_service_property" "example" {
  name                = "foo"
  enabled             = false
  category            = data.opslevel_rubric_category.security.id
  level               = data.opslevel_rubric_level.bronze.id
  component_type      = "tool"
  property            = "custom_property"
  property_definition = "release_strategy"
  predicate = {
    type = "exists"
  }
}
```


<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file


### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
