### PR TITLE
Add reminder configuration to opslevel_campaign resource

### DIFF
--- a/.changes/unreleased/Added-20260609-150500.yaml
+++ b/.changes/unreleased/Added-20260609-150500.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added a `reminder` block to the `opslevel_campaign` resource for configuring recurring Slack, email, and Microsoft Teams reminders on a schedule.
+time: 2026-06-09T15:05:00.000000-05:00

--- a/docs/data-sources/campaign.md
+++ b/docs/data-sources/campaign.md
@@ -27,8 +27,25 @@ Campaign data source
 - `name` (String) The name of the campaign.
 - `owner_id` (String) The ID of the team that owns this campaign.
 - `project_brief` (String) The raw project brief of the campaign (Markdown).
+- `reminder` (Attributes) The recurring reminder configured for this campaign, if any. (see [below for nested schema](#nestedatt--reminder))
 - `start_date` (String) The start date of the campaign.
 - `status` (String) The current status of the campaign.
 - `target_date` (String) The target end date of the campaign.
+
+<a id="nestedatt--reminder"></a>
+### Nested Schema for `reminder`
+
+Read-Only:
+
+- `channels` (List of String) The channels through which reminders are delivered.
+- `days_of_week` (List of String) The weekdays on which reminders are delivered (weekly cadence only).
+- `default_microsoft_teams_channel` (String) Microsoft Teams channel notified when a team has no default Teams contact.
+- `default_slack_channel` (String) Slack channel notified when a team has no default Slack contact.
+- `frequency` (Number) The interval (in frequency_unit) at which reminders are delivered.
+- `frequency_unit` (String) The unit of the frequency interval.
+- `message` (String) The custom message included in the reminder.
+- `next_occurrence` (String) The next time a reminder will be delivered, based on the current configuration.
+- `time_of_day` (String) The time of day reminders are delivered, in 24-hour "HH:MM" format.
+- `timezone` (String) The IANA timezone in which time_of_day is evaluated.
 
 

--- a/docs/data-sources/campaigns.md
+++ b/docs/data-sources/campaigns.md
@@ -34,8 +34,25 @@ Read-Only:
 - `name` (String) The name of the campaign.
 - `owner_id` (String) The ID of the team that owns this campaign.
 - `project_brief` (String) The raw project brief of the campaign (Markdown).
+- `reminder` (Attributes) The recurring reminder configured for this campaign, if any. (see [below for nested schema](#nestedatt--campaigns--reminder))
 - `start_date` (String) The start date of the campaign.
 - `status` (String) The current status of the campaign.
 - `target_date` (String) The target end date of the campaign.
+
+<a id="nestedatt--campaigns--reminder"></a>
+### Nested Schema for `campaigns.reminder`
+
+Read-Only:
+
+- `channels` (List of String) The channels through which reminders are delivered.
+- `days_of_week` (List of String) The weekdays on which reminders are delivered (weekly cadence only).
+- `default_microsoft_teams_channel` (String) Microsoft Teams channel notified when a team has no default Teams contact.
+- `default_slack_channel` (String) Slack channel notified when a team has no default Slack contact.
+- `frequency` (Number) The interval (in frequency_unit) at which reminders are delivered.
+- `frequency_unit` (String) The unit of the frequency interval.
+- `message` (String) The custom message included in the reminder.
+- `next_occurrence` (String) The next time a reminder will be delivered, based on the current configuration.
+- `time_of_day` (String) The time of day reminders are delivered, in 24-hour "HH:MM" format.
+- `timezone` (String) The IANA timezone in which time_of_day is evaluated.
 
 

--- a/docs/resources/campaign.md
+++ b/docs/resources/campaign.md
@@ -41,6 +41,21 @@ resource "opslevel_campaign" "upgrade_rails" {
     2. Run the Rails upgrade checklist
     3. Verify all tests pass
   EOT
+
+  # Send a weekly Slack and email reminder to component owners while the
+  # campaign is in progress. days_of_week is only valid with a weekly cadence.
+  reminder = {
+    channels       = ["slack", "email"]
+    frequency      = 1
+    frequency_unit = "week"
+    days_of_week   = ["monday", "thursday"]
+    time_of_day    = "09:30"
+    timezone       = "America/Chicago"
+    message        = "Friendly reminder to complete your Rails 7 upgrade checks."
+
+    # Fallback channel used when a team has no default Slack contact.
+    default_slack_channel = "#platform-eng"
+  }
 }
 ```
 
@@ -57,6 +72,7 @@ resource "opslevel_campaign" "upgrade_rails" {
 - `check_ids` (List of String) List of rubric check IDs to associate with this campaign. On create, checks are copied into the campaign. On update, checks are added or removed to match the desired set.
 - `filter_id` (String) The ID of the filter applied to this campaign.
 - `project_brief` (String) The project brief of the campaign (Markdown).
+- `reminder` (Attributes) Configuration for recurring campaign reminders sent to component owners via Slack, email, or Microsoft Teams. Reminders are only delivered while the campaign is in_progress or delayed. (see [below for nested schema](#nestedatt--reminder))
 - `start_date` (String) The start date of the campaign (YYYY-MM-DD). Setting both start_date and target_date schedules the campaign.
 - `target_date` (String) The target end date of the campaign (YYYY-MM-DD). Setting both start_date and target_date schedules the campaign.
 
@@ -65,6 +81,28 @@ resource "opslevel_campaign" "upgrade_rails" {
 - `html_url` (String) The URL to the campaign in the OpsLevel UI.
 - `id` (String) The ID of the campaign.
 - `status` (String) The current status of the campaign (draft, scheduled, in_progress, delayed, ended).
+
+<a id="nestedatt--reminder"></a>
+### Nested Schema for `reminder`
+
+Required:
+
+- `channels` (List of String) The channels through which reminders are delivered. One or more of: email, microsoft_teams, slack.
+- `frequency` (Number) The interval (in frequency_unit) at which reminders are delivered. Must be at least 1.
+- `frequency_unit` (String) The unit of the frequency interval. One of: day, month, week.
+- `time_of_day` (String) The time of day reminders are delivered, in 24-hour "HH:MM" format.
+- `timezone` (String) The IANA timezone in which time_of_day is evaluated (e.g. "America/Chicago").
+
+Optional:
+
+- `days_of_week` (List of String) The weekdays on which reminders are delivered. Only supported (and required) when frequency_unit is "week".
+- `default_microsoft_teams_channel` (String) Microsoft Teams channel notified when a team has no default Teams contact.
+- `default_slack_channel` (String) Slack channel notified when a team has no default Slack contact. A leading '#' is added automatically.
+- `message` (String) An optional custom message included in the reminder.
+
+Read-Only:
+
+- `next_occurrence` (String) The next time a reminder will be delivered, based on the current configuration. Null until the campaign is in_progress or delayed.
 
 ## Import
 

--- a/examples/resources/opslevel_campaign/resource.tf
+++ b/examples/resources/opslevel_campaign/resource.tf
@@ -26,4 +26,19 @@ resource "opslevel_campaign" "upgrade_rails" {
     2. Run the Rails upgrade checklist
     3. Verify all tests pass
   EOT
+
+  # Send a weekly Slack and email reminder to component owners while the
+  # campaign is in progress. days_of_week is only valid with a weekly cadence.
+  reminder = {
+    channels       = ["slack", "email"]
+    frequency      = 1
+    frequency_unit = "week"
+    days_of_week   = ["monday", "thursday"]
+    time_of_day    = "09:30"
+    timezone       = "America/Chicago"
+    message        = "Friendly reminder to complete your Rails 7 upgrade checks."
+
+    # Fallback channel used when a team has no default Slack contact.
+    default_slack_channel = "#platform-eng"
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,8 @@ require (
 	mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 // indirect
 )
 
-// replace github.com/opslevel/opslevel-go/v2026 => ./submodules/opslevel-go
+// TODO: remove before merge and bump the require above to the released opslevel-go version.
+replace github.com/opslevel/opslevel-go/v2026 => ./submodules/opslevel-go
 
 tool (
 	github.com/go-delve/delve/cmd/dlv

--- a/opslevel/datasource_opslevel_campaign.go
+++ b/opslevel/datasource_opslevel_campaign.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/opslevel/opslevel-go/v2026"
@@ -46,6 +47,54 @@ var campaignSchemaAttrs = map[string]schema.Attribute{
 		Description: "The raw project brief of the campaign (Markdown).",
 		Computed:    true,
 	},
+	"reminder": schema.SingleNestedAttribute{
+		Description: "The recurring reminder configured for this campaign, if any.",
+		Computed:    true,
+		Attributes: map[string]schema.Attribute{
+			"channels": schema.ListAttribute{
+				Description: "The channels through which reminders are delivered.",
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"frequency": schema.Int64Attribute{
+				Description: "The interval (in frequency_unit) at which reminders are delivered.",
+				Computed:    true,
+			},
+			"frequency_unit": schema.StringAttribute{
+				Description: "The unit of the frequency interval.",
+				Computed:    true,
+			},
+			"time_of_day": schema.StringAttribute{
+				Description: "The time of day reminders are delivered, in 24-hour \"HH:MM\" format.",
+				Computed:    true,
+			},
+			"timezone": schema.StringAttribute{
+				Description: "The IANA timezone in which time_of_day is evaluated.",
+				Computed:    true,
+			},
+			"days_of_week": schema.ListAttribute{
+				Description: "The weekdays on which reminders are delivered (weekly cadence only).",
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"message": schema.StringAttribute{
+				Description: "The custom message included in the reminder.",
+				Computed:    true,
+			},
+			"default_slack_channel": schema.StringAttribute{
+				Description: "Slack channel notified when a team has no default Slack contact.",
+				Computed:    true,
+			},
+			"default_microsoft_teams_channel": schema.StringAttribute{
+				Description: "Microsoft Teams channel notified when a team has no default Teams contact.",
+				Computed:    true,
+			},
+			"next_occurrence": schema.StringAttribute{
+				Description: "The next time a reminder will be delivered, based on the current configuration.",
+				Computed:    true,
+			},
+		},
+	},
 	"start_date": schema.StringAttribute{
 		Description: "The start date of the campaign.",
 		Computed:    true,
@@ -75,12 +124,13 @@ type campaignDataSourceModel struct {
 	Name         types.String `tfsdk:"name"`
 	OwnerId      types.String `tfsdk:"owner_id"`
 	ProjectBrief types.String `tfsdk:"project_brief"`
+	Reminder     types.Object `tfsdk:"reminder"`
 	StartDate    types.String `tfsdk:"start_date"`
 	Status       types.String `tfsdk:"status"`
 	TargetDate   types.String `tfsdk:"target_date"`
 }
 
-func newCampaignDataSourceModel(campaign opslevel.Campaign, identifier string) campaignDataSourceModel {
+func newCampaignDataSourceModel(ctx context.Context, diags *diag.Diagnostics, campaign opslevel.Campaign, identifier string) campaignDataSourceModel {
 	model := campaignDataSourceModel{
 		FilterId:     ComputedStringValue(string(campaign.Filter.Id)),
 		HtmlUrl:      ComputedStringValue(campaign.HtmlUrl),
@@ -89,6 +139,7 @@ func newCampaignDataSourceModel(campaign opslevel.Campaign, identifier string) c
 		Name:         ComputedStringValue(campaign.Name),
 		OwnerId:      ComputedStringValue(string(campaign.Owner.Id)),
 		ProjectBrief: ComputedStringValue(campaign.RawProjectBrief),
+		Reminder:     campaignReminderToObject(ctx, diags, campaign.Reminder, types.ObjectNull(reminderAttrTypes())),
 		Status:       ComputedStringValue(string(campaign.Status)),
 	}
 	if !campaign.StartDate.IsZero() {
@@ -133,7 +184,10 @@ func (d *CampaignDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	stateModel := newCampaignDataSourceModel(*campaign, configModel.Identifier.ValueString())
+	stateModel := newCampaignDataSourceModel(ctx, &resp.Diagnostics, *campaign, configModel.Identifier.ValueString())
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	tflog.Trace(ctx, "read an OpsLevel Campaign data source")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateModel)...)
 }

--- a/opslevel/datasource_opslevel_campaigns_all.go
+++ b/opslevel/datasource_opslevel_campaigns_all.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/opslevel/opslevel-go/v2026"
@@ -28,6 +29,7 @@ type campaignListItemModel struct {
 	Name         types.String `tfsdk:"name"`
 	OwnerId      types.String `tfsdk:"owner_id"`
 	ProjectBrief types.String `tfsdk:"project_brief"`
+	Reminder     types.Object `tfsdk:"reminder"`
 	StartDate    types.String `tfsdk:"start_date"`
 	Status       types.String `tfsdk:"status"`
 	TargetDate   types.String `tfsdk:"target_date"`
@@ -38,7 +40,7 @@ type campaignDataSourcesAllModel struct {
 	Campaigns []campaignListItemModel `tfsdk:"campaigns"`
 }
 
-func newCampaignListItemModels(campaigns []opslevel.Campaign) []campaignListItemModel {
+func newCampaignListItemModels(ctx context.Context, diags *diag.Diagnostics, campaigns []opslevel.Campaign) []campaignListItemModel {
 	models := make([]campaignListItemModel, 0, len(campaigns))
 	for _, c := range campaigns {
 		m := campaignListItemModel{
@@ -48,6 +50,7 @@ func newCampaignListItemModels(campaigns []opslevel.Campaign) []campaignListItem
 			Name:         ComputedStringValue(c.Name),
 			OwnerId:      OptionalStringValue(string(c.Owner.Id)),
 			ProjectBrief: OptionalStringValue(c.RawProjectBrief),
+			Reminder:     campaignReminderToObject(ctx, diags, c.Reminder, types.ObjectNull(reminderAttrTypes())),
 			Status:       ComputedStringValue(string(c.Status)),
 		}
 		if !c.StartDate.IsZero() {
@@ -109,7 +112,10 @@ func (d *CampaignDataSourcesAll) Read(ctx context.Context, req datasource.ReadRe
 
 	stateModel := campaignDataSourcesAllModel{
 		Status:    configModel.Status,
-		Campaigns: newCampaignListItemModels(campaigns.Nodes),
+		Campaigns: newCampaignListItemModels(ctx, &resp.Diagnostics, campaigns.Nodes),
+	}
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	tflog.Trace(ctx, "read OpsLevel Campaigns data source")

--- a/opslevel/resource_opslevel_campaign.go
+++ b/opslevel/resource_opslevel_campaign.go
@@ -368,31 +368,44 @@ func (r *CampaignResource) ValidateConfig(ctx context.Context, req resource.Vali
 		)
 	}
 
-	if !config.Reminder.IsNull() && !config.Reminder.IsUnknown() {
-		var rm CampaignReminderModel
-		resp.Diagnostics.Append(config.Reminder.As(ctx, &rm, basetypes.ObjectAsOptions{})...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+	resp.Diagnostics.Append(validateReminderConfig(ctx, config.Reminder)...)
+}
 
-		isWeekly := rm.FrequencyUnit.ValueString() == string(opslevel.CampaignReminderFrequencyUnitEnumWeek)
-		hasDays := !rm.DaysOfWeek.IsNull() && !rm.DaysOfWeek.IsUnknown() && len(rm.DaysOfWeek.Elements()) > 0
-
-		if isWeekly && !hasDays {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("reminder").AtName("days_of_week"),
-				"Invalid Reminder Configuration",
-				"days_of_week must contain at least one day when frequency_unit is \"week\".",
-			)
-		}
-		if !isWeekly && hasDays {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("reminder").AtName("days_of_week"),
-				"Invalid Reminder Configuration",
-				"days_of_week is only supported when frequency_unit is \"week\".",
-			)
-		}
+// validateReminderConfig enforces the reminder rules that the API also enforces:
+// days_of_week is required for a weekly cadence and rejected for any other cadence.
+// A null/unknown reminder (no block configured) produces no diagnostics. Returned
+// diagnostics are keyed to the days_of_week attribute path.
+func validateReminderConfig(ctx context.Context, reminder types.Object) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if reminder.IsNull() || reminder.IsUnknown() {
+		return diags
 	}
+
+	var rm CampaignReminderModel
+	diags.Append(reminder.As(ctx, &rm, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return diags
+	}
+
+	isWeekly := rm.FrequencyUnit.ValueString() == string(opslevel.CampaignReminderFrequencyUnitEnumWeek)
+	hasDays := !rm.DaysOfWeek.IsNull() && !rm.DaysOfWeek.IsUnknown() && len(rm.DaysOfWeek.Elements()) > 0
+
+	daysPath := path.Root("reminder").AtName("days_of_week")
+	if isWeekly && !hasDays {
+		diags.AddAttributeError(
+			daysPath,
+			"Invalid Reminder Configuration",
+			"days_of_week must contain at least one day when frequency_unit is \"week\".",
+		)
+	}
+	if !isWeekly && hasDays {
+		diags.AddAttributeError(
+			daysPath,
+			"Invalid Reminder Configuration",
+			"days_of_week is only supported when frequency_unit is \"week\".",
+		)
+	}
+	return diags
 }
 
 func (r *CampaignResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/opslevel/resource_opslevel_campaign.go
+++ b/opslevel/resource_opslevel_campaign.go
@@ -3,7 +3,13 @@ package opslevel
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -13,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/opslevel/opslevel-go/v2026"
 	"github.com/relvacode/iso8601"
@@ -41,8 +48,154 @@ type CampaignResourceModel struct {
 	CheckIds     types.List   `tfsdk:"check_ids"`
 	StartDate    types.String `tfsdk:"start_date"`
 	TargetDate   types.String `tfsdk:"target_date"`
+	Reminder     types.Object `tfsdk:"reminder"`
 	Status       types.String `tfsdk:"status"`
 	HtmlUrl      types.String `tfsdk:"html_url"`
+}
+
+// CampaignReminderModel describes the nested reminder configuration block.
+type CampaignReminderModel struct {
+	Channels                     types.List   `tfsdk:"channels"`
+	Frequency                    types.Int64  `tfsdk:"frequency"`
+	FrequencyUnit                types.String `tfsdk:"frequency_unit"`
+	TimeOfDay                    types.String `tfsdk:"time_of_day"`
+	Timezone                     types.String `tfsdk:"timezone"`
+	DaysOfWeek                   types.List   `tfsdk:"days_of_week"`
+	Message                      types.String `tfsdk:"message"`
+	DefaultSlackChannel          types.String `tfsdk:"default_slack_channel"`
+	DefaultMicrosoftTeamsChannel types.String `tfsdk:"default_microsoft_teams_channel"`
+	NextOccurrence               types.String `tfsdk:"next_occurrence"`
+}
+
+func reminderAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"channels":                        types.ListType{ElemType: types.StringType},
+		"frequency":                       types.Int64Type,
+		"frequency_unit":                  types.StringType,
+		"time_of_day":                     types.StringType,
+		"timezone":                        types.StringType,
+		"days_of_week":                    types.ListType{ElemType: types.StringType},
+		"message":                         types.StringType,
+		"default_slack_channel":           types.StringType,
+		"default_microsoft_teams_channel": types.StringType,
+		"next_occurrence":                 types.StringType,
+	}
+}
+
+// buildCampaignReminderInput converts the Terraform reminder object into the SDK input.
+// Returns nil when no reminder block is configured. days_of_week is only sent for
+// weekly cadences (the API rejects it otherwise).
+func buildCampaignReminderInput(ctx context.Context, diags *diag.Diagnostics, obj types.Object) *opslevel.CampaignReminderInput {
+	if obj.IsNull() || obj.IsUnknown() {
+		return nil
+	}
+	var rm CampaignReminderModel
+	diags.Append(obj.As(ctx, &rm, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil
+	}
+
+	channelStrings, d := ListValueToStringSlice(ctx, rm.Channels)
+	diags.Append(d...)
+	channels := make([]opslevel.CampaignReminderChannelEnum, len(channelStrings))
+	for i, c := range channelStrings {
+		channels[i] = opslevel.CampaignReminderChannelEnum(c)
+	}
+
+	input := &opslevel.CampaignReminderInput{
+		Channels:      channels,
+		Frequency:     int(rm.Frequency.ValueInt64()),
+		FrequencyUnit: opslevel.CampaignReminderFrequencyUnitEnum(rm.FrequencyUnit.ValueString()),
+		TimeOfDay:     rm.TimeOfDay.ValueString(),
+		Timezone:      rm.Timezone.ValueString(),
+	}
+
+	if rm.FrequencyUnit.ValueString() == string(opslevel.CampaignReminderFrequencyUnitEnumWeek) {
+		dayStrings, dd := ListValueToStringSlice(ctx, rm.DaysOfWeek)
+		diags.Append(dd...)
+		for _, day := range dayStrings {
+			input.DaysOfWeek = append(input.DaysOfWeek, opslevel.DayOfWeekEnum(day))
+		}
+	}
+
+	if !rm.Message.IsNull() && !rm.Message.IsUnknown() {
+		input.Message = rm.Message.ValueStringPointer()
+	}
+	if !rm.DefaultSlackChannel.IsNull() && !rm.DefaultSlackChannel.IsUnknown() {
+		input.DefaultSlackChannel = rm.DefaultSlackChannel.ValueStringPointer()
+	}
+	if !rm.DefaultMicrosoftTeamsChannel.IsNull() && !rm.DefaultMicrosoftTeamsChannel.IsUnknown() {
+		input.DefaultMicrosoftTeamsChannel = rm.DefaultMicrosoftTeamsChannel.ValueStringPointer()
+	}
+	return input
+}
+
+// preserveHashChannel keeps the user-configured channel value when it is
+// semantically equal to the API value (the API prefixes a leading '#'), so
+// "platform-eng" in config does not perpetually drift against "#platform-eng".
+func preserveHashChannel(apiVal string, given types.String) types.String {
+	if apiVal == "" {
+		return types.StringNull()
+	}
+	if !given.IsNull() && !given.IsUnknown() {
+		g := given.ValueString()
+		if g == apiVal || "#"+strings.TrimPrefix(g, "#") == apiVal {
+			return given
+		}
+	}
+	return types.StringValue(apiVal)
+}
+
+// campaignReminderToObject maps an SDK reminder onto a Terraform object,
+// preserving user-formatted values from the given (plan/state) object where
+// the API would otherwise introduce noise. Returns a null object when no
+// reminder is configured on the campaign.
+func campaignReminderToObject(ctx context.Context, diags *diag.Diagnostics, reminder *opslevel.CampaignReminder, given types.Object) types.Object {
+	if reminder == nil {
+		return types.ObjectNull(reminderAttrTypes())
+	}
+
+	var prior CampaignReminderModel
+	havePrior := !given.IsNull() && !given.IsUnknown()
+	if havePrior {
+		diags.Append(given.As(ctx, &prior, basetypes.ObjectAsOptions{})...)
+	}
+
+	channels := make([]attr.Value, len(reminder.Channels))
+	for i, c := range reminder.Channels {
+		channels[i] = types.StringValue(string(c))
+	}
+
+	daysList := types.ListNull(types.StringType)
+	if len(reminder.DaysOfWeek) > 0 {
+		days := make([]attr.Value, len(reminder.DaysOfWeek))
+		for i, day := range reminder.DaysOfWeek {
+			days[i] = types.StringValue(string(day))
+		}
+		daysList = types.ListValueMust(types.StringType, days)
+	}
+
+	nextOccurrence := types.StringNull()
+	if !reminder.NextOccurrence.IsZero() {
+		nextOccurrence = types.StringValue(reminder.NextOccurrence.Format(time.RFC3339))
+	}
+
+	rm := CampaignReminderModel{
+		Channels:                     types.ListValueMust(types.StringType, channels),
+		Frequency:                    types.Int64Value(int64(reminder.Frequency)),
+		FrequencyUnit:                types.StringValue(string(reminder.FrequencyUnit)),
+		TimeOfDay:                    types.StringValue(reminder.TimeOfDay),
+		Timezone:                     types.StringValue(reminder.Timezone),
+		DaysOfWeek:                   daysList,
+		Message:                      StringValueFromResourceAndModelField(reminder.Message, prior.Message),
+		DefaultSlackChannel:          preserveHashChannel(reminder.DefaultSlackChannel, prior.DefaultSlackChannel),
+		DefaultMicrosoftTeamsChannel: preserveHashChannel(reminder.DefaultMicrosoftTeamsChannel, prior.DefaultMicrosoftTeamsChannel),
+		NextOccurrence:               nextOccurrence,
+	}
+
+	obj, d := types.ObjectValueFrom(ctx, reminderAttrTypes(), rm)
+	diags.Append(d...)
+	return obj
 }
 
 func NewCampaignResourceModel(campaign opslevel.Campaign, givenModel CampaignResourceModel) CampaignResourceModel {
@@ -53,6 +206,7 @@ func NewCampaignResourceModel(campaign opslevel.Campaign, givenModel CampaignRes
 		FilterId:     OptionalStringValue(string(campaign.Filter.Id)),
 		ProjectBrief: StringValueFromResourceAndModelField(campaign.RawProjectBrief, givenModel.ProjectBrief),
 		CheckIds:     types.ListNull(types.StringType),
+		Reminder:     types.ObjectNull(reminderAttrTypes()),
 		Status:       ComputedStringValue(string(campaign.Status)),
 		HtmlUrl:      ComputedStringValue(campaign.HtmlUrl),
 	}
@@ -120,6 +274,72 @@ func (r *CampaignResource) Schema(ctx context.Context, req resource.SchemaReques
 				Description: "The target end date of the campaign (YYYY-MM-DD). Setting both start_date and target_date schedules the campaign.",
 				Optional:    true,
 			},
+			"reminder": schema.SingleNestedAttribute{
+				Description: "Configuration for recurring campaign reminders sent to component owners via Slack, email, or Microsoft Teams. Reminders are only delivered while the campaign is in_progress or delayed.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"channels": schema.ListAttribute{
+						Description: "The channels through which reminders are delivered. One or more of: " + strings.Join(opslevel.AllCampaignReminderChannelEnum, ", ") + ".",
+						Required:    true,
+						ElementType: types.StringType,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.OneOf(opslevel.AllCampaignReminderChannelEnum...)),
+						},
+					},
+					"frequency": schema.Int64Attribute{
+						Description: "The interval (in frequency_unit) at which reminders are delivered. Must be at least 1.",
+						Required:    true,
+						Validators:  []validator.Int64{int64validator.AtLeast(1)},
+					},
+					"frequency_unit": schema.StringAttribute{
+						Description: "The unit of the frequency interval. One of: " + strings.Join(opslevel.AllCampaignReminderFrequencyUnitEnum, ", ") + ".",
+						Required:    true,
+						Validators:  []validator.String{stringvalidator.OneOf(opslevel.AllCampaignReminderFrequencyUnitEnum...)},
+					},
+					"time_of_day": schema.StringAttribute{
+						Description: "The time of day reminders are delivered, in 24-hour \"HH:MM\" format.",
+						Required:    true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^([01]\d|2[0-3]):[0-5]\d$`),
+								"must be a 24-hour time in \"HH:MM\" format (e.g. \"09:30\")",
+							),
+						},
+					},
+					"timezone": schema.StringAttribute{
+						Description: "The IANA timezone in which time_of_day is evaluated (e.g. \"America/Chicago\").",
+						Required:    true,
+					},
+					"days_of_week": schema.ListAttribute{
+						Description: "The weekdays on which reminders are delivered. Only supported (and required) when frequency_unit is \"week\".",
+						Optional:    true,
+						ElementType: types.StringType,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.OneOf(opslevel.AllDayOfWeekEnum...)),
+						},
+					},
+					"message": schema.StringAttribute{
+						Description: "An optional custom message included in the reminder.",
+						Optional:    true,
+					},
+					"default_slack_channel": schema.StringAttribute{
+						Description: "Slack channel notified when a team has no default Slack contact. A leading '#' is added automatically.",
+						Optional:    true,
+					},
+					"default_microsoft_teams_channel": schema.StringAttribute{
+						Description: "Microsoft Teams channel notified when a team has no default Teams contact.",
+						Optional:    true,
+					},
+					"next_occurrence": schema.StringAttribute{
+						Description: "The next time a reminder will be delivered, based on the current configuration. Null until the campaign is in_progress or delayed.",
+						Computed:    true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+				},
+			},
 			"status": schema.StringAttribute{
 				Description: "The current status of the campaign (draft, scheduled, in_progress, delayed, ended).",
 				Computed:    true,
@@ -147,6 +367,32 @@ func (r *CampaignResource) ValidateConfig(ctx context.Context, req resource.Vali
 			"Both start_date and target_date must be set together to schedule a campaign, or both must be omitted.",
 		)
 	}
+
+	if !config.Reminder.IsNull() && !config.Reminder.IsUnknown() {
+		var rm CampaignReminderModel
+		resp.Diagnostics.Append(config.Reminder.As(ctx, &rm, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		isWeekly := rm.FrequencyUnit.ValueString() == string(opslevel.CampaignReminderFrequencyUnitEnumWeek)
+		hasDays := !rm.DaysOfWeek.IsNull() && !rm.DaysOfWeek.IsUnknown() && len(rm.DaysOfWeek.Elements()) > 0
+
+		if isWeekly && !hasDays {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("reminder").AtName("days_of_week"),
+				"Invalid Reminder Configuration",
+				"days_of_week must contain at least one day when frequency_unit is \"week\".",
+			)
+		}
+		if !isWeekly && hasDays {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("reminder").AtName("days_of_week"),
+				"Invalid Reminder Configuration",
+				"days_of_week is only supported when frequency_unit is \"week\".",
+			)
+		}
+	}
 }
 
 func (r *CampaignResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -163,6 +409,10 @@ func (r *CampaignResource) Create(ctx context.Context, req resource.CreateReques
 	if !planModel.ProjectBrief.IsNull() {
 		brief := planModel.ProjectBrief.ValueString()
 		input.ProjectBrief = &brief
+	}
+	input.Reminder = buildCampaignReminderInput(ctx, &resp.Diagnostics, planModel.Reminder)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	campaign, err := r.client.CreateCampaign(input)
@@ -215,6 +465,10 @@ func (r *CampaignResource) Create(ctx context.Context, req resource.CreateReques
 	if !planModel.CheckIds.IsUnknown() {
 		createdModel.CheckIds = planModel.CheckIds
 	}
+	createdModel.Reminder = campaignReminderToObject(ctx, &resp.Diagnostics, campaign.Reminder, planModel.Reminder)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	tflog.Trace(ctx, "created a campaign resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &createdModel)...)
 }
@@ -238,6 +492,7 @@ func (r *CampaignResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	readModel := NewCampaignResourceModel(*campaign, stateModel)
 	readModel.CheckIds = r.readCampaignCheckIds(ctx, &resp.Diagnostics, campaign.Id, stateModel.CheckIds)
+	readModel.Reminder = campaignReminderToObject(ctx, &resp.Diagnostics, campaign.Reminder, stateModel.Reminder)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -266,6 +521,17 @@ func (r *CampaignResource) Update(ctx context.Context, req resource.UpdateReques
 
 	brief := planModel.ProjectBrief.ValueString()
 	updateInput.ProjectBrief = &brief
+
+	plannedReminder := buildCampaignReminderInput(ctx, &resp.Diagnostics, planModel.Reminder)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if plannedReminder != nil {
+		updateInput.Reminder = opslevel.NewNullableFrom(*plannedReminder)
+	} else if !stateModel.Reminder.IsNull() {
+		// Reminder block removed from config -> explicitly clear it on the API.
+		updateInput.Reminder = opslevel.NewNullOf[opslevel.CampaignReminderInput]()
+	}
 
 	campaign, err := r.client.UpdateCampaign(updateInput)
 	if err != nil {
@@ -313,6 +579,10 @@ func (r *CampaignResource) Update(ctx context.Context, req resource.UpdateReques
 	updatedModel := NewCampaignResourceModel(*campaign, planModel)
 	if !planModel.CheckIds.IsUnknown() {
 		updatedModel.CheckIds = planModel.CheckIds
+	}
+	updatedModel.Reminder = campaignReminderToObject(ctx, &resp.Diagnostics, campaign.Reminder, planModel.Reminder)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 	tflog.Trace(ctx, "updated a campaign resource")
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedModel)...)

--- a/opslevel/resource_opslevel_campaign_reminder_internal_test.go
+++ b/opslevel/resource_opslevel_campaign_reminder_internal_test.go
@@ -1,0 +1,363 @@
+package opslevel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/opslevel/opslevel-go/v2026"
+	"github.com/relvacode/iso8601"
+)
+
+func stringList(values ...string) types.List {
+	elems := make([]attr.Value, len(values))
+	for i, v := range values {
+		elems[i] = types.StringValue(v)
+	}
+	return types.ListValueMust(types.StringType, elems)
+}
+
+func newReminderObject(t *testing.T, rm CampaignReminderModel) types.Object {
+	t.Helper()
+	obj, d := types.ObjectValueFrom(context.Background(), reminderAttrTypes(), rm)
+	if d.HasError() {
+		t.Fatalf("building reminder object: %v", d)
+	}
+	return obj
+}
+
+func readReminderModel(t *testing.T, obj types.Object) CampaignReminderModel {
+	t.Helper()
+	var rm CampaignReminderModel
+	if d := obj.As(context.Background(), &rm, basetypes.ObjectAsOptions{}); d.HasError() {
+		t.Fatalf("reading reminder object: %v", d)
+	}
+	return rm
+}
+
+func TestBuildCampaignReminderInput_NullReturnsNil(t *testing.T) {
+	var diags diag.Diagnostics
+	got := buildCampaignReminderInput(context.Background(), &diags, types.ObjectNull(reminderAttrTypes()))
+	if got != nil {
+		t.Fatalf("expected nil for null object, got %+v", got)
+	}
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+}
+
+func TestBuildCampaignReminderInput_WeeklyIncludesDays(t *testing.T) {
+	var diags diag.Diagnostics
+	obj := newReminderObject(t, CampaignReminderModel{
+		Channels:                     stringList("slack", "email"),
+		Frequency:                    types.Int64Value(1),
+		FrequencyUnit:                types.StringValue("week"),
+		TimeOfDay:                    types.StringValue("09:30"),
+		Timezone:                     types.StringValue("America/Chicago"),
+		DaysOfWeek:                   stringList("monday", "thursday"),
+		Message:                      types.StringValue("hello"),
+		DefaultSlackChannel:          types.StringValue("#platform-eng"),
+		DefaultMicrosoftTeamsChannel: types.StringNull(),
+		NextOccurrence:               types.StringNull(),
+	})
+
+	got := buildCampaignReminderInput(context.Background(), &diags, obj)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if got == nil {
+		t.Fatal("expected an input, got nil")
+	}
+	if got.FrequencyUnit != opslevel.CampaignReminderFrequencyUnitEnumWeek {
+		t.Errorf("frequency_unit = %q, want week", got.FrequencyUnit)
+	}
+	if got.Frequency != 1 {
+		t.Errorf("frequency = %d, want 1", got.Frequency)
+	}
+	if len(got.Channels) != 2 {
+		t.Errorf("channels = %v, want 2", got.Channels)
+	}
+	if len(got.DaysOfWeek) != 2 {
+		t.Errorf("days_of_week = %v, want 2", got.DaysOfWeek)
+	}
+	if got.Message == nil || *got.Message != "hello" {
+		t.Errorf("message = %v, want hello", got.Message)
+	}
+	if got.DefaultSlackChannel == nil || *got.DefaultSlackChannel != "#platform-eng" {
+		t.Errorf("default_slack_channel = %v, want #platform-eng", got.DefaultSlackChannel)
+	}
+	if got.DefaultMicrosoftTeamsChannel != nil {
+		t.Errorf("default_microsoft_teams_channel = %v, want nil", got.DefaultMicrosoftTeamsChannel)
+	}
+}
+
+func TestBuildCampaignReminderInput_NonWeeklyOmitsDays(t *testing.T) {
+	var diags diag.Diagnostics
+	obj := newReminderObject(t, CampaignReminderModel{
+		Channels:                     stringList("slack"),
+		Frequency:                    types.Int64Value(2),
+		FrequencyUnit:                types.StringValue("day"),
+		TimeOfDay:                    types.StringValue("14:00"),
+		Timezone:                     types.StringValue("America/Chicago"),
+		DaysOfWeek:                   stringList("monday"), // present but must be ignored
+		Message:                      types.StringNull(),
+		DefaultSlackChannel:          types.StringNull(),
+		DefaultMicrosoftTeamsChannel: types.StringNull(),
+		NextOccurrence:               types.StringNull(),
+	})
+
+	got := buildCampaignReminderInput(context.Background(), &diags, obj)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if got == nil {
+		t.Fatal("expected an input, got nil")
+	}
+	if len(got.DaysOfWeek) != 0 {
+		t.Errorf("days_of_week = %v, want empty for daily cadence", got.DaysOfWeek)
+	}
+	if got.Message != nil {
+		t.Errorf("message = %v, want nil", got.Message)
+	}
+	if got.DefaultSlackChannel != nil {
+		t.Errorf("default_slack_channel = %v, want nil", got.DefaultSlackChannel)
+	}
+}
+
+func TestPreserveHashChannel(t *testing.T) {
+	cases := []struct {
+		name     string
+		api      string
+		given    types.String
+		wantNull bool
+		want     string
+	}{
+		{"empty api returns null", "", types.StringValue("anything"), true, ""},
+		{"given null keeps api value", "#x", types.StringNull(), false, "#x"},
+		{"equal ignoring hash keeps given", "#x", types.StringValue("x"), false, "x"},
+		{"exact equal keeps given", "#x", types.StringValue("#x"), false, "#x"},
+		{"different value uses api", "#x", types.StringValue("y"), false, "#x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := preserveHashChannel(tc.api, tc.given)
+			if tc.wantNull {
+				if !got.IsNull() {
+					t.Fatalf("expected null, got %q", got.ValueString())
+				}
+				return
+			}
+			if got.IsNull() {
+				t.Fatal("unexpected null")
+			}
+			if got.ValueString() != tc.want {
+				t.Fatalf("got %q, want %q", got.ValueString(), tc.want)
+			}
+		})
+	}
+}
+
+func TestCampaignReminderToObject_NilReturnsNull(t *testing.T) {
+	var diags diag.Diagnostics
+	obj := campaignReminderToObject(context.Background(), &diags, nil, types.ObjectNull(reminderAttrTypes()))
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if !obj.IsNull() {
+		t.Fatal("expected a null object for a nil reminder")
+	}
+}
+
+func TestCampaignReminderToObject_PopulatedPreservesGivenSlackForm(t *testing.T) {
+	var diags diag.Diagnostics
+	reminder := &opslevel.CampaignReminder{
+		Channels:            []opslevel.CampaignReminderChannelEnum{opslevel.CampaignReminderChannelEnumSlack},
+		DaysOfWeek:          []opslevel.DayOfWeekEnum{opslevel.DayOfWeekEnumMonday},
+		DefaultSlackChannel: "#platform-eng",
+		Frequency:           1,
+		FrequencyUnit:       opslevel.CampaignReminderFrequencyUnitEnumWeek,
+		Message:             "hello",
+		NextOccurrence:      iso8601.Time{Time: time.Date(2026, 7, 1, 9, 30, 0, 0, time.UTC)},
+		TimeOfDay:           "09:30",
+		Timezone:            "America/Chicago",
+	}
+	// User configured the channel without the leading '#'; it should be preserved.
+	given := newReminderObject(t, CampaignReminderModel{
+		Channels:                     stringList("slack"),
+		Frequency:                    types.Int64Value(1),
+		FrequencyUnit:                types.StringValue("week"),
+		TimeOfDay:                    types.StringValue("09:30"),
+		Timezone:                     types.StringValue("America/Chicago"),
+		DaysOfWeek:                   stringList("monday"),
+		Message:                      types.StringValue("hello"),
+		DefaultSlackChannel:          types.StringValue("platform-eng"),
+		DefaultMicrosoftTeamsChannel: types.StringNull(),
+		NextOccurrence:               types.StringNull(),
+	})
+
+	obj := campaignReminderToObject(context.Background(), &diags, reminder, given)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	rm := readReminderModel(t, obj)
+
+	if rm.FrequencyUnit.ValueString() != "week" {
+		t.Errorf("frequency_unit = %q, want week", rm.FrequencyUnit.ValueString())
+	}
+	if got := rm.DefaultSlackChannel.ValueString(); got != "platform-eng" {
+		t.Errorf("default_slack_channel = %q, want platform-eng (preserved given form)", got)
+	}
+	if rm.NextOccurrence.IsNull() {
+		t.Fatal("expected next_occurrence to be set")
+	}
+	if got := rm.NextOccurrence.ValueString(); got != "2026-07-01T09:30:00Z" {
+		t.Errorf("next_occurrence = %q, want 2026-07-01T09:30:00Z", got)
+	}
+	if len(rm.DaysOfWeek.Elements()) != 1 {
+		t.Errorf("days_of_week length = %d, want 1", len(rm.DaysOfWeek.Elements()))
+	}
+}
+
+func TestCampaignReminderToObject_NoPriorUsesApiValue(t *testing.T) {
+	var diags diag.Diagnostics
+	reminder := &opslevel.CampaignReminder{
+		Channels:            []opslevel.CampaignReminderChannelEnum{opslevel.CampaignReminderChannelEnumEmail},
+		DefaultSlackChannel: "#platform-eng",
+		Frequency:           2,
+		FrequencyUnit:       opslevel.CampaignReminderFrequencyUnitEnumDay,
+		TimeOfDay:           "08:00",
+		Timezone:            "UTC",
+	}
+
+	obj := campaignReminderToObject(context.Background(), &diags, reminder, types.ObjectNull(reminderAttrTypes()))
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	rm := readReminderModel(t, obj)
+	if got := rm.DefaultSlackChannel.ValueString(); got != "#platform-eng" {
+		t.Errorf("default_slack_channel = %q, want #platform-eng", got)
+	}
+	if !rm.DaysOfWeek.IsNull() {
+		t.Errorf("days_of_week = %v, want null for daily cadence", rm.DaysOfWeek)
+	}
+	if !rm.NextOccurrence.IsNull() {
+		t.Errorf("next_occurrence = %v, want null when unset", rm.NextOccurrence)
+	}
+}
+
+func TestNewCampaignDataSourceModel_Reminder(t *testing.T) {
+	var diags diag.Diagnostics
+
+	withReminder := opslevel.Campaign{
+		Name: "C",
+		Reminder: &opslevel.CampaignReminder{
+			Channels:      []opslevel.CampaignReminderChannelEnum{opslevel.CampaignReminderChannelEnumEmail},
+			DaysOfWeek:    []opslevel.DayOfWeekEnum{opslevel.DayOfWeekEnumMonday},
+			Frequency:     1,
+			FrequencyUnit: opslevel.CampaignReminderFrequencyUnitEnumWeek,
+			TimeOfDay:     "08:00",
+			Timezone:      "UTC",
+		},
+	}
+	model := newCampaignDataSourceModel(context.Background(), &diags, withReminder, "id")
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if model.Reminder.IsNull() {
+		t.Error("expected reminder to be set on the data source model")
+	}
+
+	noReminder := newCampaignDataSourceModel(context.Background(), &diags, opslevel.Campaign{Name: "C"}, "id")
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if !noReminder.Reminder.IsNull() {
+		t.Error("expected null reminder when campaign has none")
+	}
+}
+
+func TestValidateReminderConfig(t *testing.T) {
+	base := func(freqUnit string, days types.List) CampaignReminderModel {
+		return CampaignReminderModel{
+			Channels:                     stringList("slack"),
+			Frequency:                    types.Int64Value(1),
+			FrequencyUnit:                types.StringValue(freqUnit),
+			TimeOfDay:                    types.StringValue("09:30"),
+			Timezone:                     types.StringValue("UTC"),
+			DaysOfWeek:                   days,
+			Message:                      types.StringNull(),
+			DefaultSlackChannel:          types.StringNull(),
+			DefaultMicrosoftTeamsChannel: types.StringNull(),
+			NextOccurrence:               types.StringNull(),
+		}
+	}
+
+	t.Run("null reminder is valid", func(t *testing.T) {
+		if d := validateReminderConfig(context.Background(), types.ObjectNull(reminderAttrTypes())); d.HasError() {
+			t.Fatalf("expected no error, got %v", d)
+		}
+	})
+
+	t.Run("weekly with days is valid", func(t *testing.T) {
+		obj := newReminderObject(t, base("week", stringList("monday")))
+		if d := validateReminderConfig(context.Background(), obj); d.HasError() {
+			t.Fatalf("expected no error, got %v", d)
+		}
+	})
+
+	t.Run("weekly without days errors", func(t *testing.T) {
+		obj := newReminderObject(t, base("week", types.ListNull(types.StringType)))
+		if d := validateReminderConfig(context.Background(), obj); !d.HasError() {
+			t.Fatal("expected an error for weekly cadence without days_of_week")
+		}
+	})
+
+	t.Run("daily with days errors", func(t *testing.T) {
+		obj := newReminderObject(t, base("day", stringList("monday")))
+		if d := validateReminderConfig(context.Background(), obj); !d.HasError() {
+			t.Fatal("expected an error for daily cadence with days_of_week")
+		}
+	})
+
+	t.Run("daily without days is valid", func(t *testing.T) {
+		obj := newReminderObject(t, base("day", types.ListNull(types.StringType)))
+		if d := validateReminderConfig(context.Background(), obj); d.HasError() {
+			t.Fatalf("expected no error, got %v", d)
+		}
+	})
+}
+
+func TestNewCampaignListItemModels_Reminder(t *testing.T) {
+	var diags diag.Diagnostics
+	campaigns := []opslevel.Campaign{
+		{
+			Name: "a",
+			Reminder: &opslevel.CampaignReminder{
+				Channels:      []opslevel.CampaignReminderChannelEnum{opslevel.CampaignReminderChannelEnumSlack},
+				Frequency:     1,
+				FrequencyUnit: opslevel.CampaignReminderFrequencyUnitEnumDay,
+				TimeOfDay:     "08:00",
+				Timezone:      "UTC",
+			},
+		},
+		{Name: "b"},
+	}
+
+	models := newCampaignListItemModels(context.Background(), &diags, campaigns)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if len(models) != 2 {
+		t.Fatalf("models length = %d, want 2", len(models))
+	}
+	if models[0].Reminder.IsNull() {
+		t.Error("expected reminder set on first campaign")
+	}
+	if !models[1].Reminder.IsNull() {
+		t.Error("expected null reminder on second campaign")
+	}
+}

--- a/tests/local/resource_campaign.tftest.hcl
+++ b/tests/local/resource_campaign.tftest.hcl
@@ -62,6 +62,41 @@ run "resource_campaign_big" {
     condition     = opslevel_campaign.big.check_ids[0] == var.test_id
     error_message = "wrong check_ids[0] in opslevel_campaign.big"
   }
+
+  assert {
+    condition     = opslevel_campaign.big.reminder.frequency_unit == "week"
+    error_message = "wrong reminder.frequency_unit in opslevel_campaign.big"
+  }
+
+  assert {
+    condition     = opslevel_campaign.big.reminder.frequency == 1
+    error_message = "wrong reminder.frequency in opslevel_campaign.big"
+  }
+
+  assert {
+    condition     = opslevel_campaign.big.reminder.time_of_day == "09:30"
+    error_message = "wrong reminder.time_of_day in opslevel_campaign.big"
+  }
+
+  assert {
+    condition     = opslevel_campaign.big.reminder.timezone == "America/Chicago"
+    error_message = "wrong reminder.timezone in opslevel_campaign.big"
+  }
+
+  assert {
+    condition     = length(opslevel_campaign.big.reminder.channels) == 2
+    error_message = "wrong number of reminder.channels in opslevel_campaign.big"
+  }
+
+  assert {
+    condition     = length(opslevel_campaign.big.reminder.days_of_week) == 2
+    error_message = "wrong number of reminder.days_of_week in opslevel_campaign.big"
+  }
+
+  assert {
+    condition     = opslevel_campaign.big.reminder.default_slack_channel == "#platform-eng"
+    error_message = "wrong reminder.default_slack_channel in opslevel_campaign.big"
+  }
 }
 
 run "resource_campaign_small" {

--- a/tests/local/resources.tf
+++ b/tests/local/resources.tf
@@ -29,6 +29,17 @@ resource "opslevel_campaign" "big" {
   start_date    = "2026-07-01"
   target_date   = "2026-09-30"
   check_ids     = [var.test_id]
+
+  reminder = {
+    channels              = ["slack", "email"]
+    frequency             = 1
+    frequency_unit        = "week"
+    days_of_week          = ["monday", "thursday"]
+    time_of_day           = "09:30"
+    timezone              = "America/Chicago"
+    message               = "Please complete your campaign checks."
+    default_slack_channel = "#platform-eng"
+  }
 }
 
 resource "opslevel_campaign" "small" {

--- a/tests/remote/campaign.tftest.hcl
+++ b/tests/remote/campaign.tftest.hcl
@@ -95,3 +95,95 @@ run "resource_campaign_unschedule" {
     error_message = "campaign should be back in draft status after removing dates"
   }
 }
+
+run "resource_campaign_create_with_reminder" {
+  variables {
+    name          = var.name
+    owner_id      = var.owner_id
+    project_brief = var.project_brief
+    reminder = {
+      channels       = ["slack", "email"]
+      frequency      = 1
+      frequency_unit = "week"
+      days_of_week   = ["monday", "thursday"]
+      time_of_day    = "09:30"
+      timezone       = "America/Chicago"
+      message        = "Please complete your campaign checks."
+    }
+  }
+
+  module {
+    source = "./campaign"
+  }
+
+  assert {
+    condition     = opslevel_campaign.test.reminder.frequency_unit == "week"
+    error_message = "reminder frequency_unit does not match"
+  }
+
+  assert {
+    condition     = length(opslevel_campaign.test.reminder.channels) == 2
+    error_message = "reminder channels do not match"
+  }
+
+  assert {
+    condition     = length(opslevel_campaign.test.reminder.days_of_week) == 2
+    error_message = "reminder days_of_week do not match"
+  }
+
+  assert {
+    condition     = opslevel_campaign.test.reminder.time_of_day == "09:30"
+    error_message = "reminder time_of_day does not match"
+  }
+}
+
+run "resource_campaign_update_reminder_to_daily" {
+  variables {
+    name          = var.name
+    owner_id      = var.owner_id
+    project_brief = var.project_brief
+    reminder = {
+      channels       = ["slack"]
+      frequency      = 2
+      frequency_unit = "day"
+      time_of_day    = "14:00"
+      timezone       = "America/Chicago"
+    }
+  }
+
+  module {
+    source = "./campaign"
+  }
+
+  assert {
+    condition     = opslevel_campaign.test.reminder.frequency_unit == "day"
+    error_message = "reminder frequency_unit was not updated to day"
+  }
+
+  assert {
+    condition     = opslevel_campaign.test.reminder.frequency == 2
+    error_message = "reminder frequency was not updated"
+  }
+
+  assert {
+    condition     = opslevel_campaign.test.reminder.days_of_week == null
+    error_message = "reminder days_of_week should be null for a daily cadence"
+  }
+}
+
+run "resource_campaign_clear_reminder" {
+  variables {
+    name          = var.name
+    owner_id      = var.owner_id
+    project_brief = var.project_brief
+  }
+
+  module {
+    source = "./campaign"
+  }
+
+  assert {
+    condition     = opslevel_campaign.test.reminder == null
+    error_message = "reminder should be cleared when the block is removed"
+  }
+}

--- a/tests/remote/campaign/main.tf
+++ b/tests/remote/campaign/main.tf
@@ -4,4 +4,5 @@ resource "opslevel_campaign" "test" {
   project_brief = var.project_brief
   start_date    = var.start_date
   target_date   = var.target_date
+  reminder      = var.reminder
 }

--- a/tests/remote/campaign/variables.tf
+++ b/tests/remote/campaign/variables.tf
@@ -20,3 +20,18 @@ variable "target_date" {
   type    = string
   default = null
 }
+
+variable "reminder" {
+  type = object({
+    channels                        = list(string)
+    frequency                       = number
+    frequency_unit                  = string
+    time_of_day                     = string
+    timezone                        = string
+    days_of_week                    = optional(list(string))
+    message                         = optional(string)
+    default_slack_channel           = optional(string)
+    default_microsoft_teams_channel = optional(string)
+  })
+  default = null
+}


### PR DESCRIPTION
## Summary

- Adds a `reminder` single-nested attribute to the `opslevel_campaign` resource for configuring recurring **Slack, email, and Microsoft Teams** reminders on a schedule.
- Schema validation: channel / frequency_unit / day-of-week enums, `frequency >= 1`, `HH:MM` time format, and `channels` non-empty. `ValidateConfig` enforces that `days_of_week` is required for a weekly cadence and rejected otherwise.
- CRUD wiring: omit on create when absent, send an explicit `null` to clear on update when the block is removed, and normalize the `#` prefix on `default_slack_channel` to avoid perpetual diffs.
- Exposes `reminder` as a computed attribute on the `opslevel_campaign` and `opslevel_campaigns` data sources.
- Docs, example, and a changie entry.

## Dependency

Depends on OpsLevel/opslevel-go#623. The `go.mod` `replace` directive and the `submodules/opslevel-go` pointer are temporary for development (matching the prior campaign PR workflow) and will be removed in favor of a released `opslevel-go` version bump before merge.

## Test plan

- [x] `go build ./...`, `go vet ./opslevel/`
- [x] `gofumpt` clean, `golangci-lint run ./opslevel/` (0 issues)
- [x] `task test` — terraform mock tests + Go unit tests (107 passed, 0 failed), including new reminder assertions on the `opslevel_campaign` resource
- [ ] Remote acceptance tests (`tests/remote/campaign.tftest.hcl`) — added create-with-reminder, update-to-daily, and clear-reminder runs; require a live `OPSLEVEL_API_TOKEN` and valid `owner_id`

Made with [Cursor](https://cursor.com)