### PR TITLE
Get Service Dependency Service Id

### DIFF
--- a/.changes/unreleased/Added-20250911-102604.yaml
+++ b/.changes/unreleased/Added-20250911-102604.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add ability to get at the actual service dependency service id on datasource opslevel_service_dependencies
+time: 2025-09-11T10:26:04.889822-04:00

--- a/opslevel/datasource_opslevel_service_dependencies.go
+++ b/opslevel/datasource_opslevel_service_dependencies.go
@@ -32,15 +32,17 @@ type ServiceDependenciesModel struct {
 }
 
 type dependentsModel struct {
-	Id     types.String `tfsdk:"id"`
-	Locked types.Bool   `tfsdk:"locked"`
-	Notes  types.String `tfsdk:"notes"`
+	Id        types.String `tfsdk:"id"`
+	ServiceId types.String `tfsdk:"service_id"`
+	Locked    types.Bool   `tfsdk:"locked"`
+	Notes     types.String `tfsdk:"notes"`
 }
 
 type dependenciesModel struct {
-	Id     types.String `tfsdk:"id"`
-	Locked types.Bool   `tfsdk:"locked"`
-	Notes  types.String `tfsdk:"notes"`
+	Id        types.String `tfsdk:"id"`
+	ServiceId types.String `tfsdk:"service_id"`
+	Locked    types.Bool   `tfsdk:"locked"`
+	Notes     types.String `tfsdk:"notes"`
 }
 
 func NewServiceDependenciesModel(serviceIdentifier string, dependents []dependentsModel, dependencies []dependenciesModel) ServiceDependenciesModel {
@@ -58,6 +60,10 @@ func (d *ServiceDependenciesDataSource) Metadata(ctx context.Context, req dataso
 var depsAttrs = map[string]schema.Attribute{
 	"id": schema.StringAttribute{
 		Description: "The ID of the service dependency.",
+		Computed:    true,
+	},
+	"service_id": schema.StringAttribute{
+		Description: "The ID of the service this dependency points to.",
 		Computed:    true,
 	},
 	"locked": schema.BoolAttribute{
@@ -149,9 +155,10 @@ func getDependenciesModelOfService(client *opslevel.Client, service *opslevel.Se
 
 	for _, svcDependency := range svcDependencies.Edges {
 		dependencies = append(dependencies, dependenciesModel{
-			Locked: types.BoolValue(svcDependency.Locked),
-			Id:     ComputedStringValue(string(svcDependency.Id)),
-			Notes:  ComputedStringValue(svcDependency.Notes),
+			Locked:    types.BoolValue(svcDependency.Locked),
+			Id:        ComputedStringValue(string(svcDependency.Id)),
+			ServiceId: ComputedStringValue(string(svcDependency.Node.Id)),
+			Notes:     ComputedStringValue(svcDependency.Notes),
 		})
 	}
 	return dependencies, nil
@@ -166,9 +173,10 @@ func getDependentsModelOfService(client *opslevel.Client, service *opslevel.Serv
 
 	for _, svcDependent := range svcDependents.Edges {
 		dependents = append(dependents, dependentsModel{
-			Locked: types.BoolValue(svcDependent.Locked),
-			Id:     ComputedStringValue(string(svcDependent.Id)),
-			Notes:  ComputedStringValue(svcDependent.Notes),
+			Locked:    types.BoolValue(svcDependent.Locked),
+			Id:        ComputedStringValue(string(svcDependent.Id)),
+			ServiceId: ComputedStringValue(string(svcDependent.Node.Id)),
+			Notes:     ComputedStringValue(svcDependent.Notes),
 		})
 	}
 	return dependents, nil


### PR DESCRIPTION
Resolves #601

### Problem

When using the datasource `opslevel_service_dependencies` there was no way to get at the actual service id the dependency pointed to - only the "service_dependency" join table ID.

### Solution

Add a field for this and map in the data.

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
