### PR TITLE
Always set identifiers based on received identifiers

### DIFF
--- a/opslevel/resource_opslevel_repository.go
+++ b/opslevel/resource_opslevel_repository.go
@@ -126,20 +126,10 @@ func (r *RepositoryResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	stateModel := NewRepositoryResourceModel(ctx, *updatedRepository)
 
-	// Identifier from plan can be an id or alias
-	switch planModel.Identifier.ValueString() {
-	case string(updatedRepository.Id), updatedRepository.DefaultAlias:
-		stateModel.Identifier = planModel.Identifier
-	default:
-		resp.Diagnostics.AddError(
-			"opslevel client error",
-			fmt.Sprintf("given repository identifier '%s' did not match found repository's id '%s' or alias '%s'",
-				planModel.Identifier.ValueString(),
-				string(updatedRepository.Id),
-				updatedRepository.DefaultAlias,
-			),
-		)
-		return
+	if opslevel.IsID(identifier) {
+		stateModel.Identifier = types.StringValue(string(updatedRepository.Id))
+	} else {
+		stateModel.Identifier = types.StringValue(updatedRepository.DefaultAlias)
 	}
 
 	tflog.Trace(ctx, "created a repository resource")
@@ -160,19 +150,11 @@ func (r *RepositoryResource) Read(ctx context.Context, req resource.ReadRequest,
 	verifiedStateModel := NewRepositoryResourceModel(ctx, *readRepository)
 
 	// Identifier from plan can be an id or alias
-	switch stateModel.Identifier.ValueString() {
-	case string(readRepository.Id), readRepository.DefaultAlias:
-		verifiedStateModel.Identifier = stateModel.Identifier
-	default:
-		resp.Diagnostics.AddError(
-			"opslevel client error",
-			fmt.Sprintf("given repository identifier '%s' did not match found repository's id '%s' or alias '%s'",
-				stateModel.Identifier.ValueString(),
-				string(readRepository.Id),
-				readRepository.DefaultAlias,
-			),
-		)
-		return
+	stateIdentifier := stateModel.Identifier.ValueString()
+	if opslevel.IsID(stateIdentifier) {
+		verifiedStateModel.Identifier = types.StringValue(string(readRepository.Id))
+	} else {
+		verifiedStateModel.Identifier = types.StringValue(readRepository.DefaultAlias)
 	}
 
 	// Save updated data into Terraform state
@@ -203,20 +185,11 @@ func (r *RepositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 	stateModel := NewRepositoryResourceModel(ctx, *updatedRepository)
 
-	// Identifier from plan can be an id or alias
-	switch planModel.Identifier.ValueString() {
-	case string(updatedRepository.Id), updatedRepository.DefaultAlias:
-		stateModel.Identifier = planModel.Identifier
-	default:
-		resp.Diagnostics.AddError(
-			"opslevel client error",
-			fmt.Sprintf("given repository identifier '%s' did not match found repository's id '%s' or alias '%s'",
-				planModel.Identifier.ValueString(),
-				string(updatedRepository.Id),
-				updatedRepository.DefaultAlias,
-			),
-		)
-		return
+	stateIdentifier := planModel.Identifier.ValueString()
+	if opslevel.IsID(stateIdentifier) {
+		stateModel.Identifier = types.StringValue(string(updatedRepository.Id))
+	} else {
+		stateModel.Identifier = types.StringValue(updatedRepository.DefaultAlias)
 	}
 
 	// Owner from plan can be an id or alias


### PR DESCRIPTION
Resolves #https://gitlab.com/jklabsinc/OpsLevel/-/issues/14224

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Our logic was raising an error when an identifier received from a request did not match the identifier used, preventing plans from being created. This doesn't make sense when using an alias, as it's possible for an alias to change underneath the feet of terraform.

### Solution

If you do the following:
- create a repo within opslevel (forge doesn't matter, I used github)
- import the repo, using the alias as the identifier
- ensure that the repo has been pulled into your state
- change the name within your forge
- update your config to match the new name
- error should be reproduced

This is a rough terraform config set to try, it will change based on your repo.

Initial config
```tf
resource "opslevel_team" "matterhorn" {
  name = "Matterhorn"
}

resource "opslevel_repository" "test_3" {
  identifier      = "github.com:andrewstillv15/test-3"
  owner           = opslevel_team.matterhorn.id
  sbom_generation = "opt_in"
}
```

config after name change
```tf
resource "opslevel_team" "matterhorn" {
  name = "Matterhorn"
}

resource "opslevel_repository" "test_3_renamed" {
  identifier      = "github.com:andrewstillv15/test_3_renamed"
  owner           = opslevel_team.matterhorn.id
  sbom_generation = "opt_in"
}
```

After this fix, you should be able to generate a plan with the changed repo name.

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
