### PR TITLE
Write customEvent type from api

### DIFF
--- a/.changes/unreleased/Fixed-integration-endpoint-import-type.yaml
+++ b/.changes/unreleased/Fixed-integration-endpoint-import-type.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed `opslevel_integration_endpoint` import incorrectly storing empty `type` in state, which caused forced resource replacement on subsequent plans
+time: 2026-04-01T00:00:00Z

--- a/opslevel/resource_opslevel_integration_endpoint.go
+++ b/opslevel/resource_opslevel_integration_endpoint.go
@@ -42,7 +42,7 @@ func NewIntegrationEndpointResourceModel(integrationEndpoint opslevel.Integratio
 	return IntegrationEndpointResourceModel{
 		Id:         ComputedStringValue(string(integrationEndpoint.Id)),
 		Name:       RequiredStringValue(integrationEndpoint.Name),
-		Type:       RequiredStringValue(givenModel.Type.ValueString()),
+		Type:       RequiredStringValue(integrationEndpoint.Type),
 		WebhookURL: ComputedStringValue(*integrationEndpoint.WebhookURL),
 	}
 }


### PR DESCRIPTION
Resolves #

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Reading the type out of the state was broken on import as on import there is no type in the state.

### Solution

To test, attempt to import an existing custom integration

```
  resource "opslevel_integration_endpoint" "import_me" {
    name = "<integration_name>"                                                                                                                                                                                                                                                   
    type = "customEvent"
  }

terraform import opslevel_integration_endpoint.import_me <integration_id>
```

Without the change, it will try to overwrite the "customEvent" type with an empty string. With it, it will read the response from the API (now "customEvent").

Creating an integration via the provider will still work as the type will still be "customEvent".

### Checklist

- [ ] I have run this code, and it appears to resolve the stated issue.
- [ ] This PR does not reduce total test coverage
- [ ] This PR has no user interface changes or has already received approval from product management to change the interface.
- [ ] Make a [changie](https://github.com/OpsLevel/terraform-provider-opslevel/blob/main/CONTRIBUTING.md#changie-change-log-generation) entry that explains the customer facing outcome of this change
