### PR TITLE
Added support for filtering components on component type

### DIFF
--- a/.changes/unreleased/Added-20260130-173017.yaml
+++ b/.changes/unreleased/Added-20260130-173017.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added support for filtering components on component type
+time: 2026-01-30T17:30:17.918758-05:00

--- a/docs/data-sources/services.md
+++ b/docs/data-sources/services.md
@@ -36,6 +36,17 @@ data "opslevel_services" "frontend" {
   }
 }
 
+data "opslevel_component_type" "service" {
+  identifier = "service"
+}
+
+data "opslevel_services" "only_services" {
+  filter = {
+    field = "component_type"
+    value = data.opslevel_component_type.service.id
+  }
+}
+
 output "all_services" {
   value = data.opslevel_services.all.services
 }
@@ -63,7 +74,7 @@ output "frontend_services_urls" {
 
 ### Optional
 
-- `filter` (Attributes) Used to filter services by one of 'filter`, `framework`, `language`, `lifecycle`, `owner`, `product`, `tag`, `tier' (see [below for nested schema](#nestedatt--filter))
+- `filter` (Attributes) Used to filter services by one of `component_type`, `filter`, `framework`, `language`, `lifecycle`, `owner`, `product`, `tag`, `tier` (see [below for nested schema](#nestedatt--filter))
 
 ### Read-Only
 
@@ -74,8 +85,8 @@ output "frontend_services_urls" {
 
 Required:
 
-- `field` (String) The field of the target resource to filter upon. One of `filter`, `framework`, `language`, `lifecycle`, `owner`, `product`, `tag`, `tier`
-- `value` (String) The field value of the target resource to match.
+- `field` (String) The field of the target resource to filter upon. One of `component_type`, `filter`, `framework`, `language`, `lifecycle`, `owner`, `product`, `tag`, `tier`
+- `value` (String) The field value of the target resource to match. Note: For `component_type`, this must be the component type ID (not alias). Use a `data.opslevel_component_type` data source to get the ID.
 
 
 <a id="nestedatt--services"></a>

--- a/opslevel/datasource_opslevel_services_all.go
+++ b/opslevel/datasource_opslevel_services_all.go
@@ -69,7 +69,7 @@ type serviceMinimalaDataSourceModel struct {
 }
 
 func (d *ServiceDataSourcesAll) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	validFieldNames := []string{"filter", "framework", "language", "lifecycle", "owner", "product", "tag", "tier"}
+	validFieldNames := []string{"component_type", "filter", "framework", "language", "lifecycle", "owner", "product", "tag", "tier"}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Services data source",
 
@@ -106,6 +106,13 @@ func (d *ServiceDataSourcesAll) Read(ctx context.Context, req datasource.ReadReq
 		services, err = d.client.ListServices(nil)
 	} else {
 		switch planModel.Filter.Field.ValueString() {
+		case "component_type":
+			componentTypeValue := planModel.Filter.Value.ValueString()
+			filterInput := opslevel.ServiceFilterInput{
+				Key: &opslevel.ServiceFilterEnumComponentTypeID,
+				Arg: componentTypeValue,
+			}
+			services, err = d.client.ListServicesWithInputFilter(filterInput, nil)
 		case "filter":
 			filterId := planModel.Filter.Value.ValueString()
 			if opslevel.IsID(filterId) {


### PR DESCRIPTION
Resolves #[14335
](https://gitlab.com/jklabsinc/OpsLevel/-/issues/14335)
### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

We didn't support filtering by component type in the provider when listing components

### Solution

Add support for filtering on component type

simple test config to demonstrate filtering in action

```
data "opslevel_component_type" "utility" {
  identifier = "utility"
}

resource "opslevel_service" "test_utility" {
  name = "tf-test-component-type-utility"
  type = data.opslevel_component_type.utility.alias
}

data "opslevel_services" "all" {
  depends_on = [opslevel_service.test_utility]
}

data "opslevel_services" "only_utilities" {
  filter = {
    field = "component_type"
    value = data.opslevel_component_type.utility.id
  }
  depends_on = [opslevel_service.test_utility]
}

output "all_count" {
  value = length(data.opslevel_services.all.services)
}

output "filtered_count" {
  value = length(data.opslevel_services.only_utilities.services)
}

```



<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.

  For Terraform you'll want to make sure we can CRUD the resource and then also
  be able to mutate different fields with different values, especially null.

### Given this Terraform config file
```tf

```

### The `terraform apply` output
```bash

```
-->

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
